### PR TITLE
feat(verify): redact Lean from card + color + real reproduce (Phase 16 Slice 2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,8 @@ dependencies = [
 name = "aristo-cli"
 version = "0.1.0"
 dependencies = [
+ "anstream 0.6.21",
+ "anstyle",
  "aristo",
  "aristo-core",
  "assert_cmd",

--- a/crates/aristo-cli/Cargo.toml
+++ b/crates/aristo-cli/Cargo.toml
@@ -27,6 +27,11 @@ path = "src/main.rs"
 [dependencies]
 aristo = { workspace = true }
 aristo-core = { workspace = true }
+# Phase 16 verify-card styling. anstyle = the style vocabulary; anstream =
+# an stdout wrapper that auto-strips ANSI when not a TTY (piped / CI) and
+# honors NO_COLOR. Both already resolve in the tree via clap's color feature.
+anstyle = "1"
+anstream = "0.6"
 badge-maker = "0.3.1"
 clap = { version = "4.5", features = ["derive"] }
 dirs = "5.0"

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -25,6 +25,8 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use anstyle::{AnsiColor, Color, Style};
+
 use aristo_core::canon::CanonMatchesFile;
 use aristo_core::canon_verify::{
     AnnotationOutcomeStatus, DifferentialReport, Finding, GetVerifySessionResponse,
@@ -514,7 +516,9 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
             // violation card instead of the terse bullet. Fall back to
             // the bullet when no report is attached.
             match &t.report {
-                Some(report) => render_report_card(report),
+                Some(report) => {
+                    render_report_card(report, &format!("{}{}", ann.tier, ann.canon_id))
+                }
                 None => render_test_bullet(t),
             }
         }
@@ -536,87 +540,99 @@ fn render_test_bullet(t: &TestOutcome) {
     }
 }
 
+// ── Card styling. `anstream` auto-strips these when stdout isn't a TTY
+// (piped / CI / `NO_COLOR`), so the `-`/`+` markers still carry the
+// meaning with color removed.
+const C_HEAD: Style = Style::new()
+    .bold()
+    .fg_color(Some(Color::Ansi(AnsiColor::Red)));
+const C_BOLD: Style = Style::new().bold();
+const C_DIM: Style = Style::new().dimmed();
+const C_DEL: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
+const C_ADD: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+const C_TAG: Style = Style::new()
+    .bold()
+    .fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
+
 /// Phase 16 Track A — render a [`DifferentialReport`] as a structured
-/// violation card (Slice-1 shape). Hand-emitted plain ASCII; the CLI
-/// has no color/table/box crate and that's fine. Every value is driven
-/// off the report fields; nothing is hard-coded.
-fn render_report_card(report: &DifferentialReport) {
+/// violation card. User-framed (no model/verification internals); every
+/// value is driven off the report fields. `repro_id` is the tier-qualified
+/// annotation id used for the reproduce command.
+fn render_report_card(report: &DifferentialReport, repro_id: &str) {
     let Finding::StateEq {
         expected,
         actual,
         divergence,
     } = &report.finding;
 
-    println!();
+    anstream::println!();
     // Headline + plain-language statement.
-    println!("  ✗ PROPERTY VIOLATED   {}", report.property.canon_id);
-    println!("    {}", report.property.statement);
-    println!();
+    anstream::println!(
+        "  {C_HEAD}✗ PROPERTY VIOLATED{C_HEAD:#}   {C_BOLD}{}{C_BOLD:#}",
+        report.property.canon_id
+    );
+    anstream::println!("    {}", report.property.statement);
+    anstream::println!();
 
-    // spec / impl source anchors (each optional).
-    if report.property.spec_source.is_some() || report.property.impl_source.is_some() {
-        let spec = report
-            .property
-            .spec_source
-            .as_ref()
-            .map(|s| format!("spec  {}:{}", s.path, s.line))
-            .unwrap_or_default();
-        let imp = report.property.impl_source.as_ref().map(|s| {
-            let loc = format!("impl  {}:{}", s.path, s.line);
-            match &s.snippet {
-                Some(snip) => format!("{loc} ({snip})"),
-                None => loc,
-            }
-        });
-        match imp {
-            Some(imp) if !spec.is_empty() => println!("    {spec}            {imp}"),
-            Some(imp) => println!("    {imp}"),
-            None => println!("    {spec}"),
-        }
-        println!();
+    // The impl anchor — the user's own code. The spec anchor (the closed
+    // verification harness) is deliberately not surfaced.
+    if let Some(s) = &report.property.impl_source {
+        let loc = match &s.snippet {
+            Some(snip) => format!("impl  {}:{} ({snip})", s.path, s.line),
+            None => format!("impl  {}:{}", s.path, s.line),
+        };
+        anstream::println!("    {C_DIM}{loc}{C_DIM:#}");
+        anstream::println!();
     }
 
     // The mask: compared fields + how many were ignored.
     let compared = report.relation.compared.join(", ");
     let ignored = render_ignored(&report.relation.ignored);
-    println!("    Compared: [{compared}]   (ignored: {ignored})");
-    println!();
+    anstream::println!(
+        "    {C_BOLD}Compared:{C_BOLD:#} [{compared}]   {C_DIM}(ignored: {ignored}){C_DIM:#}"
+    );
+    anstream::println!();
 
     // Two-column snapshot labels, then the -/+ divergence rows.
-    println!("        {}      {}", expected.label, actual.label);
+    anstream::println!(
+        "        {C_DIM}{}      {}{C_DIM:#}",
+        expected.label,
+        actual.label
+    );
     for d in divergence {
-        println!("      - {} = {}", d.field, d.expected);
-        println!("      + {} = {}", d.field, d.actual);
+        anstream::println!("      {C_DEL}- {} = {}{C_DEL:#}", d.field, d.expected);
+        anstream::println!("      {C_ADD}+ {} = {}{C_ADD:#}", d.field, d.actual);
         if let Some(why) = &d.provenance {
-            println!("        why  {why}");
+            anstream::println!("        {C_DIM}why  {why}{C_DIM:#}");
         }
     }
-    println!();
+    anstream::println!();
 
     // Verdict frame.
-    if let Some(cr_id) = &report.verdict.cr_id {
-        match &report.verdict.expected_to_fail {
-            Some(etf) => {
-                println!(
-                    "    Verdict   {cr_id} · EXPECTED TO FAIL (the failure IS the conformance verdict)"
-                );
-                println!("    Unblocks  {}", etf.reason);
-            }
-            None => println!("    Verdict   {cr_id}"),
+    match (&report.verdict.cr_id, &report.verdict.expected_to_fail) {
+        (Some(cr_id), Some(etf)) => {
+            anstream::println!(
+                "    {C_BOLD}Verdict{C_BOLD:#}   {cr_id} · {C_TAG}EXPECTED TO FAIL{C_TAG:#} (the failure IS the conformance verdict)"
+            );
+            anstream::println!("    {C_BOLD}Clears when{C_BOLD:#}  {}", etf.reason);
         }
-    } else if let Some(etf) = &report.verdict.expected_to_fail {
-        println!("    Verdict   EXPECTED TO FAIL (the failure IS the conformance verdict)");
-        println!("    Unblocks  {}", etf.reason);
+        (Some(cr_id), None) => {
+            anstream::println!("    {C_BOLD}Verdict{C_BOLD:#}   {cr_id}")
+        }
+        (None, Some(etf)) => {
+            anstream::println!(
+                "    {C_BOLD}Verdict{C_BOLD:#}   {C_TAG}EXPECTED TO FAIL{C_TAG:#} (the failure IS the conformance verdict)"
+            );
+            anstream::println!("    {C_BOLD}Clears when{C_BOLD:#}  {}", etf.reason);
+        }
+        (None, None) => {}
     }
-    println!();
+    anstream::println!();
 
-    // Reproduce hint, derived from canon_id + seed.
-    println!("    Reproduce");
-    println!(
-        "      aristo verify --case {} --replay",
-        reproduce_case(report)
-    );
-    println!();
+    // Reproduce — a real command scoped to this annotation.
+    anstream::println!("    {C_BOLD}Reproduce{C_BOLD:#}");
+    anstream::println!("      {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
+    anstream::println!();
 }
 
 /// Render the ignored-mask suffix: first two names, then `+N` for the
@@ -631,17 +647,6 @@ fn render_ignored(ignored: &[String]) -> String {
         format!("{}, +{rest}", head.join(", "))
     } else {
         head.join(", ")
-    }
-}
-
-/// Derive the `--case` repro token. Prefer the scenario seed (the
-/// deterministic repro key); fall back to the canon id.
-fn reproduce_case(report: &DifferentialReport) -> &str {
-    let seed = report.scenario.seed.as_str();
-    if seed.is_empty() {
-        report.property.canon_id.as_str()
-    } else {
-        seed
     }
 }
 

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -454,11 +454,12 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
     let home = tempfile::tempdir().unwrap();
     write_aretta_token(home.path(), "https://example.test");
 
+    // Lean-redacted (Slice 2.1): no model labels, no `spec_source`, the
+    // provenance + reason are turso-framed.
     let report = r#"{
       "property": {
         "canon_id": "wal_initialized_reflects_sync_outcome",
         "statement": "The WAL initialized flag is set true only after a successful sync of the wal-header.",
-        "spec_source": { "path": "verification/db/flavors/turso/wal-conformance/tests/conformance/snapshot/cr_03_initialized.rs", "line": 46 },
         "impl_source": { "path": "core/storage/wal.rs", "line": 3989, "snippet": "prepare_wal_finish" }
       },
       "scenario": {
@@ -469,7 +470,7 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
         "cr_id": "CR-03",
         "expected_to_fail": {
           "tag": "CR-03",
-          "reason": "Unblocks when turso (a) rolls back the partial header write on sync failure, or (b) exposes a public wal_initialized_atomic() accessor that distinguishes \"flag was set\" from \"file exists\"."
+          "reason": "turso (a) rolls back the partial header write on sync failure, or (b) exposes a public wal_initialized_atomic() accessor that distinguishes \"flag was set\" from \"file exists\"."
         }
       },
       "relation": {
@@ -480,9 +481,9 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
       },
       "finding": {
         "kind": "state_eq",
-        "expected": { "label": "lean (reference)", "fields": [ { "field": "initialized", "value": "false" } ] },
-        "actual": { "label": "turso (under test)", "fields": [ { "field": "initialized", "value": "true" } ] },
-        "divergence": [ { "field": "initialized", "expected": "false", "actual": "true", "provenance": "lean reads s.shared.initialized; turso reads the *.db-wal >=32-byte file-existence proxy." } ]
+        "expected": { "label": "reference", "fields": [ { "field": "initialized", "value": "false" } ] },
+        "actual": { "label": "turso (observed)", "fields": [ { "field": "initialized", "value": "true" } ] },
+        "divergence": [ { "field": "initialized", "expected": "false", "actual": "true", "provenance": "turso reports `initialized` from the *.db-wal file-existence proxy; a non-durable header reads as present." } ]
       }
     }"#;
 
@@ -531,14 +532,20 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
         .stdout(contains(
             "The WAL initialized flag is set true only after a successful sync of the wal-header.",
         ))
-        // The diff rows with -/+ markers.
+        // Lean-redacted, user-framed snapshot labels.
+        .stdout(contains("reference"))
+        .stdout(contains("turso (observed)"))
+        // The diff rows with -/+ markers (ANSI auto-stripped off-TTY).
         .stdout(contains("- initialized = false"))
         .stdout(contains("+ initialized = true"))
-        // Verdict frame: CR id + the unblock reason substring.
+        // Verdict frame: CR id + the unblock reason substring + reworded label.
         .stdout(contains("CR-03"))
         .stdout(contains("wal_initialized_atomic"))
-        // Reproduce section.
-        .stdout(contains("Reproduce"));
+        .stdout(contains("Clears when"))
+        // Reproduce section is a real command scoped to this annotation.
+        .stdout(contains(
+            "aristo verify --filter id=aristos:wal_initialized_reflects_sync_outcome --rerun",
+        ));
 }
 
 #[test]

--- a/crates/aristo-core/tests/fixtures/cr03-pass.json
+++ b/crates/aristo-core/tests/fixtures/cr03-pass.json
@@ -2,10 +2,6 @@
   "property": {
     "canon_id": "wal_initialized_reflects_sync_outcome",
     "statement": "The WAL initialized flag is set true only after a successful sync of the wal-header.",
-    "spec_source": {
-      "path": "verification/db/flavors/turso/wal-conformance/tests/conformance/snapshot/cr_03_initialized.rs",
-      "line": 46
-    },
     "impl_source": {
       "path": "core/storage/wal.rs",
       "line": 3989,
@@ -38,13 +34,13 @@
   "finding": {
     "kind": "state_eq",
     "expected": {
-      "label": "lean (reference)",
+      "label": "reference",
       "fields": [
         { "field": "initialized", "value": "false" }
       ]
     },
     "actual": {
-      "label": "turso (under test)",
+      "label": "turso (observed)",
       "fields": [
         { "field": "initialized", "value": "false" }
       ]

--- a/crates/aristo-core/tests/fixtures/cr03.minimal.json
+++ b/crates/aristo-core/tests/fixtures/cr03.minimal.json
@@ -2,10 +2,6 @@
   "property": {
     "canon_id": "wal_initialized_reflects_sync_outcome",
     "statement": "The WAL initialized flag is set true only after a successful sync of the wal-header.",
-    "spec_source": {
-      "path": "verification/db/flavors/turso/wal-conformance/tests/conformance/snapshot/cr_03_initialized.rs",
-      "line": 46
-    },
     "impl_source": {
       "path": "core/storage/wal.rs",
       "line": 3989,
@@ -20,7 +16,7 @@
     "cr_id": "CR-03",
     "expected_to_fail": {
       "tag": "CR-03",
-      "reason": "Unblocks when turso (a) rolls back the partial header write on sync failure, or (b) exposes a public wal_initialized_atomic() accessor that distinguishes \"flag was set\" from \"file exists\"."
+      "reason": "turso (a) rolls back the partial header write on sync failure, or (b) exposes a public wal_initialized_atomic() accessor that distinguishes \"flag was set\" from \"file exists\"."
     }
   },
   "relation": {
@@ -42,7 +38,7 @@
   "finding": {
     "kind": "state_eq",
     "expected": {
-      "label": "lean (reference)",
+      "label": "reference",
       "fields": [
         { "field": "initialized", "value": "false" },
         { "field": "max_frame", "value": "0" },
@@ -57,7 +53,7 @@
       ]
     },
     "actual": {
-      "label": "turso (under test)",
+      "label": "turso (observed)",
       "fields": [
         { "field": "initialized", "value": "true" },
         { "field": "max_frame", "value": "0" },
@@ -76,7 +72,7 @@
         "field": "initialized",
         "expected": "false",
         "actual": "true",
-        "provenance": "lean reads s.shared.initialized; turso reads the *.db-wal >=32-byte file-existence proxy. The header pwrite landed before the failed sync, so the proxy sees a non-durable header as present — a durability/proxy collapse, not a raw value mismatch."
+        "provenance": "turso reports `initialized` from the *.db-wal file-existence proxy (a >=32-byte header on disk). The header write landed before the sync failed, so a non-durable header reads as present — turso cannot distinguish \"header bytes exist\" from \"header is durable\". The property requires a successful header sync before initialized is true."
       }
     ]
   }


### PR DESCRIPTION
Phase 16 Slice 2.1 — the verify card is user-facing, so it must speak turso + the property only.

- **Lean redaction** (data-driven, flows from the updated harness report): labels render `reference` / `turso (observed)`; the closed-source spec anchor is no longer surfaced (only the user's `impl` line); provenance/reason turso-framed.
- **Two warts:** Reproduce is now a real command (`aristo verify --filter id=<tier><canon_id> --rerun`, was bogus `--case <seed> --replay`); verdict label `Clears when` (kills `Unblocks Unblocks` doubling).
- **Color** via `anstyle`+`anstream` (already in-tree via clap): bold headline/labels, red `-`/green `+`, dim metadata. **anstream auto-strips ANSI off-TTY** (piped/CI/`NO_COLOR`); `-`/`+` carry meaning when color is removed.

Coordinated with aretta-books + aretta-code redaction PRs (same golden). CLI card test + core round-trip green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)