### PR TITLE
ci: Trusted Publishing release workflow (OIDC, no token)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+# Publish to crates.io on a version tag, via crates.io Trusted
+# Publishing (GitHub OIDC) — no long-lived token stored in the repo.
+#
+# ── One-time crates.io setup (per crate) ──────────────────────────────
+# For EACH of aristo, aristo-core, aristo-macros, aristo-cli:
+#   crates.io → the crate → Settings → Trusted Publishing → Add, with:
+#     Repository owner:  aretta-ai
+#     Repository name:   aristo
+#     Workflow filename: release.yml
+#     Environment:       release        (must match `environment:` below)
+# (A crate must have been published once already before you can add a
+#  trusted publisher for it — which all four have, from the 0.1.0 manual
+#  release.)
+#
+# ── Cutting a release ─────────────────────────────────────────────────
+#   1. Bump [workspace.package] version (cascades to all four crates).
+#   2. Promote CHANGELOG [Unreleased] → [vX.Y.Z] — DATE.
+#   3. Land on main (green CI), then:
+#        git tag -s vX.Y.Z -m "Aristo vX.Y.Z" && git push origin vX.Y.Z
+#   This workflow then publishes all four crates automatically.
+#
+# NOTE: every crate must be at the new (unpublished) version, or its
+# `cargo publish` step errors with "crate version already uploaded".
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  id-token: write          # required to mint the OIDC token
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Gate on a GitHub Environment named "release" — lets you add
+    # required reviewers / branch limits to releases later, and is the
+    # environment the crates.io trusted-publisher config is scoped to.
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # Exchange the GitHub OIDC token for a short-lived crates.io token.
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      # Publish in dependency order (macros → meta → core → cli).
+      # cargo blocks until each crate is live in the index before
+      # returning, so the next step resolves the freshly-published dep.
+      - run: cargo publish -p aristo-macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - run: cargo publish -p aristo
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - run: cargo publish -p aristo-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - run: cargo publish -p aristo-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+- ci: `release.yml` — automated crates.io publishing on `v*.*.*` tags via Trusted Publishing (GitHub OIDC, no stored token). Publishes all four crates in dependency order using a short-lived token minted from the workflow's OIDC identity; gated on a `release` GitHub Environment. Requires a one-time per-crate trusted-publisher config on crates.io (documented in the workflow header). For v0.1.1+; the 0.1.0 release is published manually.
+
 ## [v0.1.0] — 2026-05-29
 
 First public release. The MVP cuts the offline scope of Aristo's annotation SDK: declare verifiable intent above a function, hash it against the function body, classify the function's verification status, and surface drift before it ships. Phase 2 (server-side commands, paid `verify="full"`, free-tier `verify="test"`, `verify --audit-only`, `aristos:`-namespace renames) is deferred until the `aristo sync` infrastructure ships.


### PR DESCRIPTION
Automated crates.io publishing on `v*.*.*` tags via **Trusted Publishing** (GitHub OIDC) — no long-lived token stored in the repo. For ongoing **v0.1.1+** releases (0.1.0 is published manually).

**What it does:** on a version tag, mints a short-lived crates.io token from the workflow's OIDC identity (`rust-lang/crates-io-auth-action`) and publishes all four crates in dependency order (macros → meta → core → cli), gated on a `release` GitHub Environment.

**One-time setup you must do on crates.io** (per crate — aristo, aristo-core, aristo-macros, aristo-cli):
Settings → Trusted Publishing → Add: owner `aretta-ai`, repo `aristo`, workflow `release.yml`, environment `release`. (Each crate must already be published once — done in 0.1.0.)

Also create the `release` GitHub Environment (Settings → Environments) — optionally with required reviewers for release gating.

**Release flow after this:** bump version + promote CHANGELOG, land on main, then `git tag -s vX.Y.Z && git push origin vX.Y.Z` → workflow publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)