### PR TITLE
feat(cli): aristo verify dispatches canon-verify for full+canon-bound entries (§14 E1–E4)

### DIFF
--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.1.0"
-generated_at = "2026-05-25T06:14:45.301189Z"
+generated_at = "2026-05-25T06:15:26.17746Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -1077,7 +1077,7 @@ status = "neural"
 text_hash = "sha256:52a7f47cb64e5ff1cbf3eb2bf9d3fbada34b756a1ed78158e8e54ea8e0d4e51a"
 body_hash = "sha256:47a6992664050a69cc2739f41caab782724deba6a78e93f1763149535cc150cb"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn resolve_verify_level (line 311)"
+site = "fn resolve_verify_level (line 356)"
 covered_region = "function"
 
 [verify_bool_true_resolves_through_project_default]
@@ -1088,7 +1088,7 @@ status = "neural"
 text_hash = "sha256:98cd0efced314712df6f2fc59cbd60d95bed2c03b6670f5e9086aeca59a2c684"
 body_hash = "sha256:47a6992664050a69cc2739f41caab782724deba6a78e93f1763149535cc150cb"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn resolve_verify_level (line 323)"
+site = "fn resolve_verify_level (line 368)"
 covered_region = "function"
 
 [verify_false_arm_is_intentional_skip]
@@ -1099,7 +1099,7 @@ status = "neural"
 text_hash = "sha256:abb61b58993697f0c741e36ed6ee821fe7a7539a6ecf6d316900e292f7198a93"
 body_hash = "sha256:e4def345cc196a3718bc5c5cbbe6a9f763632a5344e00562f09685eec5feed11"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run (line 110)"
+site = "fn run (line 131)"
 covered_region = "statement"
 
 [verify_migrates_legacy_pending_neural_toml_to_queue]
@@ -1121,7 +1121,7 @@ status = "neural"
 text_hash = "sha256:0da73449029c5ac290374f71589048e283bb0c913c998a23d1c344347f81978e"
 body_hash = "sha256:74a7875b3adf5c47c7af8c22f122f1298f0e82ba013e1528b398ef9fa5944145"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run_pop_next (line 163)"
+site = "fn run_pop_next (line 208)"
 covered_region = "function"
 
 [verify_queue_status_is_non_destructive_peek]
@@ -1132,7 +1132,7 @@ status = "unknown"
 text_hash = "sha256:c1d5e4f08bfc2116718b94c7334dfdffdcf7981731e2e20d067e5dc617cdc608"
 body_hash = "sha256:96de1a2fc087ab877a852c94a7abb823017bad3e2c12318f4ea51e808c24a791"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run_queue_status (line 189)"
+site = "fn run_queue_status (line 234)"
 covered_region = "function"
 
 [verify_skip_consults_validator_not_just_status]
@@ -1143,7 +1143,7 @@ status = "unknown"
 text_hash = "sha256:ec349c62caa14bf353768509d1662e6ec68dc8d5d703d542e698ca3c5fb1089f"
 body_hash = "sha256:92a9f4dcd35a81ce63e0cd198bee192b970574abf1a2282d7fc7dd2b693f163c"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn skip_because_proof_still_holds (line 348)"
+site = "fn skip_because_proof_still_holds (line 393)"
 covered_region = "function"
 
 [walk_directory_is_deterministic]

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -21,16 +21,42 @@
 //! verification mechanism (see `docs/deferred/verify-test-design.md`)
 //! and out of scope for §14.
 
+use std::collections::HashSet;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use aristo_core::canon::CanonMatchesFile;
 use aristo_core::canon_verify::{
-    HttpVerifyClient, PostVerifySessionResponse, VerifyClient, VerifyError, VerifySessionRequest,
+    AnnotationOutcomeStatus, GetVerifySessionResponse, HttpVerifyClient, PostVerifySessionResponse,
+    SessionStatus, TestOutcomeStatus, VerifyClient, VerifyError, VerifySessionRequest,
     VerifySessionTag,
 };
 use aristo_core::index::{AnnotationId, IndexEntry, IndexFile, IntentEntry};
 
 use crate::{CliError, CliResult};
+
+/// Long-poll server-side hold-time (§7c row 9). The server may ignore
+/// this and return immediately in the prototype — the SDK still sends
+/// the hint for forward-compat.
+const LONGPOLL_WAIT_SECS: u32 = 30;
+
+/// Default between-poll backoff when the server returns immediately.
+/// Keeps the CLI rendering smooth (§7c row 9 "3s render") and bounded.
+/// Overridable via `ARISTO_VERIFY_POLL_MS` for tests; production
+/// callers never set it.
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+fn poll_interval() -> Duration {
+    if let Ok(ms) = std::env::var("ARISTO_VERIFY_POLL_MS") {
+        if let Ok(n) = ms.parse::<u64>() {
+            return Duration::from_millis(n);
+        }
+    }
+    POLL_INTERVAL
+}
+
+/// Heartbeat cadence (§7c row 13: "still running… (N seconds elapsed)").
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Identifies an entry pending canon-verify dispatch. Lightweight —
 /// the actual request body assembly happens in [`build_tags`].
@@ -178,6 +204,8 @@ pub(crate) fn run_canon_dispatch(
     workspace_root: &Path,
     matches_path: &Path,
     canon_entries: &[CanonDispatchEntry<'_>],
+    tags_filter: Option<&[String]>,
+    wait: bool,
 ) -> CliResult<usize> {
     if canon_entries.is_empty() {
         return Ok(0);
@@ -194,7 +222,25 @@ pub(crate) fn run_canon_dispatch(
         ),
         exit_code: 1,
     })?;
-    let tags = build_tags(canon_entries, &matches);
+    let mut tags = build_tags(canon_entries, &matches);
+
+    // 2b. Optional --tags filter (E4): subset to the requested ids.
+    // Validates each requested id (reject `arta_*` — those are server-
+    // side opaque refs that the user never sees in source).
+    if let Some(requested) = tags_filter {
+        let allowed = build_tag_filter_set(canon_entries, requested)?;
+        tags.retain(|t| allowed.contains(&t.annotation_id));
+        if tags.is_empty() {
+            return Err(CliError::Other {
+                message: format!(
+                    "--tags filter matched zero eligible canon-bound entries. \
+                     Requested ids: {}",
+                    requested.join(", ")
+                ),
+                exit_code: 1,
+            });
+        }
+    }
     if tags.is_empty() {
         // Every canon-bound entry was missing a cache entry. Surface
         // a helpful message rather than POSTing empty.
@@ -264,11 +310,269 @@ pub(crate) fn run_canon_dispatch(
         tags,
     };
     let resp = client.post_session(&req).map_err(verify_error_to_cli)?;
-
-    // 7. Print user-facing summary (detach default per §7c row 1).
     let dispatched = req.tags.len();
     print_session_dispatched(&req, &resp);
+
+    // 7. Optional poll-to-completion (--wait).
+    if wait {
+        let final_snapshot = poll_until_terminal(&*client, &resp.session_id)?;
+        render_final_snapshot(&final_snapshot);
+        if !final_snapshot.summary.is_success() {
+            // §7c row 7: any failed / build_failed / inconclusive → exit 1.
+            return Err(CliError::Other {
+                message: format!(
+                    "canon-verify reported {} failed, {} build_failed, {} inconclusive",
+                    final_snapshot.summary.failed,
+                    final_snapshot.summary.build_failed,
+                    final_snapshot.summary.inconclusive
+                ),
+                exit_code: 1,
+            });
+        }
+    }
+
     Ok(dispatched)
+}
+
+/// Re-attach to an existing session (E3 — `aristo verify --view <id>`).
+/// One GET (or polling loop with --wait), render, exit-code derive.
+/// Skips POST + push-first precheck entirely.
+pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
+    let creds = aristo_core::auth::resolve_full().map_err(no_auth_to_cli_error)?;
+    let base_url = std::env::var("ARETTA_API_URL")
+        .unwrap_or_else(|_| creds.server.as_str().to_string());
+    let client: Box<dyn VerifyClient> =
+        if let Some(mock) = test_mock_client_from_env() {
+            mock
+        } else {
+            Box::new(HttpVerifyClient::new(base_url, &creds.token))
+        };
+
+    let snapshot = if wait {
+        poll_until_terminal(&*client, session_id)?
+    } else {
+        client
+            .get_session(session_id, None)
+            .map_err(verify_error_to_cli)?
+    };
+    render_final_snapshot(&snapshot);
+    if wait && !snapshot.summary.is_success() {
+        return Err(CliError::Other {
+            message: format!(
+                "canon-verify reported {} failed, {} build_failed, {} inconclusive",
+                snapshot.summary.failed,
+                snapshot.summary.build_failed,
+                snapshot.summary.inconclusive
+            ),
+            exit_code: 1,
+        });
+    }
+    Ok(())
+}
+
+/// Long-poll loop until the session reaches a terminal state. Renders
+/// an intermediate snapshot at first non-terminal response so the user
+/// sees the in-flight state; emits a heartbeat every 60s.
+fn poll_until_terminal<C: VerifyClient + ?Sized>(
+    client: &C,
+    session_id: &str,
+) -> CliResult<GetVerifySessionResponse> {
+    let started = Instant::now();
+    let mut last_heartbeat = started;
+    let mut intermediate_rendered = false;
+
+    loop {
+        let snapshot = client
+            .get_session(session_id, Some(LONGPOLL_WAIT_SECS))
+            .map_err(verify_error_to_cli)?;
+        if snapshot.status.is_terminal() {
+            return Ok(snapshot);
+        }
+        if !intermediate_rendered {
+            // First non-terminal poll: show what's running.
+            println!();
+            println!(
+                "  status: {} ({} of {} annotations verified so far)",
+                status_label(snapshot.status),
+                snapshot.summary.verified,
+                snapshot.summary.total_annotations
+            );
+            intermediate_rendered = true;
+        }
+        if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+            let elapsed = started.elapsed().as_secs();
+            println!("  still running… ({elapsed}s elapsed)");
+            last_heartbeat = Instant::now();
+        }
+        // Back off briefly so we don't hammer when the server returns
+        // immediately (i.e., when ?wait= is ignored — current proxy
+        // state).
+        std::thread::sleep(poll_interval());
+    }
+}
+
+fn build_tag_filter_set(
+    canon_entries: &[CanonDispatchEntry<'_>],
+    requested: &[String],
+) -> CliResult<HashSet<String>> {
+    let mut allowed: HashSet<String> = HashSet::new();
+    // Build a map from canon-bound AnnotationId.as_str() → linked arta_*
+    // so the user can pass either source-form ids (`aristos:foo`) or
+    // canon-id suffixes (`foo`) without surprises.
+    let mut by_source: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+    let mut by_canon: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
+    for d in canon_entries {
+        let linked = match &d.entry.binding {
+            aristo_core::index::BindingState::Bound { linked } => linked.as_str().to_string(),
+            aristo_core::index::BindingState::Certified { linked, .. } => {
+                linked.as_str().to_string()
+            }
+            aristo_core::index::BindingState::Local => continue,
+        };
+        by_source.insert(d.id.as_str(), linked.clone());
+        let canon = strip_canon_prefix(d.id.as_str());
+        by_canon.insert(canon, linked);
+    }
+    for raw in requested {
+        let id = raw.trim();
+        if id.is_empty() {
+            continue;
+        }
+        if id.starts_with("arta_") {
+            return Err(CliError::Other {
+                message: format!(
+                    "--tags rejects opaque server ids (got `{id}`). Pass the source-form id \
+                     instead, e.g. `--tags aristos:foo,kanon:bar`."
+                ),
+                exit_code: 2,
+            });
+        }
+        if let Some(linked) = by_source.get(id) {
+            allowed.insert(linked.clone());
+        } else if let Some(linked) = by_canon.get(id) {
+            allowed.insert(linked.clone());
+        } else {
+            return Err(CliError::Other {
+                message: format!(
+                    "--tags id `{id}` is not a canon-bound entry in this workspace's index"
+                ),
+                exit_code: 1,
+            });
+        }
+    }
+    Ok(allowed)
+}
+
+// ─── Rendering (WORKFLOW.md §6 — CLI form) ──────────────────────────────────
+
+fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
+    println!();
+    println!(
+        "session {} — verifying {} against canon {}",
+        snapshot.session_id,
+        short_sha(&snapshot.user_commit_sha),
+        snapshot.canon_version
+    );
+    println!(
+        "status: {} ({}/{} verified)",
+        status_label(snapshot.status),
+        snapshot.summary.verified,
+        snapshot.summary.total_annotations
+    );
+    println!();
+    println!(
+        "{:<55}  {:<14} TESTS",
+        "ANNOTATION", "STATUS"
+    );
+    for ann in &snapshot.annotations {
+        let icon = annotation_icon(ann.status);
+        let passed = ann
+            .tests
+            .iter()
+            .filter(|t| matches!(t.status, TestOutcomeStatus::Pass))
+            .count();
+        let header = format!(
+            "{}{}@{} ({})",
+            ann.tier, ann.canon_id, ann.version, ann.scope
+        );
+        let tests_summary = if ann.tests.is_empty() {
+            "(no coverage)".to_string()
+        } else {
+            format!("{}/{} passed", passed, ann.tests.len())
+        };
+        println!(
+            "{:<55}  {} {:<11}  {}",
+            header,
+            icon,
+            annotation_status_word(ann.status),
+            tests_summary
+        );
+        println!("  {}", ann.source_path);
+        for t in &ann.tests {
+            if !matches!(
+                t.status,
+                TestOutcomeStatus::Fail
+                    | TestOutcomeStatus::BuildFailed
+                    | TestOutcomeStatus::CloneFailed
+                    | TestOutcomeStatus::Timeout
+                    | TestOutcomeStatus::Error
+            ) {
+                continue;
+            }
+            let bin = t.test_binary.as_deref().unwrap_or("(session)");
+            let word = test_status_word(t.status);
+            match &t.stderr_url {
+                Some(url) => println!("  • {bin} {word} — see {url}"),
+                None => println!("  • {bin} {word}"),
+            }
+        }
+    }
+    println!();
+    // No `view_url` on GetVerifySessionResponse; the dashboard link is
+    // derivable from session_id when needed but we surface only the
+    // session id here to keep the output tight.
+}
+
+fn status_label(s: SessionStatus) -> &'static str {
+    match s {
+        SessionStatus::Queued => "queued",
+        SessionStatus::Running => "running",
+        SessionStatus::Done => "done",
+        SessionStatus::Failed => "failed",
+        SessionStatus::TimedOut => "timed out",
+        SessionStatus::Cancelled => "cancelled",
+    }
+}
+
+fn annotation_icon(s: AnnotationOutcomeStatus) -> &'static str {
+    match s {
+        AnnotationOutcomeStatus::Verified => "[ok]",
+        AnnotationOutcomeStatus::Failed => "[fail]",
+        AnnotationOutcomeStatus::BuildFailed => "[warn]",
+        AnnotationOutcomeStatus::Inconclusive => "[?]",
+        AnnotationOutcomeStatus::NoCoverage => "[--]",
+    }
+}
+
+fn annotation_status_word(s: AnnotationOutcomeStatus) -> &'static str {
+    match s {
+        AnnotationOutcomeStatus::Verified => "verified",
+        AnnotationOutcomeStatus::Failed => "failed",
+        AnnotationOutcomeStatus::BuildFailed => "build_failed",
+        AnnotationOutcomeStatus::Inconclusive => "inconclusive",
+        AnnotationOutcomeStatus::NoCoverage => "no_coverage",
+    }
+}
+
+fn test_status_word(s: TestOutcomeStatus) -> &'static str {
+    match s {
+        TestOutcomeStatus::Pass => "passed",
+        TestOutcomeStatus::Fail => "failed",
+        TestOutcomeStatus::BuildFailed => "build_failed",
+        TestOutcomeStatus::CloneFailed => "clone_failed",
+        TestOutcomeStatus::Timeout => "timeout",
+        TestOutcomeStatus::Error => "error",
+    }
 }
 
 fn print_session_dispatched(req: &VerifySessionRequest, resp: &PostVerifySessionResponse) {
@@ -353,10 +657,22 @@ fn test_mock_client_from_env() -> Option<Box<dyn VerifyClient>> {
         session_id: p.session_id,
         view_url: p.view_url,
         plan_size: p.plan_size,
-    })?;
+    });
+    // Pre-canned GET response sequence (for --view + --wait paths).
+    let get_responses: Vec<GetVerifySessionResponse> = parsed.gets.unwrap_or_default();
     // Record the POST body to a sibling file so tests can inspect it.
     let record_path = format!("{path}.posted.json");
-    let mock = aristo_core::canon_verify::MockVerifyClient::with_post_response(post_resp);
+    let mock = match (post_resp, get_responses.is_empty()) {
+        (Some(p), true) => aristo_core::canon_verify::MockVerifyClient::with_post_response(p),
+        (Some(p), false) => aristo_core::canon_verify::MockVerifyClient::with_post_and_gets(
+            p,
+            get_responses,
+        ),
+        (None, false) => {
+            aristo_core::canon_verify::MockVerifyClient::with_get_responses(get_responses)
+        }
+        (None, true) => return None,
+    };
     Some(Box::new(RecordingMock {
         inner: mock,
         record_path,
@@ -366,6 +682,7 @@ fn test_mock_client_from_env() -> Option<Box<dyn VerifyClient>> {
 #[derive(serde::Deserialize)]
 struct FixtureFile {
     post: Option<FixturePost>,
+    gets: Option<Vec<GetVerifySessionResponse>>,
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -1,0 +1,710 @@
+//! Canon-verify dispatch path for `aristo verify`.
+//!
+//! Replaces the original `pending_full > 0 => NotImplemented` arm in
+//! `commands/verify/mod.rs`. For Full-resolved entries that are
+//! canon-bound (`aristos:` or `kanon:`), this module:
+//!
+//! 1. Builds [`VerifySessionTag`]s from the index + canon-matches cache.
+//! 2. Runs the push-first precheck via [`aristo_core::git`].
+//! 3. POSTs `/canon/verify/sessions` and prints `session_id` +
+//!    `view_url` for the user (detach default per WORKFLOW.md §7c row 1).
+//!
+//! Auth is required: the §14 design predicates canon-verify on having
+//! an `arta_*` token (we re-derive scopes server-side and authorize
+//! against `repository_flavors`). If no token is resolved, the SDK
+//! surfaces an actionable "run `aristo auth login`" hint and skips —
+//! it does NOT graceful-degrade (the user explicitly asked to verify;
+//! we shouldn't silently no-op).
+//!
+//! Non-canon-bound `verify="full"` entries fall through to the
+//! existing deferred-design `NotImplemented` arm — they're a separate
+//! verification mechanism (see `docs/deferred/verify-test-design.md`)
+//! and out of scope for §14.
+
+use std::path::Path;
+
+use aristo_core::canon::CanonMatchesFile;
+use aristo_core::canon_verify::{
+    HttpVerifyClient, PostVerifySessionResponse, VerifyClient, VerifyError, VerifySessionRequest,
+    VerifySessionTag,
+};
+use aristo_core::index::{AnnotationId, IndexEntry, IndexFile, IntentEntry};
+
+use crate::{CliError, CliResult};
+
+/// Identifies an entry pending canon-verify dispatch. Lightweight —
+/// the actual request body assembly happens in [`build_tags`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CanonDispatchEntry<'a> {
+    pub id: &'a AnnotationId,
+    pub entry: &'a IntentEntry,
+}
+
+/// From the full set of Full-resolved annotation ids (computed by the
+/// existing dispatcher loop), partition them into the canon-verify
+/// bucket vs. the legacy non-canon bucket.
+///
+/// Canon-bound = id namespace is `aristos:` or `kanon:` per
+/// [`AnnotationId::is_canon_bound`].
+pub(crate) fn partition_full<'a>(
+    index: &'a IndexFile,
+    pending_full_ids: &[&'a AnnotationId],
+) -> (
+    Vec<CanonDispatchEntry<'a>>,
+    Vec<&'a AnnotationId>, // non-canon-bound; keep the NotImplemented hint
+) {
+    let mut canon: Vec<CanonDispatchEntry<'a>> = Vec::new();
+    let mut other: Vec<&'a AnnotationId> = Vec::new();
+    for id in pending_full_ids {
+        let Some(entry) = index.entries.get(*id) else {
+            continue;
+        };
+        let IndexEntry::Intent(intent) = entry else {
+            // Assume entries don't carry `verify` (resolve to Bool(false));
+            // they never reach the Full arm. Defensive.
+            continue;
+        };
+        if id.is_canon_bound() {
+            canon.push(CanonDispatchEntry {
+                id,
+                entry: intent,
+            });
+        } else {
+            other.push(id);
+        }
+    }
+    (canon, other)
+}
+
+/// Build the [`VerifySessionTag`] list for a set of canon-bound
+/// Full-resolved entries. Joins the index entry (for `annotation_id`
+/// via `binding.linked` + source_path via `file:line`) with the
+/// canon-matches cache (for `canon_id` + `version`).
+///
+/// Entries whose `linked` is missing (Local binding state — which
+/// shouldn't happen for canon-prefixed ids but is defensively
+/// handled), whose canon-matches entry is absent, or whose accepted-
+/// match list is empty are silently dropped from the dispatch.
+/// They'd fail the server-side eligibility check anyway and surface
+/// a clearer error on the next `aristo canon refresh`.
+pub(crate) fn build_tags(
+    entries: &[CanonDispatchEntry<'_>],
+    matches: &CanonMatchesFile,
+) -> Vec<VerifySessionTag> {
+    entries
+        .iter()
+        .filter_map(|d| build_one_tag(d, matches))
+        .collect()
+}
+
+fn build_one_tag(
+    dispatch: &CanonDispatchEntry<'_>,
+    matches: &CanonMatchesFile,
+) -> Option<VerifySessionTag> {
+    let annotation_id = match &dispatch.entry.binding {
+        aristo_core::index::BindingState::Local => return None,
+        aristo_core::index::BindingState::Bound { linked } => linked.as_str().to_string(),
+        aristo_core::index::BindingState::Certified { linked, .. } => {
+            linked.as_str().to_string()
+        }
+    };
+    // Strip `aristos:` / `kanon:` prefix to get the bare canon_id.
+    let canon_id = strip_canon_prefix(dispatch.id.as_str()).to_string();
+    // Pull version from canon-matches cache. The cache is keyed by
+    // the FULL AnnotationId (matching the source-form id used in
+    // both source and index).
+    let cache_entry = matches.entries.get(dispatch.id)?;
+    let accepted = cache_entry.accepted_matches.first()?;
+    let version = accepted.version.clone();
+
+    let source_path = format_source_path(&dispatch.entry.file, dispatch.entry.site.as_str());
+
+    Some(VerifySessionTag {
+        annotation_id,
+        canon_id,
+        version,
+        source_path,
+    })
+}
+
+fn strip_canon_prefix(id: &str) -> &str {
+    id.strip_prefix("aristos:")
+        .or_else(|| id.strip_prefix("kanon:"))
+        .unwrap_or(id)
+}
+
+/// Format `file:line` from the index entry's `file` + the line
+/// extracted from `site`. The site format is `"fn foo (line N)"`
+/// per the walker / index emit; absent a line (defensive), we emit
+/// just the file path so the user still sees a clickable hint.
+fn format_source_path(file: &str, site: &str) -> String {
+    match extract_line(site) {
+        Some(line) => format!("{file}:{line}"),
+        None => file.to_string(),
+    }
+}
+
+fn extract_line(site: &str) -> Option<u32> {
+    let after = site.split(" (line ").nth(1)?;
+    let trimmed = after.trim_end_matches(')');
+    trimmed.parse().ok()
+}
+
+/// What the dispatcher does after partitioning + tag-building. Surfaced
+/// as a separate fn so tests can drive it with a mock client.
+#[cfg(test)]
+pub(crate) fn dispatch_session<C: VerifyClient + ?Sized>(
+    client: &C,
+    req: &VerifySessionRequest,
+) -> Result<PostVerifySessionResponse, VerifyError> {
+    client.post_session(req)
+}
+
+/// End-to-end canon-verify dispatch:
+///
+/// 1. Build the tag list (silent skip for entries with no
+///    canon-matches cache entry — they'd 4xx anyway).
+/// 2. If empty, return 0 (nothing to dispatch — the existing skip-
+///    counters in `emit_summary` already informed the user).
+/// 3. Push-first precheck via git.
+/// 4. Derive `commit_sha` + `repo_full_name`.
+/// 5. Construct the HTTP client + POST.
+/// 6. Print `session_id` + `view_url`.
+///
+/// Returns the number of tags actually dispatched (for the summary
+/// emit on the caller side). Errors are CLI errors so the caller can
+/// `?` them up.
+pub(crate) fn run_canon_dispatch(
+    workspace_root: &Path,
+    matches_path: &Path,
+    canon_entries: &[CanonDispatchEntry<'_>],
+) -> CliResult<usize> {
+    if canon_entries.is_empty() {
+        return Ok(0);
+    }
+
+    // 1. Auth — required up front. If no token, surface actionable hint.
+    let creds = aristo_core::auth::resolve_full().map_err(no_auth_to_cli_error)?;
+
+    // 2. Build tags from index + cache. Drop the no-version cases.
+    let matches = CanonMatchesFile::read(matches_path).map_err(|e| CliError::Other {
+        message: format!(
+            "failed to read canon-matches cache at {}: {e}",
+            matches_path.display()
+        ),
+        exit_code: 1,
+    })?;
+    let tags = build_tags(canon_entries, &matches);
+    if tags.is_empty() {
+        // Every canon-bound entry was missing a cache entry. Surface
+        // a helpful message rather than POSTing empty.
+        println!(
+            "\n→ {} canon-bound entries are pending verification, but no `accepted_matches` were found in",
+            canon_entries.len()
+        );
+        println!(
+            "  .aristo/canon-matches.toml. Run `aristo canon refresh` to repopulate the cache."
+        );
+        return Ok(0);
+    }
+
+    // 3. Resolve repo + commit_sha via git.
+    let repo_full_name = match aristo_core::auth::derive_repo_full_name(workspace_root) {
+        Ok(r) => r,
+        Err(e) => {
+            // ARISTO_REPO env override as a CI escape hatch.
+            std::env::var("ARISTO_REPO").map_err(|_| CliError::Other {
+                message: format!(
+                    "could not determine repo for canon-verify: {e}\n  \
+                     Set ARISTO_REPO=<owner/repo> to override (CI use)."
+                ),
+                exit_code: 1,
+            })?
+        }
+    };
+    let commit_sha = aristo_core::git::rev_parse_head(workspace_root).map_err(|e| {
+        CliError::Other {
+            message: format!("git rev-parse HEAD failed: {e}"),
+            exit_code: 1,
+        }
+    })?;
+
+    // 4. Push-first precheck (WORKFLOW.md §4 + §7c).
+    let pushed = aristo_core::git::commit_present_on_remote(workspace_root, &commit_sha)
+        .map_err(|e| CliError::Other {
+            message: format!("git push-first precheck failed: {e}"),
+            exit_code: 1,
+        })?;
+    if !pushed {
+        return Err(CliError::Other {
+            message: format!(
+                "HEAD ({}) is not pushed to origin. Push your branch first; \
+                 `aristo verify --watch` for local-edit sync is planned but \
+                 not yet shipped.",
+                short_sha(&commit_sha)
+            ),
+            exit_code: 1,
+        });
+    }
+
+    // 5. Build the HTTP client. ARETTA_API_URL overrides for tests.
+    let base_url = std::env::var("ARETTA_API_URL")
+        .unwrap_or_else(|_| creds.server.as_str().to_string());
+    let client: Box<dyn VerifyClient> =
+        if let Some(mock) = test_mock_client_from_env() {
+            mock
+        } else {
+            Box::new(HttpVerifyClient::new(base_url, &creds.token))
+        };
+
+    // 6. POST.
+    let req = VerifySessionRequest {
+        repo_full_name,
+        commit_sha,
+        tags,
+    };
+    let resp = client.post_session(&req).map_err(verify_error_to_cli)?;
+
+    // 7. Print user-facing summary (detach default per §7c row 1).
+    let dispatched = req.tags.len();
+    print_session_dispatched(&req, &resp);
+    Ok(dispatched)
+}
+
+fn print_session_dispatched(req: &VerifySessionRequest, resp: &PostVerifySessionResponse) {
+    let annotation_word = if resp.plan_size == 1 {
+        "annotation"
+    } else {
+        "annotations"
+    };
+    println!();
+    println!(
+        "→ canon-verify session dispatched — verifying {} {annotation_word} against {}",
+        resp.plan_size,
+        short_sha(&req.commit_sha)
+    );
+    println!("  session: {}", resp.session_id);
+    println!("  view:    {}", resp.view_url);
+    println!();
+    println!(
+        "  Re-attach with: aristo verify --view {} --wait",
+        resp.session_id
+    );
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+fn no_auth_to_cli_error(e: aristo_core::auth::AuthError) -> CliError {
+    CliError::Other {
+        message: format!(
+            "canon-verify requires authentication: {e}\n  \
+             Run `aristo auth login` to sign in.\n  \
+             (Without a token, the SDK skips canon-bound `verify=\"full\"` \
+             entries — they'd be rejected server-side anyway.)"
+        ),
+        exit_code: 1,
+    }
+}
+
+fn verify_error_to_cli(e: VerifyError) -> CliError {
+    match e {
+        VerifyError::Auth(inner) => CliError::Other {
+            message: format!(
+                "canon-verify auth error: {inner}\n  \
+                 Your token may be expired — re-run `aristo auth login`."
+            ),
+            exit_code: 1,
+        },
+        VerifyError::BadRequest { status, message } if status == 402 => CliError::Other {
+            message: format!(
+                "no canon coverage applies for your scopes — \
+                 contact Aretta for DP onboarding to enable verification.\n  \
+                 (server message: {message})"
+            ),
+            exit_code: 1,
+        },
+        VerifyError::BadRequest { status, message } => CliError::Other {
+            message: format!("canon-verify server rejected request (HTTP {status}): {message}"),
+            exit_code: 1,
+        },
+        other => CliError::Other {
+            message: format!("canon-verify failed: {other}"),
+            exit_code: 1,
+        },
+    }
+}
+
+// ─── Test-only mock plumbing ────────────────────────────────────────────────
+
+/// Build a [`VerifyClient`] from `ARISTO_CANON_VERIFY_FIXTURE` if set.
+///
+/// The env var points at a JSON file with the canned POST response.
+/// Used by CLI integration tests to exercise the dispatch path
+/// without spinning up an HTTP server. Production callers must never
+/// set this; the file-on-disk gating + env var make accidental
+/// production use loud.
+fn test_mock_client_from_env() -> Option<Box<dyn VerifyClient>> {
+    let path = std::env::var("ARISTO_CANON_VERIFY_FIXTURE").ok()?;
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed: FixtureFile = serde_json::from_str(&raw).ok()?;
+    let post_resp = parsed.post.map(|p| PostVerifySessionResponse {
+        session_id: p.session_id,
+        view_url: p.view_url,
+        plan_size: p.plan_size,
+    })?;
+    // Record the POST body to a sibling file so tests can inspect it.
+    let record_path = format!("{path}.posted.json");
+    let mock = aristo_core::canon_verify::MockVerifyClient::with_post_response(post_resp);
+    Some(Box::new(RecordingMock {
+        inner: mock,
+        record_path,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+struct FixtureFile {
+    post: Option<FixturePost>,
+}
+
+#[derive(serde::Deserialize)]
+struct FixturePost {
+    session_id: String,
+    view_url: String,
+    plan_size: u32,
+}
+
+/// Wraps [`MockVerifyClient`] to write the POSTed request body to a
+/// sidecar file so the CLI integration test can assert wire-shape.
+struct RecordingMock {
+    inner: aristo_core::canon_verify::MockVerifyClient,
+    record_path: String,
+}
+
+impl VerifyClient for RecordingMock {
+    fn post_session(
+        &self,
+        req: &VerifySessionRequest,
+    ) -> Result<PostVerifySessionResponse, VerifyError> {
+        if let Ok(serialized) = serde_json::to_string_pretty(req) {
+            let _ = std::fs::write(&self.record_path, serialized);
+        }
+        self.inner.post_session(req)
+    }
+
+    fn get_session(
+        &self,
+        session_id: &str,
+        wait_seconds: Option<u32>,
+    ) -> Result<aristo_core::canon_verify::GetVerifySessionResponse, VerifyError> {
+        self.inner.get_session(session_id, wait_seconds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aristo_core::canon::{AcceptedMatch, CacheEntry, CacheMeta, PrefixTier};
+    use aristo_core::index::{
+        ArtaId, BindingState, CoveredRegion, IndexEntry, IntentEntry, Meta, Sha256, Status,
+        VerifyLevel, VerifyMethod,
+    };
+    use std::collections::BTreeMap;
+
+    fn empty_index() -> IndexFile {
+        IndexFile {
+            meta: Meta {
+                schema_version: 1,
+                generated_by: None,
+                generated_at: None,
+                source_root: None,
+            },
+            entries: BTreeMap::new(),
+        }
+    }
+
+    fn zero_hash() -> Sha256 {
+        Sha256::parse(&format!("sha256:{}", "0".repeat(64))).unwrap()
+    }
+
+    fn arta(s: &str) -> ArtaId {
+        ArtaId::parse(s).unwrap()
+    }
+
+    fn intent(
+        id: &str,
+        binding: BindingState,
+        file: &str,
+        site_with_line: &str,
+    ) -> (AnnotationId, IntentEntry) {
+        (
+            AnnotationId::parse(id).unwrap(),
+            IntentEntry {
+                text: "the property".into(),
+                verify: VerifyLevel::Method(VerifyMethod::Full),
+                status: Status::Unknown,
+                text_hash: zero_hash(),
+                body_hash: zero_hash(),
+                file: file.into(),
+                site: site_with_line.into(),
+                covered_region: CoveredRegion::Function,
+                binding,
+                parent: None,
+                last_critiqued_at_text_hash: None,
+                last_critique_finding_count: None,
+            },
+        )
+    }
+
+    fn matches_with(id: &AnnotationId, canon_id: &str, version: &str) -> CanonMatchesFile {
+        let mut f = CanonMatchesFile::default();
+        f.meta = CacheMeta::default();
+        f.entries.insert(
+            id.clone(),
+            CacheEntry {
+                last_match_text_hash: "x".into(),
+                canon_fetched_at: "2026-05-24T00:00:00Z".into(),
+                pending_matches: vec![],
+                accepted_matches: vec![AcceptedMatch {
+                    canon_id: canon_id.into(),
+                    version: version.into(),
+                    canonical_text: "the property".into(),
+                    canon_version: "v0.2.0".into(),
+                    confidence: 0.95,
+                    prefix_tier: PrefixTier::Aristos,
+                    backed_by: Some("test backing".into()),
+                    accepted_at: "2026-05-24T00:00:00Z".into(),
+                    bound_at: "2026-05-24T00:00:00Z".into(),
+                }],
+                rejected_matches: vec![],
+            },
+        );
+        f
+    }
+
+    // ─── partition_full ───────────────────────────────────────────────────
+
+    #[test]
+    fn partition_separates_canon_bound_from_local() {
+        let (aristos_id, aristos_entry) = intent(
+            "aristos:foo",
+            BindingState::Bound {
+                linked: arta("arta_op4q3z9NbV"),
+            },
+            "src/x.rs",
+            "fn x (line 1)",
+        );
+        let (kanon_id, kanon_entry) = intent(
+            "kanon:bar",
+            BindingState::Bound {
+                linked: arta("arta_xyz1234567"),
+            },
+            "src/y.rs",
+            "fn y (line 10)",
+        );
+        let (local_id, local_entry) =
+            intent("baz", BindingState::Local, "src/z.rs", "fn z (line 5)");
+
+        let mut index = empty_index();
+        index
+            .entries
+            .insert(aristos_id.clone(), IndexEntry::Intent(aristos_entry));
+        index
+            .entries
+            .insert(kanon_id.clone(), IndexEntry::Intent(kanon_entry));
+        index
+            .entries
+            .insert(local_id.clone(), IndexEntry::Intent(local_entry));
+
+        let pending = vec![&aristos_id, &kanon_id, &local_id];
+        let (canon, other) = partition_full(&index, &pending);
+
+        assert_eq!(canon.len(), 2);
+        assert_eq!(other.len(), 1);
+        assert_eq!(other[0].as_str(), "baz");
+        let canon_ids: Vec<_> = canon.iter().map(|c| c.id.as_str()).collect();
+        assert!(canon_ids.contains(&"aristos:foo"));
+        assert!(canon_ids.contains(&"kanon:bar"));
+    }
+
+    #[test]
+    fn partition_returns_empty_for_no_input() {
+        let index = empty_index();
+        let (canon, other) = partition_full(&index, &[]);
+        assert!(canon.is_empty());
+        assert!(other.is_empty());
+    }
+
+    // ─── build_tags ───────────────────────────────────────────────────────
+
+    #[test]
+    fn build_tags_emits_arta_id_canon_id_version_and_source_path() {
+        let (id, entry) = intent(
+            "aristos:vacuum_preserves_logical_content",
+            BindingState::Bound {
+                linked: arta("arta_op4q3z9NbV"),
+            },
+            "crates/vacuum/src/lib.rs",
+            "fn vacuum (line 42)",
+        );
+        let matches = matches_with(&id, "vacuum_preserves_logical_content", "v0.1.0");
+        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+
+        let tags = build_tags(&dispatch, &matches);
+        assert_eq!(tags.len(), 1);
+        let t = &tags[0];
+        assert_eq!(t.annotation_id, "arta_op4q3z9NbV");
+        assert_eq!(t.canon_id, "vacuum_preserves_logical_content");
+        assert_eq!(t.version, "v0.1.0");
+        assert_eq!(t.source_path, "crates/vacuum/src/lib.rs:42");
+    }
+
+    #[test]
+    fn build_tags_works_for_certified_binding_state() {
+        // Certified binding still carries `linked` — the SDK should
+        // re-dispatch on --rerun (caller's responsibility; we just
+        // need to handle the variant).
+        use aristo_core::index::{CommitHash, VerifiedOutcome};
+        let (id, entry) = intent(
+            "kanon:foo",
+            BindingState::Certified {
+                linked: arta("arta_aaaa1234"),
+                verified_outcome: VerifiedOutcome::parse(&format!("v1:{}", "A".repeat(86)))
+                    .unwrap(),
+                last_verified_at_commit: CommitHash::parse(&"a".repeat(40)).unwrap(),
+            },
+            "src/foo.rs",
+            "fn foo (line 7)",
+        );
+        let matches = matches_with(&id, "foo", "v0.2.0");
+        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let tags = build_tags(&dispatch, &matches);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].annotation_id, "arta_aaaa1234");
+        assert_eq!(tags[0].canon_id, "foo");
+        assert_eq!(tags[0].version, "v0.2.0");
+    }
+
+    #[test]
+    fn build_tags_drops_entries_missing_from_cache() {
+        // Canon-bound entry but no cache row — the cache is the only
+        // source of truth for `version`. Drop silently rather than
+        // POST an empty version that'd 4xx server-side.
+        let (id, entry) = intent(
+            "aristos:foo",
+            BindingState::Bound {
+                linked: arta("arta_aaaa1234"),
+            },
+            "src/foo.rs",
+            "fn foo (line 7)",
+        );
+        let matches = CanonMatchesFile::default();
+        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let tags = build_tags(&dispatch, &matches);
+        assert!(tags.is_empty(), "missing cache entry must drop the tag");
+    }
+
+    #[test]
+    fn build_tags_drops_local_binding() {
+        // Defensive: canon-prefixed id but `BindingState::Local` —
+        // shouldn't happen in practice but the partition is by id-
+        // prefix only; the build must handle missing linked gracefully.
+        let (id, entry) = intent(
+            "aristos:foo",
+            BindingState::Local,
+            "src/foo.rs",
+            "fn foo (line 7)",
+        );
+        let matches = matches_with(&id, "foo", "v0.1.0");
+        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let tags = build_tags(&dispatch, &matches);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn build_tags_falls_back_to_file_only_when_site_lacks_line() {
+        let (id, entry) = intent(
+            "aristos:foo",
+            BindingState::Bound {
+                linked: arta("arta_aaaa1234"),
+            },
+            "src/foo.rs",
+            "fn foo", // no "(line N)" suffix
+        );
+        let matches = matches_with(&id, "foo", "v0.1.0");
+        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let tags = build_tags(&dispatch, &matches);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].source_path, "src/foo.rs");
+    }
+
+    // ─── strip_canon_prefix ──────────────────────────────────────────────
+
+    #[test]
+    fn strip_canon_prefix_handles_both_tiers_and_no_prefix() {
+        assert_eq!(strip_canon_prefix("aristos:foo_bar"), "foo_bar");
+        assert_eq!(strip_canon_prefix("kanon:checkout_total_non_negative"), "checkout_total_non_negative");
+        // No prefix — pass through (defensive).
+        assert_eq!(strip_canon_prefix("local_id"), "local_id");
+    }
+
+    // ─── extract_line ────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_line_parses_walker_emitted_site_format() {
+        assert_eq!(extract_line("fn foo (line 42)"), Some(42));
+        assert_eq!(extract_line("fn really::long::path (line 1)"), Some(1));
+        assert_eq!(extract_line("fn x"), None);
+        assert_eq!(extract_line(""), None);
+    }
+
+    // ─── dispatch_session (with mock client) ─────────────────────────────
+
+    #[test]
+    fn dispatch_session_round_trips_through_mock() {
+        let mock = aristo_core::canon_verify::MockVerifyClient::with_post_response(
+            PostVerifySessionResponse {
+                session_id: "01HMTEST".into(),
+                view_url: "https://dev.aretta.ai/dashboard/jobs/01HMTEST".into(),
+                plan_size: 1,
+            },
+        );
+        let req = VerifySessionRequest {
+            repo_full_name: "owner/repo".into(),
+            commit_sha: "deadbeef".into(),
+            tags: vec![VerifySessionTag {
+                annotation_id: "arta_x".into(),
+                canon_id: "foo".into(),
+                version: "v0.1.0".into(),
+                source_path: "src/x.rs:1".into(),
+            }],
+        };
+        let resp = dispatch_session(&mock, &req).expect("dispatch ok");
+        assert_eq!(resp.session_id, "01HMTEST");
+        let posted = mock.posted_requests();
+        assert_eq!(posted.len(), 1);
+        assert_eq!(posted[0].tags[0].annotation_id, "arta_x");
+    }
+
+    #[test]
+    fn dispatch_session_propagates_server_error() {
+        let mock = aristo_core::canon_verify::MockVerifyClient::with_post_error(
+            VerifyError::BadRequest {
+                status: 402,
+                message: "no_canon_coverage".into(),
+            },
+        );
+        let req = VerifySessionRequest {
+            repo_full_name: "o/r".into(),
+            commit_sha: "x".into(),
+            tags: vec![],
+        };
+        let err = dispatch_session(&mock, &req).unwrap_err();
+        match err {
+            VerifyError::BadRequest { status: 402, .. } => {}
+            other => panic!("expected BadRequest 402, got {other:?}"),
+        }
+    }
+
+}

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -91,10 +91,7 @@ pub(crate) fn partition_full<'a>(
             continue;
         };
         if id.is_canon_bound() {
-            canon.push(CanonDispatchEntry {
-                id,
-                entry: intent,
-            });
+            canon.push(CanonDispatchEntry { id, entry: intent });
         } else {
             other.push(id);
         }
@@ -130,9 +127,7 @@ fn build_one_tag(
     let annotation_id = match &dispatch.entry.binding {
         aristo_core::index::BindingState::Local => return None,
         aristo_core::index::BindingState::Bound { linked } => linked.as_str().to_string(),
-        aristo_core::index::BindingState::Certified { linked, .. } => {
-            linked.as_str().to_string()
-        }
+        aristo_core::index::BindingState::Certified { linked, .. } => linked.as_str().to_string(),
     };
     // Strip `aristos:` / `kanon:` prefix to get the bare canon_id.
     let canon_id = strip_canon_prefix(dispatch.id.as_str()).to_string();
@@ -268,18 +263,19 @@ pub(crate) fn run_canon_dispatch(
             })?
         }
     };
-    let commit_sha = aristo_core::git::rev_parse_head(workspace_root).map_err(|e| {
-        CliError::Other {
+    let commit_sha =
+        aristo_core::git::rev_parse_head(workspace_root).map_err(|e| CliError::Other {
             message: format!("git rev-parse HEAD failed: {e}"),
             exit_code: 1,
-        }
-    })?;
+        })?;
 
     // 4. Push-first precheck (WORKFLOW.md §4 + §7c).
-    let pushed = aristo_core::git::commit_present_on_remote(workspace_root, &commit_sha)
-        .map_err(|e| CliError::Other {
-            message: format!("git push-first precheck failed: {e}"),
-            exit_code: 1,
+    let pushed =
+        aristo_core::git::commit_present_on_remote(workspace_root, &commit_sha).map_err(|e| {
+            CliError::Other {
+                message: format!("git push-first precheck failed: {e}"),
+                exit_code: 1,
+            }
         })?;
     if !pushed {
         return Err(CliError::Other {
@@ -294,14 +290,13 @@ pub(crate) fn run_canon_dispatch(
     }
 
     // 5. Build the HTTP client. ARETTA_API_URL overrides for tests.
-    let base_url = std::env::var("ARETTA_API_URL")
-        .unwrap_or_else(|_| creds.server.as_str().to_string());
-    let client: Box<dyn VerifyClient> =
-        if let Some(mock) = test_mock_client_from_env() {
-            mock
-        } else {
-            Box::new(HttpVerifyClient::new(base_url, &creds.token))
-        };
+    let base_url =
+        std::env::var("ARETTA_API_URL").unwrap_or_else(|_| creds.server.as_str().to_string());
+    let client: Box<dyn VerifyClient> = if let Some(mock) = test_mock_client_from_env() {
+        mock
+    } else {
+        Box::new(HttpVerifyClient::new(base_url, &creds.token))
+    };
 
     // 6. POST.
     let req = VerifySessionRequest {
@@ -339,14 +334,13 @@ pub(crate) fn run_canon_dispatch(
 /// Skips POST + push-first precheck entirely.
 pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
     let creds = aristo_core::auth::resolve_full().map_err(no_auth_to_cli_error)?;
-    let base_url = std::env::var("ARETTA_API_URL")
-        .unwrap_or_else(|_| creds.server.as_str().to_string());
-    let client: Box<dyn VerifyClient> =
-        if let Some(mock) = test_mock_client_from_env() {
-            mock
-        } else {
-            Box::new(HttpVerifyClient::new(base_url, &creds.token))
-        };
+    let base_url =
+        std::env::var("ARETTA_API_URL").unwrap_or_else(|_| creds.server.as_str().to_string());
+    let client: Box<dyn VerifyClient> = if let Some(mock) = test_mock_client_from_env() {
+        mock
+    } else {
+        Box::new(HttpVerifyClient::new(base_url, &creds.token))
+    };
 
     let snapshot = if wait {
         poll_until_terminal(&*client, session_id)?
@@ -480,10 +474,7 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
         snapshot.summary.total_annotations
     );
     println!();
-    println!(
-        "{:<55}  {:<14} TESTS",
-        "ANNOTATION", "STATUS"
-    );
+    println!("{:<55}  {:<14} TESTS", "ANNOTATION", "STATUS");
     for ann in &snapshot.annotations {
         let icon = annotation_icon(ann.status);
         let passed = ann
@@ -621,7 +612,10 @@ fn verify_error_to_cli(e: VerifyError) -> CliError {
             ),
             exit_code: 1,
         },
-        VerifyError::BadRequest { status, message } if status == 402 => CliError::Other {
+        VerifyError::BadRequest {
+            status: 402,
+            message,
+        } => CliError::Other {
             message: format!(
                 "no canon coverage applies for your scopes — \
                  contact Aretta for DP onboarding to enable verification.\n  \
@@ -664,10 +658,9 @@ fn test_mock_client_from_env() -> Option<Box<dyn VerifyClient>> {
     let record_path = format!("{path}.posted.json");
     let mock = match (post_resp, get_responses.is_empty()) {
         (Some(p), true) => aristo_core::canon_verify::MockVerifyClient::with_post_response(p),
-        (Some(p), false) => aristo_core::canon_verify::MockVerifyClient::with_post_and_gets(
-            p,
-            get_responses,
-        ),
+        (Some(p), false) => {
+            aristo_core::canon_verify::MockVerifyClient::with_post_and_gets(p, get_responses)
+        }
         (None, false) => {
             aristo_core::canon_verify::MockVerifyClient::with_get_responses(get_responses)
         }
@@ -775,8 +768,10 @@ mod tests {
     }
 
     fn matches_with(id: &AnnotationId, canon_id: &str, version: &str) -> CanonMatchesFile {
-        let mut f = CanonMatchesFile::default();
-        f.meta = CacheMeta::default();
+        let mut f = CanonMatchesFile {
+            meta: CacheMeta::default(),
+            ..CanonMatchesFile::default()
+        };
         f.entries.insert(
             id.clone(),
             CacheEntry {
@@ -866,7 +861,10 @@ mod tests {
             "fn vacuum (line 42)",
         );
         let matches = matches_with(&id, "vacuum_preserves_logical_content", "v0.1.0");
-        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let dispatch = vec![CanonDispatchEntry {
+            id: &id,
+            entry: &entry,
+        }];
 
         let tags = build_tags(&dispatch, &matches);
         assert_eq!(tags.len(), 1);
@@ -895,7 +893,10 @@ mod tests {
             "fn foo (line 7)",
         );
         let matches = matches_with(&id, "foo", "v0.2.0");
-        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let dispatch = vec![CanonDispatchEntry {
+            id: &id,
+            entry: &entry,
+        }];
         let tags = build_tags(&dispatch, &matches);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].annotation_id, "arta_aaaa1234");
@@ -917,7 +918,10 @@ mod tests {
             "fn foo (line 7)",
         );
         let matches = CanonMatchesFile::default();
-        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let dispatch = vec![CanonDispatchEntry {
+            id: &id,
+            entry: &entry,
+        }];
         let tags = build_tags(&dispatch, &matches);
         assert!(tags.is_empty(), "missing cache entry must drop the tag");
     }
@@ -934,7 +938,10 @@ mod tests {
             "fn foo (line 7)",
         );
         let matches = matches_with(&id, "foo", "v0.1.0");
-        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let dispatch = vec![CanonDispatchEntry {
+            id: &id,
+            entry: &entry,
+        }];
         let tags = build_tags(&dispatch, &matches);
         assert!(tags.is_empty());
     }
@@ -950,7 +957,10 @@ mod tests {
             "fn foo", // no "(line N)" suffix
         );
         let matches = matches_with(&id, "foo", "v0.1.0");
-        let dispatch = vec![CanonDispatchEntry { id: &id, entry: &entry }];
+        let dispatch = vec![CanonDispatchEntry {
+            id: &id,
+            entry: &entry,
+        }];
         let tags = build_tags(&dispatch, &matches);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].source_path, "src/foo.rs");
@@ -961,7 +971,10 @@ mod tests {
     #[test]
     fn strip_canon_prefix_handles_both_tiers_and_no_prefix() {
         assert_eq!(strip_canon_prefix("aristos:foo_bar"), "foo_bar");
-        assert_eq!(strip_canon_prefix("kanon:checkout_total_non_negative"), "checkout_total_non_negative");
+        assert_eq!(
+            strip_canon_prefix("kanon:checkout_total_non_negative"),
+            "checkout_total_non_negative"
+        );
         // No prefix — pass through (defensive).
         assert_eq!(strip_canon_prefix("local_id"), "local_id");
     }
@@ -1006,12 +1019,11 @@ mod tests {
 
     #[test]
     fn dispatch_session_propagates_server_error() {
-        let mock = aristo_core::canon_verify::MockVerifyClient::with_post_error(
-            VerifyError::BadRequest {
+        let mock =
+            aristo_core::canon_verify::MockVerifyClient::with_post_error(VerifyError::BadRequest {
                 status: 402,
                 message: "no_canon_coverage".into(),
-            },
-        );
+            });
         let req = VerifySessionRequest {
             repo_full_name: "o/r".into(),
             commit_sha: "x".into(),
@@ -1023,5 +1035,4 @@ mod tests {
             other => panic!("expected BadRequest 402, got {other:?}"),
         }
     }
-
 }

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -28,6 +28,7 @@ use crate::workspace::Workspace;
 use crate::{CliError, CliResult};
 
 pub(crate) mod apply;
+pub(crate) mod canon_dispatch;
 pub(crate) mod pending;
 pub(crate) mod session_kind;
 pub(crate) mod submit;
@@ -95,7 +96,7 @@ pub(crate) fn run(
     let mut stats = Stats::default();
     let mut pending_neural: Vec<&AnnotationId> = Vec::new();
     let mut pending_test: usize = 0;
-    let mut pending_full: usize = 0;
+    let mut pending_full: Vec<&AnnotationId> = Vec::new();
 
     for (id, entry) in index.entries.iter() {
         if !matches_all(id, entry, &filters) {
@@ -125,7 +126,7 @@ pub(crate) fn run(
                 pending_neural.push(id);
             }
             VerifyLevel::Method(VerifyMethod::Test) => pending_test += 1,
-            VerifyLevel::Method(VerifyMethod::Full) => pending_full += 1,
+            VerifyLevel::Method(VerifyMethod::Full) => pending_full.push(id),
         }
     }
 
@@ -136,25 +137,46 @@ pub(crate) fn run(
     };
     let _ = enqueued; // count surfaced via emit_summary below
 
-    emit_summary(&stats, pending_neural.len(), pending_test, pending_full);
+    // Partition `verify="full"` entries into canon-bound (kanon: /
+    // aristos:) vs. non-canon. Canon-bound entries dispatch through
+    // §14 canon-verify; non-canon-bound entries hit the deferred
+    // verify=full design path (see docs/deferred/verify-test-design.md).
+    let (canon_full, other_full) = canon_dispatch::partition_full(&index, &pending_full);
 
-    // Slice 23 ships neural via the in-agent skill route. test and full
-    // were originally milestone E slices 24/26 but are deferred to post-MVP
-    // pending the spec-schema + injection-mechanism design (see
-    // docs/deferred/verify-test-design.md). If the user has entries needing
-    // those methods, surface a NotImplemented at the end with the deferred-
-    // design pointer so the message is actionable rather than blocking-on-
-    // a-slice-number-that-isn't-coming.
+    emit_summary(
+        &stats,
+        pending_neural.len(),
+        pending_test,
+        canon_full.len() + other_full.len(),
+    );
+
+    // §14 canon-verify dispatch. Auth required (user-confirmed in
+    // session): without an arta_* token, server-side authorization
+    // would reject anyway, so we skip with an actionable hint rather
+    // than POSTing a guaranteed-401.
+    let dispatched = canon_dispatch::run_canon_dispatch(
+        &ws.root,
+        &ws.canon_matches_path(),
+        &canon_full,
+    )?;
+    let _ = dispatched;
+
+    // Slice 23 ships neural via the in-agent skill route. test +
+    // non-canon-bound full were originally milestone E slices 24/26
+    // but are deferred to post-MVP pending the spec-schema +
+    // injection-mechanism design. Canon-bound full is now live (§14);
+    // the deferred design only governs the non-canon path.
     if pending_test > 0 {
         return Err(CliError::NotImplemented {
             what: "aristo verify (verify=\"test\")",
             hint: "post-MVP — see docs/deferred/verify-test-design.md",
         });
     }
-    if pending_full > 0 {
+    if !other_full.is_empty() {
         return Err(CliError::NotImplemented {
-            what: "aristo verify (verify=\"full\")",
-            hint: "post-MVP — depends on verify=\"test\"; see docs/deferred/verify-test-design.md",
+            what: "aristo verify (verify=\"full\") for non-canon-bound entries",
+            hint: "post-MVP — see docs/deferred/verify-test-design.md. \
+                   Canon-bound (`kanon:` / `aristos:`) entries dispatch via §14.",
         });
     }
     Ok(())

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -50,8 +50,27 @@ pub(crate) fn run(
     queue_status: bool,
     id: Option<String>,
     json: Option<String>,
+    wait: bool,
+    view: Option<String>,
+    tags: &[String],
 ) -> CliResult<()> {
     let _ = (check, strict); // wired for forward-compat; no behavior yet (see module doc)
+
+    // E3: `--view <session_id>` attaches to an existing session.
+    // Read-only — no session guard, no workspace mutation. Runs
+    // before workspace resolution since the operation only needs
+    // an HTTP client (auth + server URL).
+    if let Some(session_id) = view {
+        if !tags.is_empty() {
+            return Err(CliError::Other {
+                message: "--tags is not compatible with --view (the session was already \
+                          dispatched with its tag set)".into(),
+                exit_code: 2,
+            });
+        }
+        return canon_dispatch::run_view_session(&session_id, wait);
+    }
+
     let ws = workspace_or_error()?;
     emit_advisory_if_stale(&freshness_check(&ws));
     let index = read_index(&ws.index_path())?;
@@ -154,10 +173,13 @@ pub(crate) fn run(
     // session): without an arta_* token, server-side authorization
     // would reject anyway, so we skip with an actionable hint rather
     // than POSTing a guaranteed-401.
+    let tags_filter = if tags.is_empty() { None } else { Some(tags) };
     let dispatched = canon_dispatch::run_canon_dispatch(
         &ws.root,
         &ws.canon_matches_path(),
         &canon_full,
+        tags_filter,
+        wait,
     )?;
     let _ = dispatched;
 

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -64,7 +64,8 @@ pub(crate) fn run(
         if !tags.is_empty() {
             return Err(CliError::Other {
                 message: "--tags is not compatible with --view (the session was already \
-                          dispatched with its tag set)".into(),
+                          dispatched with its tag set)"
+                    .into(),
                 exit_code: 2,
             });
         }

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -234,6 +234,30 @@ enum Commands {
         /// Safe to call concurrently.
         #[arg(long = "queue-status", conflicts_with_all = ["apply_verdicts", "submit_verdict"])]
         queue_status: bool,
+        /// Block until the canon-verify session reaches a terminal
+        /// state, rendering a snapshot at each long-poll return and
+        /// emitting a `still running…` heartbeat every 60s. Exit code
+        /// is derived from the final summary: `0` iff every
+        /// annotation is `verified` or `no_coverage`. Without
+        /// `--wait` the SDK detaches after dispatch (prints session
+        /// id and exits 0). Combine with `--view <id>` to attach to
+        /// a session another invocation started.
+        #[arg(long = "wait")]
+        wait: bool,
+        /// Re-attach to a previously-dispatched canon-verify session
+        /// by id. Skips the source eligibility scan, push-first
+        /// precheck, and POST — just GETs the session state and
+        /// renders. Combine with `--wait` to block until terminal.
+        #[arg(long = "view", value_name = "SESSION_ID")]
+        view: Option<String>,
+        /// Subset the canon-verify dispatch to the listed annotation
+        /// ids. Comma-separated; each id must be a canon-bound entry
+        /// (`aristos:foo` or `kanon:bar`) in the workspace's index.
+        /// Bare canon-id suffixes (e.g. `foo`) are accepted as a
+        /// shorthand. `arta_*` (server-side opaque) ids are rejected
+        /// — those are not user-facing.
+        #[arg(long = "tags", value_name = "id1,id2,...", value_delimiter = ',')]
+        tags: Vec<String>,
     },
 
     /// Run the critique skill against annotation prose — opinionated
@@ -766,6 +790,9 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
             json,
             pop_next,
             queue_status,
+            wait,
+            view,
+            tags,
         } => commands::verify::run(
             &filters,
             rerun,
@@ -778,6 +805,9 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
             queue_status,
             id,
             json,
+            wait,
+            view,
+            &tags,
         ),
         Commands::Critique {
             filters,

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -67,17 +67,17 @@ fn init_repo_with_pushed_head(dir: &Path) -> tempfile::TempDir {
     // resolve — we override the actual remote target separately.
     run_git(
         dir,
-        &["remote", "add", "origin", "https://github.com/owner/repo.git"],
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
     );
     // Now point that origin at the local bare repo for the push.
     run_git(
         dir,
-        &[
-            "remote",
-            "set-url",
-            "origin",
-            bare.path().to_str().unwrap(),
-        ],
+        &["remote", "set-url", "origin", bare.path().to_str().unwrap()],
     );
     // Seed file so git has something to commit. The SDK only cares
     // that HEAD is reachable from `origin/*`; subsequent uncommitted
@@ -214,13 +214,18 @@ fn canon_bound_full_with_auth_posts_session_and_prints_session_id() {
     aristo_in(tmp.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join(".config"))
-        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .env(
+            "ARISTO_CANON_VERIFY_FIXTURE",
+            tmp.path().join("verify-fixture.json"),
+        )
         .arg("verify")
         .assert()
         .success()
         .stdout(contains("canon-verify session dispatched"))
         .stdout(contains("01HMTESTSESSION"))
-        .stdout(contains("https://dev.aretta.ai/dashboard/jobs/01HMTESTSESSION"))
+        .stdout(contains(
+            "https://dev.aretta.ai/dashboard/jobs/01HMTESTSESSION",
+        ))
         .stdout(contains("aristo verify --view 01HMTESTSESSION"));
 
     // Wire-shape assertions: the SDK's POST body must match WORKFLOW.md §4.
@@ -248,7 +253,12 @@ fn local_only_commit_rejected_by_push_first_precheck() {
     run_git(tmp.path(), &["config", "commit.gpgsign", "false"]);
     run_git(
         tmp.path(),
-        &["remote", "add", "origin", "https://github.com/owner/repo.git"],
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
     );
     fs::write(tmp.path().join("README"), b"seed").unwrap();
     workspace_with_one_canon_bound_full_intent(tmp.path());
@@ -267,7 +277,10 @@ fn local_only_commit_rejected_by_push_first_precheck() {
     aristo_in(tmp.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join(".config"))
-        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .env(
+            "ARISTO_CANON_VERIFY_FIXTURE",
+            tmp.path().join("verify-fixture.json"),
+        )
         .arg("verify")
         .assert()
         .failure()
@@ -574,7 +587,10 @@ bound_at = "2026-05-24T00:00:00Z"
     aristo_in(tmp.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join(".config"))
-        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .env(
+            "ARISTO_CANON_VERIFY_FIXTURE",
+            tmp.path().join("verify-fixture.json"),
+        )
         .args(["verify", "--tags", "kanon:beta"])
         .assert()
         .success();
@@ -582,7 +598,11 @@ bound_at = "2026-05-24T00:00:00Z"
     let captured = fs::read_to_string(&captured_path).unwrap();
     let body: serde_json::Value = serde_json::from_str(&captured).unwrap();
     let tags = body["tags"].as_array().unwrap();
-    assert_eq!(tags.len(), 1, "--tags kanon:beta must dispatch one tag, got {tags:?}");
+    assert_eq!(
+        tags.len(),
+        1,
+        "--tags kanon:beta must dispatch one tag, got {tags:?}"
+    );
     assert_eq!(tags[0]["annotation_id"], "arta_beta00000000");
     assert_eq!(tags[0]["canon_id"], "beta");
 }

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -1,0 +1,329 @@
+//! `aristo verify` canon-verify dispatch (§14 phase E1) — end-to-end
+//! integration tests.
+//!
+//! Goes through the real CLI binary (`aristo verify`) against a
+//! tempdir workspace + git repo. The HTTP call to the proxy is
+//! intercepted via the `ARISTO_CANON_VERIFY_FIXTURE` env var (a
+//! test-only escape hatch in `commands/verify/canon_dispatch.rs`)
+//! which:
+//!
+//! 1. Returns a canned `PostVerifySessionResponse` from a JSON file.
+//! 2. Writes the actual request body the SDK sent to `<fixture>.posted.json`
+//!    so this test can assert wire-shape correctness.
+//!
+//! What we pin:
+//!
+//! - The SDK reaches the dispatch path for `verify="full"` +
+//!   `aristos:` / `kanon:` ids.
+//! - Push-first precheck rejects local-only commits (no origin/*).
+//! - Auth-missing yields the actionable hint, not a panic.
+//! - The POST body shape matches WORKFLOW.md §4 wire (tags carry
+//!   `arta_*` ids, bare canon_ids, version from cache, `file:line`
+//!   source_path).
+//! - Output prints session_id + view_url in detach default.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ZERO_HASH: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    // Belt + braces: every test sets up its own env-var isolation.
+    // Strip both potential auth sources by default.
+    cmd.env_remove("ARETTA_TOKEN");
+    cmd
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Initialize `dir` as a git repo with `origin` pointing at a sibling
+/// bare repo, and commit the current contents so HEAD is on
+/// `origin/main`. Returns the bare-upstream tempdir (so the caller
+/// keeps it alive — dropping it would invalidate the remote URL).
+fn init_repo_with_pushed_head(dir: &Path) -> tempfile::TempDir {
+    let bare = tempfile::tempdir().unwrap();
+    run_git(bare.path(), &["init", "--bare", "-q"]);
+    run_git(dir, &["init", "-q", "-b", "main"]);
+    run_git(dir, &["config", "user.email", "t@x"]);
+    run_git(dir, &["config", "user.name", "t"]);
+    run_git(dir, &["config", "commit.gpgsign", "false"]);
+    // Add a GitHub-shaped origin URL so the SDK's `derive_repo_full_name`
+    // produces `owner/repo` cleanly. The actual URL doesn't need to
+    // resolve — we override the actual remote target separately.
+    run_git(
+        dir,
+        &["remote", "add", "origin", "https://github.com/owner/repo.git"],
+    );
+    // Now point that origin at the local bare repo for the push.
+    run_git(
+        dir,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            bare.path().to_str().unwrap(),
+        ],
+    );
+    // Seed file so git has something to commit. The SDK only cares
+    // that HEAD is reachable from `origin/*`; subsequent uncommitted
+    // workspace changes are fine.
+    fs::write(dir.join("README"), b"seed").unwrap();
+    run_git(dir, &["add", "-A"]);
+    run_git(dir, &["commit", "-q", "-m", "init"]);
+    run_git(dir, &["push", "-q", "origin", "main"]);
+    // Restore the GitHub URL on origin so derive_repo_full_name picks
+    // it up. (push happened against the bare upstream.)
+    run_git(
+        dir,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    bare
+}
+
+/// Write an `.aristo/index.toml` with one canon-bound (aristos:)
+/// intent at `verify="full"`. Returns the bare upstream + the
+/// fixture file path.
+fn workspace_with_one_canon_bound_full_intent(dir: &Path) {
+    aristo_in(dir).arg("init").assert().success();
+    // aristos:foo with `linked = arta_...` is the only legal way to
+    // have a bound canon-tier entry — id-namespace ↔ binding-state
+    // agreement is enforced by the index validator.
+    let body = format!(
+        "[__meta__]\nschema_version = 1\n\n\
+         [\"aristos:foo\"]\nkind = \"intent\"\ntext = \"the property\"\n\
+         verify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/foo.rs\"\nsite = \"fn foo (line 42)\"\n\
+         covered_region = \"function\"\n\
+         linked = \"arta_op4q3z9NbV\"\n",
+    );
+    fs::write(dir.join(".aristo/index.toml"), body).unwrap();
+
+    // Matching canon-matches cache entry — version source of truth.
+    let matches = r#"
+[__meta__]
+schema_version = 1
+
+["aristos:foo"]
+last_match_text_hash = "blake3:test"
+canon_fetched_at = "2026-05-24T00:00:00Z"
+
+[["aristos:foo".accepted_matches]]
+canon_id = "foo"
+version = "v0.1.0"
+canonical_text = "the property"
+canon_version = "v0.2.0"
+confidence = 0.95
+prefix_tier = "aristos:"
+backed_by = "test backing"
+accepted_at = "2026-05-24T00:00:00Z"
+bound_at = "2026-05-24T00:00:00Z"
+"#;
+    fs::write(dir.join(".aristo/canon-matches.toml"), matches).unwrap();
+}
+
+/// Write a fixture file the SDK reads via ARISTO_CANON_VERIFY_FIXTURE.
+/// Returns the path the SDK will write the captured POST body to.
+fn write_post_fixture(dir: &Path, session_id: &str, plan_size: u32) -> PathBuf {
+    let path = dir.join("verify-fixture.json");
+    let body = format!(
+        r#"{{
+          "post": {{
+            "session_id": "{session_id}",
+            "view_url": "https://dev.aretta.ai/dashboard/jobs/{session_id}",
+            "plan_size": {plan_size}
+          }}
+        }}"#
+    );
+    fs::write(&path, body).unwrap();
+    dir.join("verify-fixture.json.posted.json")
+}
+
+fn write_aretta_token(home: &Path, server_url: &str) {
+    // Stand up XDG-style credentials so `auth::resolve_full()` picks
+    // up a token without env-var auth. The store layout matches
+    // `aristo_core::auth::store::credentials_path_with`.
+    let creds_dir = home.join(".config/aristo");
+    fs::create_dir_all(&creds_dir).unwrap();
+    let body = format!(
+        r#"
+[aretta]
+token = "arta_test_token_xxx"
+server = "{server_url}"
+user_login = "tester"
+user_id = 1
+repo = "owner/repo"
+issued_at = "2026-05-24T00:00:00Z"
+"#
+    );
+    fs::write(creds_dir.join("credentials"), body).unwrap();
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn canon_bound_full_with_no_auth_surfaces_aristo_auth_login_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    // No auth on disk + no env var. The dispatcher must surface the
+    // actionable hint and exit non-zero, NOT crash and NOT silently
+    // skip.
+    let home = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .arg("verify")
+        .assert()
+        .failure()
+        .stderr(contains("canon-verify requires authentication"))
+        .stderr(contains("aristo auth login"));
+}
+
+#[test]
+fn canon_bound_full_with_auth_posts_session_and_prints_session_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+    let captured_path = write_post_fixture(tmp.path(), "01HMTESTSESSION", 1);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .arg("verify")
+        .assert()
+        .success()
+        .stdout(contains("canon-verify session dispatched"))
+        .stdout(contains("01HMTESTSESSION"))
+        .stdout(contains("https://dev.aretta.ai/dashboard/jobs/01HMTESTSESSION"))
+        .stdout(contains("aristo verify --view 01HMTESTSESSION"));
+
+    // Wire-shape assertions: the SDK's POST body must match WORKFLOW.md §4.
+    let captured = fs::read_to_string(&captured_path)
+        .unwrap_or_else(|e| panic!("expected captured POST at {captured_path:?}: {e}"));
+    let body: serde_json::Value = serde_json::from_str(&captured).unwrap();
+    assert_eq!(body["repo_full_name"], "owner/repo");
+    assert!(body["commit_sha"].as_str().unwrap().len() == 40);
+    let tags = body["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0]["annotation_id"], "arta_op4q3z9NbV");
+    assert_eq!(tags[0]["canon_id"], "foo");
+    assert_eq!(tags[0]["version"], "v0.1.0");
+    assert_eq!(tags[0]["source_path"], "src/foo.rs:42");
+}
+
+#[test]
+fn local_only_commit_rejected_by_push_first_precheck() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Init repo but DO NOT push — HEAD is local-only. The precheck
+    // must reject before the SDK POSTs.
+    run_git(tmp.path(), &["init", "-q", "-b", "main"]);
+    run_git(tmp.path(), &["config", "user.email", "t@x"]);
+    run_git(tmp.path(), &["config", "user.name", "t"]);
+    run_git(tmp.path(), &["config", "commit.gpgsign", "false"]);
+    run_git(
+        tmp.path(),
+        &["remote", "add", "origin", "https://github.com/owner/repo.git"],
+    );
+    fs::write(tmp.path().join("README"), b"seed").unwrap();
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    run_git(tmp.path(), &["add", "-A"]);
+    // --no-verify bypasses the pre-commit hook `aristo init` installed
+    // (it'd re-stamp from an empty source tree and wipe our manual
+    // index entry); the test only needs HEAD to exist + be unpushed.
+    run_git(tmp.path(), &["commit", "-q", "--no-verify", "-m", "init"]);
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+    // Even with a fixture set, the precheck should reject before the
+    // mock client is reached.
+    let _captured = write_post_fixture(tmp.path(), "01HMUNREACHED", 1);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .arg("verify")
+        .assert()
+        .failure()
+        .stderr(contains("not pushed to origin"))
+        .stderr(contains("Push your branch first"));
+}
+
+#[test]
+fn missing_cache_entry_for_canon_bound_full_skips_with_refresh_hint() {
+    // Canon-bound entry but no canon-matches cache row — can't resolve
+    // the `version` field; SDK must skip with a refresh hint, not
+    // POST an invalid request.
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    // Clobber the cache to empty so the build_tags filter drops the entry.
+    fs::write(
+        tmp.path().join(".aristo/canon-matches.toml"),
+        "[__meta__]\nschema_version = 1\n",
+    )
+    .unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .arg("verify")
+        .assert()
+        .success()
+        .stdout(contains("aristo canon refresh"));
+}
+
+#[test]
+fn non_canon_bound_full_intent_still_yields_deferred_design_message() {
+    // Regression for the pre-§14 NotImplemented arm — local-id
+    // intents at verify=full must still hit the deferred-design
+    // NotImplemented (their verification mechanism is unrelated to
+    // canon-verify).
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    aristo_in(tmp.path()).arg("init").assert().success();
+    let body = format!(
+        "[__meta__]\nschema_version = 1\n\n\
+         [my_local_full]\nkind = \"intent\"\ntext = \"x\"\nverify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/x.rs\"\nsite = \"fn x (line 1)\"\n\
+         covered_region = \"function\"\n",
+    );
+    fs::write(tmp.path().join(".aristo/index.toml"), body).unwrap();
+
+    aristo_in(tmp.path())
+        .arg("verify")
+        .assert()
+        .failure()
+        .stderr(contains("non-canon-bound"))
+        .stderr(contains("post-MVP"));
+}

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -302,6 +302,328 @@ fn missing_cache_entry_for_canon_bound_full_skips_with_refresh_hint() {
         .stdout(contains("aristo canon refresh"));
 }
 
+/// Fixture builder for `--wait` / `--view` paths: takes a JSON object
+/// describing the post-and-gets sequence and writes it to a file the
+/// SDK reads via ARISTO_CANON_VERIFY_FIXTURE.
+fn write_full_fixture(dir: &Path, body: &str) -> PathBuf {
+    let path = dir.join("verify-fixture.json");
+    fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn wait_blocks_until_session_terminal_and_renders_final_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    // Two GET responses: one running, one done. The poll loop must
+    // skip the first, render the second.
+    let fixture_body = r#"{
+      "post": {
+        "session_id": "01HMWAIT",
+        "view_url": "https://dev.aretta.ai/dashboard/jobs/01HMWAIT",
+        "plan_size": 1
+      },
+      "gets": [
+        {
+          "session_id": "01HMWAIT",
+          "status": "running",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "annotations": [],
+          "summary": {"total_annotations": 1, "verified": 0, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        },
+        {
+          "session_id": "01HMWAIT",
+          "status": "done",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "completed_at": "2026-05-24T00:01:00Z",
+          "annotations": [
+            {
+              "annotation_id": "arta_op4q3z9NbV",
+              "canon_id": "foo",
+              "version": "v0.1.0",
+              "scope": "turso",
+              "tier": "aristos:",
+              "source_path": "src/foo.rs:42",
+              "status": "verified",
+              "tests": [{"test_binary": "foo_conform", "status": "pass", "duration_ms": 1234}]
+            }
+          ],
+          "summary": {"total_annotations": 1, "verified": 1, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        }
+      ]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture_body);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .success()
+        .stdout(contains("01HMWAIT"))
+        .stdout(contains("session 01HMWAIT"))
+        .stdout(contains("status: done (1/1 verified)"))
+        .stdout(contains("aristos:foo@v0.1.0"))
+        .stdout(contains("verified"));
+}
+
+#[test]
+fn wait_exits_nonzero_when_summary_has_failures() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    let fixture_body = r#"{
+      "post": {"session_id": "01HMFAIL", "view_url": "https://x", "plan_size": 1},
+      "gets": [
+        {
+          "session_id": "01HMFAIL",
+          "status": "done",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "completed_at": "2026-05-24T00:01:00Z",
+          "annotations": [
+            {
+              "annotation_id": "arta_op4q3z9NbV",
+              "canon_id": "foo",
+              "version": "v0.1.0",
+              "scope": "turso",
+              "tier": "aristos:",
+              "source_path": "src/foo.rs:42",
+              "status": "failed",
+              "tests": [{"test_binary": "foo_conform", "status": "fail", "duration_ms": 1234}]
+            }
+          ],
+          "summary": {"total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        }
+      ]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture_body);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        .stdout(contains("status: done"))
+        .stdout(contains("failed"))
+        .stderr(contains("1 failed"));
+}
+
+#[test]
+fn view_attaches_to_existing_session_without_post() {
+    // --view <id> skips POST entirely — no workspace, no git, no auth-
+    // sourced repo. Only a single GET. We deliberately don't init a
+    // git repo in this test to prove push-first/precheck is skipped.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    // No `post` block — the SDK should never POST under --view.
+    let fixture_body = r#"{
+      "gets": [
+        {
+          "session_id": "01HMVIEW",
+          "status": "running",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "annotations": [],
+          "summary": {"total_annotations": 0, "verified": 0, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        }
+      ]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture_body);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .args(["verify", "--view", "01HMVIEW"])
+        .assert()
+        .success()
+        .stdout(contains("session 01HMVIEW"))
+        .stdout(contains("status: running"));
+
+    // The .posted.json sidecar must NOT have been written.
+    let posted = tmp.path().join("verify-fixture.json.posted.json");
+    assert!(
+        !posted.exists(),
+        "--view must not POST; sidecar exists at {posted:?}"
+    );
+}
+
+#[test]
+fn view_with_wait_blocks_until_terminal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    let fixture_body = r#"{
+      "gets": [
+        {
+          "session_id": "01HMVW",
+          "status": "running",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "annotations": [],
+          "summary": {"total_annotations": 1, "verified": 0, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        },
+        {
+          "session_id": "01HMVW",
+          "status": "done",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "completed_at": "2026-05-24T00:01:00Z",
+          "annotations": [],
+          "summary": {"total_annotations": 1, "verified": 1, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0}
+        }
+      ]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture_body);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--view", "01HMVW", "--wait"])
+        .assert()
+        .success()
+        .stdout(contains("status: done (1/1 verified)"));
+}
+
+#[test]
+fn tags_filter_narrows_to_requested_canon_bound_ids() {
+    // Two canon-bound entries; --tags picks one. Wire-shape proves
+    // only the requested tag's annotation_id reached the POST body.
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    aristo_in(tmp.path()).arg("init").assert().success();
+    let body = format!(
+        "[__meta__]\nschema_version = 1\n\n\
+         [\"aristos:alpha\"]\nkind = \"intent\"\ntext = \"a\"\n\
+         verify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/a.rs\"\nsite = \"fn a (line 1)\"\n\
+         covered_region = \"function\"\nlinked = \"arta_alpha000000\"\n\n\
+         [\"kanon:beta\"]\nkind = \"intent\"\ntext = \"b\"\n\
+         verify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/b.rs\"\nsite = \"fn b (line 1)\"\n\
+         covered_region = \"function\"\nlinked = \"arta_beta00000000\"\n",
+    );
+    fs::write(tmp.path().join(".aristo/index.toml"), body).unwrap();
+    let matches = r#"
+[__meta__]
+schema_version = 1
+
+["aristos:alpha"]
+last_match_text_hash = "blake3:a"
+canon_fetched_at = "2026-05-24T00:00:00Z"
+[["aristos:alpha".accepted_matches]]
+canon_id = "alpha"
+version = "v0.1.0"
+canonical_text = "a"
+canon_version = "v0.2.0"
+confidence = 0.9
+prefix_tier = "aristos:"
+backed_by = "x"
+accepted_at = "2026-05-24T00:00:00Z"
+bound_at = "2026-05-24T00:00:00Z"
+
+["kanon:beta"]
+last_match_text_hash = "blake3:b"
+canon_fetched_at = "2026-05-24T00:00:00Z"
+[["kanon:beta".accepted_matches]]
+canon_id = "beta"
+version = "v0.2.0"
+canonical_text = "b"
+canon_version = "v0.2.0"
+confidence = 0.9
+prefix_tier = "kanon:"
+accepted_at = "2026-05-24T00:00:00Z"
+bound_at = "2026-05-24T00:00:00Z"
+"#;
+    fs::write(tmp.path().join(".aristo/canon-matches.toml"), matches).unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+    let captured_path = write_post_fixture(tmp.path(), "01HMTAGS", 1);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", tmp.path().join("verify-fixture.json"))
+        .args(["verify", "--tags", "kanon:beta"])
+        .assert()
+        .success();
+
+    let captured = fs::read_to_string(&captured_path).unwrap();
+    let body: serde_json::Value = serde_json::from_str(&captured).unwrap();
+    let tags = body["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 1, "--tags kanon:beta must dispatch one tag, got {tags:?}");
+    assert_eq!(tags[0]["annotation_id"], "arta_beta00000000");
+    assert_eq!(tags[0]["canon_id"], "beta");
+}
+
+#[test]
+fn tags_rejects_arta_prefixed_ids() {
+    // arta_* is server-side opaque; users should never paste it.
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .args(["verify", "--tags", "arta_op4q3z9NbV"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(contains("--tags rejects opaque server ids"));
+}
+
+#[test]
+fn view_with_tags_is_rejected_as_incompatible() {
+    // The session was already dispatched with its tag set; --tags is
+    // not meaningful on attach.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .args(["verify", "--view", "01HM", "--tags", "aristos:foo"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(contains("--tags is not compatible with --view"));
+}
+
 #[test]
 fn non_canon_bound_full_intent_still_yields_deferred_design_message() {
     // Regression for the pre-§14 NotImplemented arm — local-id

--- a/crates/aristo-core/src/canon_verify/mock_client.rs
+++ b/crates/aristo-core/src/canon_verify/mock_client.rs
@@ -76,6 +76,23 @@ impl MockVerifyClient {
         }
     }
 
+    /// Construct a mock that returns this POST response on the first
+    /// POST and replays the GET sequence in order. Useful for testing
+    /// the full POST → poll loop end-to-end (E2 `--wait`).
+    pub fn with_post_and_gets(
+        post: PostVerifySessionResponse,
+        get_responses: Vec<GetVerifySessionResponse>,
+    ) -> Self {
+        Self {
+            post_response: Mutex::new(Some(Ok(post))),
+            get_responses: Mutex::new(
+                get_responses.into_iter().map(Ok).collect::<Vec<_>>(),
+            ),
+            posted: Mutex::new(Vec::new()),
+            fetched: Mutex::new(Vec::new()),
+        }
+    }
+
     /// Inspect the requests POSTed so far. Useful for asserting wire-
     /// shape correctness in dispatcher tests.
     pub fn posted_requests(&self) -> Vec<VerifySessionRequest> {

--- a/crates/aristo-core/src/canon_verify/mock_client.rs
+++ b/crates/aristo-core/src/canon_verify/mock_client.rs
@@ -85,9 +85,7 @@ impl MockVerifyClient {
     ) -> Self {
         Self {
             post_response: Mutex::new(Some(Ok(post))),
-            get_responses: Mutex::new(
-                get_responses.into_iter().map(Ok).collect::<Vec<_>>(),
-            ),
+            get_responses: Mutex::new(get_responses.into_iter().map(Ok).collect::<Vec<_>>()),
             posted: Mutex::new(Vec::new()),
             fetched: Mutex::new(Vec::new()),
         }


### PR DESCRIPTION
## Summary

Stacked on #2. §14 Phase E1–E4 — wires the SDK side of canon-verify execution into `aristo verify`.

**E1 (commit 125c723)** — Entries resolved to `verify="full"` are partitioned by id namespace. Canon-bound (`aristos:` / `kanon:`) entries collect into a single POST to `/canon/verify/sessions` per invocation; the SDK prints session_id + view_url and exits 0 (detach default per §7c row 1). Non-canon-bound `verify=full` entries keep the existing deferred-design NotImplemented hint.

- Auth required up front: no `arta_*` token → actionable \`aristo auth login\` hint, exit 1.
- Push-first precheck via \`git branch -r --contains\` (WORKFLOW.md §4). Local-only HEADs are rejected before the POST.
- Missing canon-matches cache entries are silently skipped from dispatch (we don't know the \`version\` to send); SDK surfaces an \`aristo canon refresh\` hint if every canon-bound entry is in this state.

**E2 (commit 8913ef5) — \`--wait\`**: polls \`GET /canon/verify/sessions/:id?wait=30\` after POST, rendering the WORKFLOW.md §6 snapshot once the session reaches terminal. No client-side timeout (§7c row 13); \"still running… (Ns elapsed)\" heartbeat every 60s. Exit code per §7c row 7: 0 iff \`failed + build_failed + inconclusive == 0\`; \`no_coverage\` is informational.

**E3 (commit 8913ef5) — \`--view <session_id>\`**: re-attaches to an existing session without scanning the workspace, running the push-first precheck, or POSTing. Single GET (or polling loop with \`--wait\`). Works from any directory because it only needs auth + server URL.

**E4 (commit 8913ef5) — \`--tags <id1,id2,…>\`**: subsets the dispatched tag set to the listed canon-bound ids. Accepts source-form ids (\`aristos:foo\`, \`kanon:bar\`) and bare canon-id suffixes. Rejects \`arta_*\` (server-side opaque) ids with an actionable error.

## Design follow-up notes
- **`--watch` (local-edit sync via mutagen-agent)** — flagged in the error message as planned but not shipped; matches WORKFLOW.md §4 \"Push-first; mutagen later\".
- **`?wait=N` server-side long-poll** — SDK sends the hint for forward-compat. Server currently ignores; SDK falls back to client-side 3 s polling (configurable via `ARISTO_VERIFY_POLL_MS` for tests).

## Test plan

- [x] 11 unit tests in \`canon_dispatch.rs\` (partition_full, build_tags, strip_canon_prefix, extract_line, dispatch_session round-trip).
- [x] 12 CLI integration tests in \`tests/verify_canon_dispatch.rs\` exercising the full path end-to-end against real git repos + tempdir workspaces. Wire-shape assertions on captured POST bodies pin to WORKFLOW.md §4.
- [x] All 53 workspace test suites green; 289 unit tests in aristo-cli (up from 273 pre-§14).
- [x] Existing `verify_command.rs` regression tests (23) still pass; non-canon-bound \`verify=\"full\"\` keeps the deferred-design NotImplemented arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)