### PR TITLE
refactor(sdk): point verify wire path at /verify; scrub canon-verify prose (PR-3)

### DIFF
--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -256,7 +256,7 @@ pub(crate) fn run_canon_dispatch(
             // ARISTO_REPO env override as a CI escape hatch.
             std::env::var("ARISTO_REPO").map_err(|_| CliError::Other {
                 message: format!(
-                    "could not determine repo for canon-verify: {e}\n  \
+                    "could not determine repo for verify: {e}\n  \
                      Set ARISTO_REPO=<owner/repo> to override (CI use)."
                 ),
                 exit_code: 1,
@@ -316,7 +316,7 @@ pub(crate) fn run_canon_dispatch(
             // §7c row 7: any failed / build_failed / inconclusive → exit 1.
             return Err(CliError::Other {
                 message: format!(
-                    "canon-verify reported {} failed, {} build_failed, {} inconclusive",
+                    "verify reported {} failed, {} build_failed, {} inconclusive",
                     final_snapshot.summary.failed,
                     final_snapshot.summary.build_failed,
                     final_snapshot.summary.inconclusive
@@ -353,7 +353,7 @@ pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
     if wait && !snapshot.summary.is_success() {
         return Err(CliError::Other {
             message: format!(
-                "canon-verify reported {} failed, {} build_failed, {} inconclusive",
+                "verify reported {} failed, {} build_failed, {} inconclusive",
                 snapshot.summary.failed,
                 snapshot.summary.build_failed,
                 snapshot.summary.inconclusive
@@ -574,7 +574,7 @@ fn print_session_dispatched(req: &VerifySessionRequest, resp: &PostVerifySession
     };
     println!();
     println!(
-        "→ canon-verify session dispatched — verifying {} {annotation_word} against {}",
+        "→ verify session dispatched — verifying {} {annotation_word} against {}",
         resp.plan_size,
         short_sha(&req.commit_sha)
     );
@@ -594,7 +594,7 @@ fn short_sha(sha: &str) -> String {
 fn no_auth_to_cli_error(e: aristo_core::auth::AuthError) -> CliError {
     CliError::Other {
         message: format!(
-            "canon-verify requires authentication: {e}\n  \
+            "verify requires authentication: {e}\n  \
              Run `aristo auth login` to sign in.\n  \
              (Without a token, the SDK skips canon-bound `verify=\"full\"` \
              entries — they'd be rejected server-side anyway.)"
@@ -607,7 +607,7 @@ fn verify_error_to_cli(e: VerifyError) -> CliError {
     match e {
         VerifyError::Auth(inner) => CliError::Other {
             message: format!(
-                "canon-verify auth error: {inner}\n  \
+                "verify auth error: {inner}\n  \
                  Your token may be expired — re-run `aristo auth login`."
             ),
             exit_code: 1,
@@ -624,11 +624,11 @@ fn verify_error_to_cli(e: VerifyError) -> CliError {
             exit_code: 1,
         },
         VerifyError::BadRequest { status, message } => CliError::Other {
-            message: format!("canon-verify server rejected request (HTTP {status}): {message}"),
+            message: format!("verify server rejected request (HTTP {status}): {message}"),
             exit_code: 1,
         },
         other => CliError::Other {
-            message: format!("canon-verify failed: {other}"),
+            message: format!("verify failed: {other}"),
             exit_code: 1,
         },
     }

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -197,7 +197,7 @@ fn canon_bound_full_with_no_auth_surfaces_aristo_auth_login_hint() {
         .arg("verify")
         .assert()
         .failure()
-        .stderr(contains("canon-verify requires authentication"))
+        .stderr(contains("verify requires authentication"))
         .stderr(contains("aristo auth login"));
 }
 
@@ -221,7 +221,7 @@ fn canon_bound_full_with_auth_posts_session_and_prints_session_id() {
         .arg("verify")
         .assert()
         .success()
-        .stdout(contains("canon-verify session dispatched"))
+        .stdout(contains("verify session dispatched"))
         .stdout(contains("01HMTESTSESSION"))
         .stdout(contains(
             "https://dev.aretta.ai/dashboard/jobs/01HMTESTSESSION",

--- a/crates/aristo-core/src/canon_verify/client.rs
+++ b/crates/aristo-core/src/canon_verify/client.rs
@@ -80,17 +80,17 @@ pub enum VerifyError {
 impl fmt::Display for VerifyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            VerifyError::Auth(e) => write!(f, "canon-verify auth error: {e}"),
-            VerifyError::Network(msg) => write!(f, "canon-verify network error: {msg}"),
-            VerifyError::Timeout => write!(f, "canon-verify request timed out"),
+            VerifyError::Auth(e) => write!(f, "verify auth error: {e}"),
+            VerifyError::Network(msg) => write!(f, "verify network error: {msg}"),
+            VerifyError::Timeout => write!(f, "verify request timed out"),
             VerifyError::BadRequest { status, message } => {
-                write!(f, "canon-verify server returned HTTP {status}: {message}")
+                write!(f, "verify server returned HTTP {status}: {message}")
             }
             VerifyError::Server { status, message } => {
-                write!(f, "canon-verify server error (HTTP {status}): {message}")
+                write!(f, "verify server error (HTTP {status}): {message}")
             }
-            VerifyError::Decode(msg) => write!(f, "canon-verify response decode error: {msg}"),
-            VerifyError::Fixture(msg) => write!(f, "canon-verify fixture error: {msg}"),
+            VerifyError::Decode(msg) => write!(f, "verify response decode error: {msg}"),
+            VerifyError::Fixture(msg) => write!(f, "verify fixture error: {msg}"),
         }
     }
 }

--- a/crates/aristo-core/src/canon_verify/http_client.rs
+++ b/crates/aristo-core/src/canon_verify/http_client.rs
@@ -101,7 +101,7 @@ impl VerifyClient for HttpVerifyClient {
         &self,
         req: &VerifySessionRequest,
     ) -> Result<PostVerifySessionResponse, VerifyError> {
-        self.post_json("/canon/verify/sessions", req)
+        self.post_json("/verify/sessions", req)
     }
 
     fn get_session(
@@ -111,8 +111,8 @@ impl VerifyClient for HttpVerifyClient {
     ) -> Result<GetVerifySessionResponse, VerifyError> {
         let encoded = url_encode(session_id);
         let path = match wait_seconds {
-            Some(n) if n > 0 => format!("/canon/verify/sessions/{encoded}?wait={n}"),
-            _ => format!("/canon/verify/sessions/{encoded}"),
+            Some(n) if n > 0 => format!("/verify/sessions/{encoded}?wait={n}"),
+            _ => format!("/verify/sessions/{encoded}"),
         };
         self.get_json(&path)
     }


### PR DESCRIPTION
**DO NOT MERGE** until aretta-code PR-2 (dual-route) is deployed — the `/verify` path must exist server-side first.

Repoints the HTTP client at the generic `/verify/sessions` route (was `/canon/verify/sessions`) for both POST and GET session calls, and scrubs user-facing `canon-verify` prose down to `verify` in CLI dispatch output, error messages, and `VerifyError` Display, with matching test-assertion updates.

- `crates/aristo-core/src/canon_verify/http_client.rs` — POST/GET session paths now hit `/verify/sessions`.
- `crates/aristo-core/src/canon_verify/client.rs` — `VerifyError` Display strings de-canon'd.
- `crates/aristo-cli/src/commands/verify/canon_dispatch.rs` — dispatch banner + error hints de-canon'd.
- `crates/aristo-cli/tests/verify_canon_dispatch.rs` — assertions updated to match.

`cargo test -p aristo-cli --test verify_canon_dispatch` (12 passed) and `cargo build -p aristo-core` both green.