### PR TITLE
feat(verify): user-side known-failure waivers — `aristo verify --accept` (Phase 16 (c))

### DIFF
--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.1.0"
-generated_at = "2026-05-30T03:25:29.311321Z"
+generated_at = "2026-06-02T00:14:46.406828Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -1077,7 +1077,7 @@ status = "neural"
 text_hash = "sha256:52a7f47cb64e5ff1cbf3eb2bf9d3fbada34b756a1ed78158e8e54ea8e0d4e51a"
 body_hash = "sha256:47a6992664050a69cc2739f41caab782724deba6a78e93f1763149535cc150cb"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn resolve_verify_level (line 356)"
+site = "fn resolve_verify_level (line 373)"
 covered_region = "function"
 
 [verify_bool_true_resolves_through_project_default]
@@ -1088,7 +1088,7 @@ status = "neural"
 text_hash = "sha256:98cd0efced314712df6f2fc59cbd60d95bed2c03b6670f5e9086aeca59a2c684"
 body_hash = "sha256:47a6992664050a69cc2739f41caab782724deba6a78e93f1763149535cc150cb"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn resolve_verify_level (line 368)"
+site = "fn resolve_verify_level (line 385)"
 covered_region = "function"
 
 [verify_false_arm_is_intentional_skip]
@@ -1099,7 +1099,7 @@ status = "neural"
 text_hash = "sha256:abb61b58993697f0c741e36ed6ee821fe7a7539a6ecf6d316900e292f7198a93"
 body_hash = "sha256:e4def345cc196a3718bc5c5cbbe6a9f763632a5344e00562f09685eec5feed11"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run (line 131)"
+site = "fn run (line 147)"
 covered_region = "statement"
 
 [verify_migrates_legacy_pending_neural_toml_to_queue]
@@ -1121,7 +1121,7 @@ status = "neural"
 text_hash = "sha256:0da73449029c5ac290374f71589048e283bb0c913c998a23d1c344347f81978e"
 body_hash = "sha256:74a7875b3adf5c47c7af8c22f122f1298f0e82ba013e1528b398ef9fa5944145"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run_pop_next (line 208)"
+site = "fn run_pop_next (line 225)"
 covered_region = "function"
 
 [verify_queue_status_is_non_destructive_peek]
@@ -1132,7 +1132,7 @@ status = "unknown"
 text_hash = "sha256:c1d5e4f08bfc2116718b94c7334dfdffdcf7981731e2e20d067e5dc617cdc608"
 body_hash = "sha256:96de1a2fc087ab877a852c94a7abb823017bad3e2c12318f4ea51e808c24a791"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn run_queue_status (line 234)"
+site = "fn run_queue_status (line 251)"
 covered_region = "function"
 
 [verify_skip_consults_validator_not_just_status]
@@ -1143,7 +1143,7 @@ status = "unknown"
 text_hash = "sha256:ec349c62caa14bf353768509d1662e6ec68dc8d5d703d542e698ca3c5fb1089f"
 body_hash = "sha256:92a9f4dcd35a81ce63e0cd198bee192b970574abf1a2282d7fc7dd2b693f163c"
 file = "crates/aristo-cli/src/commands/verify/mod.rs"
-site = "fn skip_because_proof_still_holds (line 393)"
+site = "fn skip_because_proof_still_holds (line 410)"
 covered_region = "function"
 
 [walk_directory_is_deterministic]
@@ -1176,5 +1176,5 @@ status = "neural"
 text_hash = "sha256:7dea8fbc1b236a0e3295c3d981ab61891cd213a335288052488a6aae09f0ef61"
 body_hash = "sha256:77bd66ccd1707698327bed561db8685eba167255e2cce8bc338e15ba23f912e9"
 file = "crates/aristo-cli/src/workspace.rs"
-site = "impl Workspace::load_config (line 139)"
+site = "impl Workspace::load_config (line 147)"
 covered_region = "function"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
+ "textwrap",
  "time",
  "toml 0.8.23",
  "trycmd",
@@ -1256,6 +1257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snapbox"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1366,17 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -1589,6 +1607,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/aristo-cli/Cargo.toml
+++ b/crates/aristo-cli/Cargo.toml
@@ -40,6 +40,10 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit"] }
+# Phase 16 verify-card layout: word-wrap to a fixed width (no mid-word cuts,
+# clean continuation lines) + ANSI-aware display-width measurement for the
+# box frame. We do not hand-roll the wrapping.
+textwrap = "0.16"
 time = { version = "0.3", features = ["formatting"] }
 toml = "0.8"
 walkdir = "2.5"

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -580,6 +580,22 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &Exp
                 None => render_test_bullet(t),
             }
         }
+
+        // Un-waived property failure: point the user at the one-liner that
+        // acknowledges it as a known gap. Future runs then report a "known
+        // gap (accepted)" instead of a failure (with a strict ratchet so a
+        // stale waiver can't rot). Offered only for a property `Failed` —
+        // the only outcome a waiver can forgive.
+        if matches!(ann.status, AnnotationOutcomeStatus::Failed) && waiver_match.is_none() {
+            anstream::println!(
+                "    {C_BOLD}Known limitation?{C_BOLD:#} acknowledge it so future runs report a known gap, not a failure:"
+            );
+            anstream::println!(
+                "      {C_DIM}aristo verify --accept {}{} --because \"<why this is OK for now>\"{C_DIM:#}",
+                ann.tier, ann.canon_id
+            );
+            anstream::println!();
+        }
     }
 
     // Phase 16 (c): a waiver that matched no annotation this run is stale or
@@ -657,9 +673,6 @@ const C_BOLD: Style = Style::new().bold();
 const C_DIM: Style = Style::new().dimmed();
 const C_DEL: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
 const C_ADD: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
-const C_TAG: Style = Style::new()
-    .bold()
-    .fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
 
 /// Phase 16 Track A — render a [`DifferentialReport`] as a structured
 /// violation card. User-framed (no model/verification internals); every
@@ -712,27 +725,6 @@ fn render_report_card(report: &DifferentialReport, repro_id: &str) {
         if let Some(why) = &d.provenance {
             anstream::println!("        {C_DIM}why  {why}{C_DIM:#}");
         }
-    }
-    anstream::println!();
-
-    // Verdict frame.
-    match (&report.verdict.cr_id, &report.verdict.expected_to_fail) {
-        (Some(cr_id), Some(etf)) => {
-            anstream::println!(
-                "    {C_BOLD}Verdict{C_BOLD:#}   {cr_id} · {C_TAG}EXPECTED TO FAIL{C_TAG:#} (the failure IS the conformance verdict)"
-            );
-            anstream::println!("    {C_BOLD}Clears when{C_BOLD:#}  {}", etf.reason);
-        }
-        (Some(cr_id), None) => {
-            anstream::println!("    {C_BOLD}Verdict{C_BOLD:#}   {cr_id}")
-        }
-        (None, Some(etf)) => {
-            anstream::println!(
-                "    {C_BOLD}Verdict{C_BOLD:#}   {C_TAG}EXPECTED TO FAIL{C_TAG:#} (the failure IS the conformance verdict)"
-            );
-            anstream::println!("    {C_BOLD}Clears when{C_BOLD:#}  {}", etf.reason);
-        }
-        (None, None) => {}
     }
     anstream::println!();
 

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use anstyle::{AnsiColor, Color, Style};
+use anstyle::{Ansi256Color, AnsiColor, Color, Style};
 
 use aristo_core::canon::CanonMatchesFile;
 use aristo_core::canon_verify::{
@@ -551,7 +551,14 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &Exp
         // both cases the per-test card loop is skipped.
         if let Some((id, exp)) = &waiver_match {
             if waived_failing {
-                render_accepted_gap(exp);
+                // Show the SAME violation detail, reframed as an accepted
+                // known failure (orange headline) with the user's reason as a
+                // footer. Fall back to the bare frame if no report is attached.
+                let repro = format!("{}{}", ann.tier, ann.canon_id);
+                match first_failing_report(&ann.tests) {
+                    Some(report) => render_violation_card(report, &repro, CardKind::Accepted(exp)),
+                    None => render_accepted_gap(exp),
+                }
                 continue;
             }
             if ratchet_breach {
@@ -575,9 +582,11 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &Exp
             // violation card instead of the terse bullet. Fall back to
             // the bullet when no report is attached.
             match &t.report {
-                Some(report) => {
-                    render_report_card(report, &format!("{}{}", ann.tier, ann.canon_id))
-                }
+                Some(report) => render_violation_card(
+                    report,
+                    &format!("{}{}", ann.tier, ann.canon_id),
+                    CardKind::Violated,
+                ),
                 None => render_test_bullet(t),
             }
         }
@@ -637,19 +646,19 @@ fn render_test_bullet(t: &TestOutcome) {
     }
 }
 
-/// Phase 16 (c) — a user-accepted gap. Replaces the red violation card
-/// with the user's own reason: this property is known to fail and has
-/// been explicitly waived, so it is not a build failure.
+/// Phase 16 (c) — the bare accepted-gap frame, used only when the failing
+/// test carried no structured report (so there's no violation body to
+/// show). The rich path reuses [`render_violation_card`] with
+/// [`CardKind::Accepted`].
 fn render_accepted_gap(exp: &Expectation) {
     let mut card = Card::new();
     card.raw(
-        format!("{C_BOLD}known gap (accepted){C_BOLD:#}"),
-        "known gap (accepted)",
+        format!("{C_WARN}⚠ KNOWN PROPERTY FAILURE{C_WARN:#}"),
+        "⚠ KNOWN PROPERTY FAILURE",
     );
     card.blank();
-    card.wrap(&exp.reason, Style::new(), 0);
+    card.wrap_hang("accepted  ", &exp.reason, C_WARN);
     if let Some(tracking) = &exp.tracking {
-        card.blank();
         card.line(&format!("tracking  {tracking}"), C_DIM, 0);
     }
     anstream::println!();
@@ -690,12 +699,30 @@ const C_BOLD: Style = Style::new().bold();
 const C_DIM: Style = Style::new().dimmed();
 const C_DEL: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
 const C_ADD: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+/// Orange — a known, accepted failure: not a passing run, but not a red
+/// build break either. 256-color so it reads as orange (not yellow).
+const C_WARN: Style = Style::new()
+    .bold()
+    .fg_color(Some(Color::Ansi256(Ansi256Color(208))));
 
-/// Phase 16 Track A — render a [`DifferentialReport`] as a structured
-/// violation card. User-framed (no model/verification internals); every
-/// value is driven off the report fields. `repro_id` is the tier-qualified
-/// annotation id used for the reproduce command.
-fn render_report_card(report: &DifferentialReport, repro_id: &str) {
+/// How a property-failure card is framed.
+enum CardKind<'a> {
+    /// Un-waived: red `PROPERTY VIOLATED`; the caller prints the reproduce
+    /// command + accept hint below the card.
+    Violated,
+    /// A user-accepted gap: orange `KNOWN PROPERTY FAILURE`; the same
+    /// violation body, plus the user's reason + tracker as a footer.
+    Accepted(&'a Expectation),
+}
+
+/// Render a [`DifferentialReport`] as a structured card. User-framed (no
+/// model/verification internals); every value is driven off the report
+/// fields. The only difference between an un-waived failure and an
+/// accepted gap is the headline colour/label and the footer — the
+/// violation detail (statement, diff, provenance) is identical, because an
+/// accepted gap is still a real, visible failure the user chose to live
+/// with.
+fn render_violation_card(report: &DifferentialReport, repro_id: &str, kind: CardKind<'_>) {
     let Finding::StateEq {
         expected,
         actual,
@@ -703,14 +730,23 @@ fn render_report_card(report: &DifferentialReport, repro_id: &str) {
     } = &report.finding;
 
     let mut card = Card::new();
-    // Headline + plain-language statement (wrapped to the card width).
-    card.raw(
-        format!(
-            "{C_HEAD}✗ PROPERTY VIOLATED{C_HEAD:#}  {C_BOLD}{}{C_BOLD:#}",
-            report.property.canon_id
+    // Headline — red "violated" vs. orange "known failure".
+    match &kind {
+        CardKind::Violated => card.raw(
+            format!(
+                "{C_HEAD}✗ PROPERTY VIOLATED{C_HEAD:#}  {C_BOLD}{}{C_BOLD:#}",
+                report.property.canon_id
+            ),
+            &format!("✗ PROPERTY VIOLATED  {}", report.property.canon_id),
         ),
-        &format!("✗ PROPERTY VIOLATED  {}", report.property.canon_id),
-    );
+        CardKind::Accepted(_) => card.raw(
+            format!(
+                "{C_WARN}⚠ KNOWN PROPERTY FAILURE{C_WARN:#}  {C_BOLD}{}{C_BOLD:#}",
+                report.property.canon_id
+            ),
+            &format!("⚠ KNOWN PROPERTY FAILURE  {}", report.property.canon_id),
+        ),
+    }
     card.blank();
     card.wrap(&report.property.statement, Style::new(), 0);
 
@@ -750,15 +786,43 @@ fn render_report_card(report: &DifferentialReport, repro_id: &str) {
         }
     }
 
+    // Accepted footer: the user's acknowledgement, inside the card.
+    if let CardKind::Accepted(exp) = &kind {
+        card.blank();
+        card.wrap_hang("accepted  ", &exp.reason, C_WARN);
+        if let Some(tracking) = &exp.tracking {
+            card.line(&format!("tracking  {tracking}"), C_DIM, 0);
+        }
+    }
+
     anstream::println!();
     anstream::print!("{}", card.render());
 
-    // Reproduce — kept BELOW the card so the command stays on one
-    // copy-pasteable line.
+    // Reproduce — only for an un-waived failure (an accepted gap needs no
+    // action). Kept BELOW the card so the command stays one copy-pasteable
+    // line.
+    if matches!(kind, CardKind::Violated) {
+        anstream::println!();
+        anstream::println!("  {C_BOLD}Reproduce{C_BOLD:#}");
+        anstream::println!("    {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
+    }
     anstream::println!();
-    anstream::println!("  {C_BOLD}Reproduce{C_BOLD:#}");
-    anstream::println!("    {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
-    anstream::println!();
+}
+
+/// The report on the first failing test of an annotation, if any.
+fn first_failing_report(tests: &[TestOutcome]) -> Option<&DifferentialReport> {
+    tests.iter().find_map(|t| {
+        matches!(
+            t.status,
+            TestOutcomeStatus::Fail
+                | TestOutcomeStatus::BuildFailed
+                | TestOutcomeStatus::CloneFailed
+                | TestOutcomeStatus::Timeout
+                | TestOutcomeStatus::Error
+        )
+        .then_some(t.report.as_ref())
+        .flatten()
+    })
 }
 
 /// Render the ignored-mask suffix: first two names, then `+N` for the

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -33,8 +33,11 @@ use aristo_core::canon_verify::{
     HttpVerifyClient, PostVerifySessionResponse, SessionStatus, TestOutcome, TestOutcomeStatus,
     VerifyClient, VerifyError, VerifySessionRequest, VerifySessionTag,
 };
+use aristo_core::expectations::{Expectation, ExpectationsFile};
 use aristo_core::index::{AnnotationId, IndexEntry, IndexFile, IntentEntry};
 
+use super::waiver;
+use crate::workspace::Workspace;
 use crate::{CliError, CliResult};
 
 /// Long-poll server-side hold-time (§7c row 9). The server may ignore
@@ -200,6 +203,7 @@ pub(crate) fn dispatch_session<C: VerifyClient + ?Sized>(
 pub(crate) fn run_canon_dispatch(
     workspace_root: &Path,
     matches_path: &Path,
+    expectations_path: &Path,
     canon_entries: &[CanonDispatchEntry<'_>],
     tags_filter: Option<&[String]>,
     wait: bool,
@@ -312,23 +316,41 @@ pub(crate) fn run_canon_dispatch(
 
     // 7. Optional poll-to-completion (--wait).
     if wait {
-        let final_snapshot = poll_until_terminal(&*client, &resp.session_id)?;
-        render_final_snapshot(&final_snapshot);
-        if !final_snapshot.summary.is_success() {
-            // §7c row 7: any failed / build_failed / inconclusive → exit 1.
-            return Err(CliError::Other {
-                message: format!(
-                    "verify reported {} failed, {} build_failed, {} inconclusive",
-                    final_snapshot.summary.failed,
-                    final_snapshot.summary.build_failed,
-                    final_snapshot.summary.inconclusive
-                ),
+        // Phase 16 (c): the user's accepted gaps are a read-time join over
+        // the results — they decide which failures are "known" (green) and
+        // catch a waived property that has started passing (red ratchet).
+        let expectations =
+            ExpectationsFile::read(expectations_path).map_err(|e| CliError::Other {
+                message: format!("failed to read {}: {e}", expectations_path.display()),
                 exit_code: 1,
-            });
+            })?;
+        let final_snapshot = poll_until_terminal(&*client, &resp.session_id)?;
+        render_final_snapshot(&final_snapshot, &expectations);
+        let verdict = waiver::evaluate(&final_snapshot, &expectations);
+        if verdict.is_red() {
+            return Err(exit_error_for(&verdict));
         }
     }
 
     Ok(dispatched)
+}
+
+/// The `--wait` failure error, worded from the waiver-aware verdict.
+/// `failed` counts only un-waived (genuine) property failures; a tripped
+/// ratchet is surfaced explicitly so the message points at the fix.
+fn exit_error_for(verdict: &waiver::WaiverVerdict) -> CliError {
+    let ratchet = if verdict.ratchet_breaches > 0 {
+        format!(", {} accepted-gap-now-passes", verdict.ratchet_breaches)
+    } else {
+        String::new()
+    };
+    CliError::Other {
+        message: format!(
+            "verify reported {} failed, {} build_failed, {} inconclusive{ratchet}",
+            verdict.unwaived_failed, verdict.build_failed, verdict.inconclusive
+        ),
+        exit_code: 1,
+    }
 }
 
 /// Re-attach to an existing session (E3 — `aristo verify --view <id>`).
@@ -351,17 +373,20 @@ pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
             .get_session(session_id, None)
             .map_err(verify_error_to_cli)?
     };
-    render_final_snapshot(&snapshot);
-    if wait && !snapshot.summary.is_success() {
-        return Err(CliError::Other {
-            message: format!(
-                "verify reported {} failed, {} build_failed, {} inconclusive",
-                snapshot.summary.failed,
-                snapshot.summary.build_failed,
-                snapshot.summary.inconclusive
-            ),
-            exit_code: 1,
-        });
+    // Best-effort waiver join: `--view` doesn't require a workspace (it
+    // only needs an HTTP client), so if there's no `.aristo/` above cwd we
+    // simply apply no waivers. When run inside a repo, the accepted gaps
+    // shape the render + exit exactly as the dispatch path.
+    let expectations = Workspace::find(None)
+        .ok()
+        .map(|ws| ExpectationsFile::read(&ws.expectations_path()).unwrap_or_default())
+        .unwrap_or_default();
+    render_final_snapshot(&snapshot, &expectations);
+    if wait {
+        let verdict = waiver::evaluate(&snapshot, &expectations);
+        if verdict.is_red() {
+            return Err(exit_error_for(&verdict));
+        }
     }
     Ok(())
 }
@@ -461,7 +486,7 @@ fn build_tag_filter_set(
 
 // ─── Rendering (WORKFLOW.md §6 — CLI form) ──────────────────────────────────
 
-fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
+fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &ExpectationsFile) {
     println!();
     println!(
         "session {} — verifying {} against canon {}",
@@ -478,7 +503,23 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
     println!();
     println!("{:<55}  {:<14} TESTS", "ANNOTATION", "STATUS");
     for ann in &snapshot.annotations {
-        let icon = annotation_icon(ann.status);
+        // Phase 16 (c): is this annotation a user-accepted gap?
+        let waiver_match: Option<(AnnotationId, &Expectation)> =
+            waiver::waiver_key(&ann.tier, &ann.canon_id)
+                .and_then(|id| expectations.get(&id).map(|e| (id, e)));
+        let waived_failing =
+            matches!(ann.status, AnnotationOutcomeStatus::Failed) && waiver_match.is_some();
+        let ratchet_breach =
+            matches!(ann.status, AnnotationOutcomeStatus::Verified) && waiver_match.is_some();
+
+        let (icon, word) = if waived_failing {
+            ("[gap]", "accepted")
+        } else {
+            (
+                annotation_icon(ann.status),
+                annotation_status_word(ann.status),
+            )
+        };
         let passed = ann
             .tests
             .iter()
@@ -493,14 +534,23 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse) {
         } else {
             format!("{}/{} passed", passed, ann.tests.len())
         };
-        println!(
-            "{:<55}  {} {:<11}  {}",
-            header,
-            icon,
-            annotation_status_word(ann.status),
-            tests_summary
-        );
+        println!("{:<55}  {} {:<11}  {}", header, icon, word, tests_summary);
         println!("  {}", ann.source_path);
+
+        // A waived gap replaces the violation card with the accepted-gap
+        // frame; a waived property that now passes trips the ratchet. In
+        // both cases the per-test card loop is skipped.
+        if let Some((id, exp)) = &waiver_match {
+            if waived_failing {
+                render_accepted_gap(exp);
+                continue;
+            }
+            if ratchet_breach {
+                render_ratchet_breach(id);
+                continue;
+            }
+        }
+
         for t in &ann.tests {
             if !matches!(
                 t.status,
@@ -538,6 +588,33 @@ fn render_test_bullet(t: &TestOutcome) {
         Some(url) => println!("  • {bin} {word} — see {url}"),
         None => println!("  • {bin} {word}"),
     }
+}
+
+/// Phase 16 (c) — a user-accepted gap. Replaces the red violation card
+/// with the user's own reason: this property is known to fail and has
+/// been explicitly waived, so it is not a build failure.
+fn render_accepted_gap(exp: &Expectation) {
+    anstream::println!();
+    anstream::println!("    {C_BOLD}known gap (accepted){C_BOLD:#}  {}", exp.reason);
+    if let Some(tracking) = &exp.tracking {
+        anstream::println!("    {C_DIM}tracking{C_DIM:#}              {tracking}");
+    }
+    anstream::println!();
+}
+
+/// Phase 16 (c) — the strict ratchet. A waived property that now passes
+/// is a red signal: the gap is closed, so the waiver is stale and must be
+/// removed before it silently masks a future regression.
+fn render_ratchet_breach(id: &AnnotationId) {
+    anstream::println!();
+    anstream::println!(
+        "    {C_HEAD}✗ accepted gap now passes{C_HEAD:#} — this property now holds."
+    );
+    anstream::println!(
+        "    {C_BOLD}Remove{C_BOLD:#} the stale waiver for `{}` from .aristo/expectations.toml",
+        id.as_str()
+    );
+    anstream::println!();
 }
 
 // ── Card styling. `anstream` auto-strips these when stdout isn't a TTY

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -36,6 +36,7 @@ use aristo_core::canon_verify::{
 use aristo_core::expectations::{Expectation, ExpectationsFile};
 use aristo_core::index::{AnnotationId, IndexEntry, IndexFile, IntentEntry};
 
+use super::card::Card;
 use super::waiver;
 use crate::workspace::Workspace;
 use crate::{CliError, CliResult};
@@ -640,11 +641,19 @@ fn render_test_bullet(t: &TestOutcome) {
 /// with the user's own reason: this property is known to fail and has
 /// been explicitly waived, so it is not a build failure.
 fn render_accepted_gap(exp: &Expectation) {
-    anstream::println!();
-    anstream::println!("    {C_BOLD}known gap (accepted){C_BOLD:#}  {}", exp.reason);
+    let mut card = Card::new();
+    card.raw(
+        format!("{C_BOLD}known gap (accepted){C_BOLD:#}"),
+        "known gap (accepted)",
+    );
+    card.blank();
+    card.wrap(&exp.reason, Style::new(), 0);
     if let Some(tracking) = &exp.tracking {
-        anstream::println!("    {C_DIM}tracking{C_DIM:#}              {tracking}");
+        card.blank();
+        card.line(&format!("tracking  {tracking}"), C_DIM, 0);
     }
+    anstream::println!();
+    anstream::print!("{}", card.render());
     anstream::println!();
 }
 
@@ -652,14 +661,22 @@ fn render_accepted_gap(exp: &Expectation) {
 /// is a red signal: the gap is closed, so the waiver is stale and must be
 /// removed before it silently masks a future regression.
 fn render_ratchet_breach(id: &AnnotationId) {
+    let mut card = Card::new();
+    card.raw(
+        format!("{C_HEAD}✗ accepted gap now passes{C_HEAD:#}"),
+        "✗ accepted gap now passes",
+    );
+    card.blank();
+    card.wrap(
+        "This property now holds, so the waiver is stale — remove it from \
+         .aristo/expectations.toml:",
+        Style::new(),
+        0,
+    );
+    card.blank();
+    card.line(id.as_str(), C_DIM, 2);
     anstream::println!();
-    anstream::println!(
-        "    {C_HEAD}✗ accepted gap now passes{C_HEAD:#} — this property now holds."
-    );
-    anstream::println!(
-        "    {C_BOLD}Remove{C_BOLD:#} the stale waiver for `{}` from .aristo/expectations.toml",
-        id.as_str()
-    );
+    anstream::print!("{}", card.render());
     anstream::println!();
 }
 
@@ -685,14 +702,17 @@ fn render_report_card(report: &DifferentialReport, repro_id: &str) {
         divergence,
     } = &report.finding;
 
-    anstream::println!();
-    // Headline + plain-language statement.
-    anstream::println!(
-        "  {C_HEAD}✗ PROPERTY VIOLATED{C_HEAD:#}   {C_BOLD}{}{C_BOLD:#}",
-        report.property.canon_id
+    let mut card = Card::new();
+    // Headline + plain-language statement (wrapped to the card width).
+    card.raw(
+        format!(
+            "{C_HEAD}✗ PROPERTY VIOLATED{C_HEAD:#}  {C_BOLD}{}{C_BOLD:#}",
+            report.property.canon_id
+        ),
+        &format!("✗ PROPERTY VIOLATED  {}", report.property.canon_id),
     );
-    anstream::println!("    {}", report.property.statement);
-    anstream::println!();
+    card.blank();
+    card.wrap(&report.property.statement, Style::new(), 0);
 
     // The impl anchor — the user's own code. The spec anchor (the closed
     // verification harness) is deliberately not surfaced.
@@ -701,36 +721,43 @@ fn render_report_card(report: &DifferentialReport, repro_id: &str) {
             Some(snip) => format!("impl  {}:{} ({snip})", s.path, s.line),
             None => format!("impl  {}:{}", s.path, s.line),
         };
-        anstream::println!("    {C_DIM}{loc}{C_DIM:#}");
-        anstream::println!();
+        card.blank();
+        card.line(&loc, C_DIM, 0);
     }
+    card.blank();
 
     // The mask: compared fields + how many were ignored.
     let compared = report.relation.compared.join(", ");
     let ignored = render_ignored(&report.relation.ignored);
-    anstream::println!(
-        "    {C_BOLD}Compared:{C_BOLD:#} [{compared}]   {C_DIM}(ignored: {ignored}){C_DIM:#}"
+    card.raw(
+        format!("{C_BOLD}Compared:{C_BOLD:#} [{compared}]   {C_DIM}(ignored: {ignored}){C_DIM:#}"),
+        &format!("Compared: [{compared}]   (ignored: {ignored})"),
     );
-    anstream::println!();
+    card.blank();
 
-    // Two-column snapshot labels, then the -/+ divergence rows.
-    anstream::println!(
-        "        {C_DIM}{}      {}{C_DIM:#}",
-        expected.label,
-        actual.label
+    // Snapshot labels, then the -/+ divergence rows (provenance wrapped
+    // with a hanging `why` label).
+    card.line(
+        &format!("{}      {}", expected.label, actual.label),
+        C_DIM,
+        4,
     );
     for d in divergence {
-        anstream::println!("      {C_DEL}- {} = {}{C_DEL:#}", d.field, d.expected);
-        anstream::println!("      {C_ADD}+ {} = {}{C_ADD:#}", d.field, d.actual);
+        card.line(&format!("- {} = {}", d.field, d.expected), C_DEL, 2);
+        card.line(&format!("+ {} = {}", d.field, d.actual), C_ADD, 2);
         if let Some(why) = &d.provenance {
-            anstream::println!("        {C_DIM}why  {why}{C_DIM:#}");
+            card.wrap_hang("  why  ", why, C_DIM);
         }
     }
-    anstream::println!();
 
-    // Reproduce — a real command scoped to this annotation.
-    anstream::println!("    {C_BOLD}Reproduce{C_BOLD:#}");
-    anstream::println!("      {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
+    anstream::println!();
+    anstream::print!("{}", card.render());
+
+    // Reproduce — kept BELOW the card so the command stays on one
+    // copy-pasteable line.
+    anstream::println!();
+    anstream::println!("  {C_BOLD}Reproduce{C_BOLD:#}");
+    anstream::println!("    {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
     anstream::println!();
 }
 

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -373,14 +373,18 @@ pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
             .get_session(session_id, None)
             .map_err(verify_error_to_cli)?
     };
-    // Best-effort waiver join: `--view` doesn't require a workspace (it
-    // only needs an HTTP client), so if there's no `.aristo/` above cwd we
-    // simply apply no waivers. When run inside a repo, the accepted gaps
-    // shape the render + exit exactly as the dispatch path.
-    let expectations = Workspace::find(None)
-        .ok()
-        .map(|ws| ExpectationsFile::read(&ws.expectations_path()).unwrap_or_default())
-        .unwrap_or_default();
+    // `--view` doesn't require a workspace (it only needs an HTTP client),
+    // so with no `.aristo/` above cwd we apply no waivers. When a workspace
+    // IS present we read its expectations the same way the dispatch path
+    // does — a *malformed* file hard-errors (loud, not silently dropped);
+    // only a genuinely-absent file reads as empty.
+    let expectations = match Workspace::find(None) {
+        Ok(ws) => ExpectationsFile::read(&ws.expectations_path()).map_err(|e| CliError::Other {
+            message: format!("failed to read {}: {e}", ws.expectations_path().display()),
+            exit_code: 1,
+        })?,
+        Err(_) => ExpectationsFile::default(),
+    };
     render_final_snapshot(&snapshot, &expectations);
     if wait {
         let verdict = waiver::evaluate(&snapshot, &expectations);
@@ -507,8 +511,12 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &Exp
         let waiver_match: Option<(AnnotationId, &Expectation)> =
             waiver::waiver_key(&ann.tier, &ann.canon_id)
                 .and_then(|id| expectations.get(&id).map(|e| (id, e)));
-        let waived_failing =
-            matches!(ann.status, AnnotationOutcomeStatus::Failed) && waiver_match.is_some();
+        // A clean accepted gap is a waived property `Failed` with no
+        // operational test failure hiding in its test set — an operational
+        // break falls through to the normal card so it can't be masked.
+        let waived_failing = matches!(ann.status, AnnotationOutcomeStatus::Failed)
+            && waiver_match.is_some()
+            && !waiver::tests_operationally_broken(&ann.tests);
         let ratchet_breach =
             matches!(ann.status, AnnotationOutcomeStatus::Verified) && waiver_match.is_some();
 
@@ -573,6 +581,28 @@ fn render_final_snapshot(snapshot: &GetVerifySessionResponse, expectations: &Exp
             }
         }
     }
+
+    // Phase 16 (c): a waiver that matched no annotation this run is stale or
+    // drifted (renamed upstream, removed from source, or never applicable).
+    // Surface it on stderr so the silent-non-match can't rot unnoticed.
+    let matched: std::collections::BTreeSet<AnnotationId> = snapshot
+        .annotations
+        .iter()
+        .filter_map(|ann| {
+            let id = waiver::waiver_key(&ann.tier, &ann.canon_id)?;
+            expectations.is_waived(&id).then_some(id)
+        })
+        .collect();
+    for id in expectations.entries.keys() {
+        if !matched.contains(id) {
+            eprintln!(
+                "  note: waiver for `{}` in .aristo/expectations.toml matched no annotation this \
+                 run — renamed, removed, or stale. `aristo list` to check; remove if no longer needed.",
+                id.as_str()
+            );
+        }
+    }
+
     println!();
     // No `view_url` on GetVerifySessionResponse; the dashboard link is
     // derivable from session_id when needed but we surface only the

--- a/crates/aristo-cli/src/commands/verify/card.rs
+++ b/crates/aristo-cli/src/commands/verify/card.rs
@@ -1,0 +1,167 @@
+//! A bordered, width-bounded "card" for verify output.
+//!
+//! Word-wrapping is delegated to [`textwrap`] — no mid-word cuts, clean
+//! continuation lines that start at a column, never a fragment. The frame
+//! is a fixed-width box. Every line's width is measured on the **plain**
+//! (un-styled) text, never the ANSI-styled form, so the right edge stays
+//! aligned whether or not `anstream` strips the color downstream (TTY vs.
+//! piped / CI).
+//!
+//! Long *commands* are deliberately kept OUT of the card by callers and
+//! printed below it, so they stay on one copy-pasteable line.
+
+use anstyle::Style;
+use textwrap::core::display_width;
+use textwrap::{Options, WordSplitter};
+
+/// Base wrap options: never split a word at a hyphen — identifiers and
+/// paths (`wal-header`, `file-existence`, `.db-wal`) must survive whole.
+fn base_opts() -> Options<'static> {
+    Options::new(INNER).word_splitter(WordSplitter::NoHyphenation)
+}
+
+/// Total card width including borders. Content wraps to `WIDTH - 4`
+/// (`│ ` + content + ` │`). Chosen so the whole card fits in 88 columns.
+pub(crate) const WIDTH: usize = 88;
+const INNER: usize = WIDTH - 4;
+
+/// A card under construction. Push rows, then [`render`](Card::render).
+pub(crate) struct Card {
+    rows: Vec<Row>,
+}
+
+struct Row {
+    /// The styled (possibly ANSI-bearing) content.
+    styled: String,
+    /// Its visible width, measured on the plain text.
+    width: usize,
+}
+
+impl Card {
+    pub(crate) fn new() -> Self {
+        Self { rows: Vec::new() }
+    }
+
+    pub(crate) fn blank(&mut self) {
+        self.rows.push(Row {
+            styled: String::new(),
+            width: 0,
+        });
+    }
+
+    /// A single, uniformly-styled line indented `indent` spaces. Not
+    /// wrapped — for short structured rows (labels, diff rows, ids).
+    pub(crate) fn line(&mut self, text: &str, style: Style, indent: usize) {
+        let pad = " ".repeat(indent);
+        self.rows.push(Row {
+            styled: format!("{pad}{style}{text}{style:#}"),
+            width: indent + display_width(text),
+        });
+    }
+
+    /// A pre-styled line that mixes several styles; `plain` is its visible
+    /// form, used only to measure width.
+    pub(crate) fn raw(&mut self, styled: String, plain: &str) {
+        self.rows.push(Row {
+            styled,
+            width: display_width(plain),
+        });
+    }
+
+    /// A word-wrapped paragraph, uniformly styled, indented `indent` spaces.
+    pub(crate) fn wrap(&mut self, text: &str, style: Style, indent: usize) {
+        let ind = " ".repeat(indent);
+        let opts = base_opts().initial_indent(&ind).subsequent_indent(&ind);
+        self.push_wrapped(text, style, &opts);
+    }
+
+    /// A word-wrapped paragraph with a hanging `label`: the first line
+    /// starts with the label, continuations align under the text. Uniformly
+    /// styled (label included).
+    pub(crate) fn wrap_hang(&mut self, label: &str, text: &str, style: Style) {
+        let subs = " ".repeat(display_width(label));
+        let opts = base_opts().initial_indent(label).subsequent_indent(&subs);
+        self.push_wrapped(text, style, &opts);
+    }
+
+    fn push_wrapped(&mut self, text: &str, style: Style, opts: &textwrap::Options<'_>) {
+        for line in textwrap::wrap(text, opts) {
+            let width = display_width(&line);
+            self.rows.push(Row {
+                styled: format!("{style}{line}{style:#}"),
+                width,
+            });
+        }
+    }
+
+    /// Render the framed card (with a trailing newline). The border is plain
+    /// (no ANSI, so the box never needs ANSI-aware width math); content keeps
+    /// whatever styling the caller applied. A row wider than the inner width
+    /// is not padded — its right border shifts out rather than the text being
+    /// cut (callers keep long commands out of the card for this reason).
+    pub(crate) fn render(&self) -> String {
+        let rule = "─".repeat(INNER + 2);
+        let mut out = format!("┌{rule}┐\n");
+        for row in &self.rows {
+            let pad = " ".repeat(INNER.saturating_sub(row.width));
+            out.push_str(&format!("│ {}{pad} │\n", row.styled));
+        }
+        out.push_str(&format!("└{rule}┘\n"));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_rendered_line_fits_the_width_when_plain() {
+        // A long paragraph wraps; no plain line exceeds WIDTH, and words
+        // are never split mid-token.
+        let mut c = Card::new();
+        c.line("✗ PROPERTY VIOLATED  some_canon_id", Style::new(), 0);
+        c.blank();
+        c.wrap(
+            "The WAL initialized flag is set true only after a successful sync of the wal-header, \
+             which means a non-durable header that merely exists on disk must not read as present.",
+            Style::new(),
+            0,
+        );
+        c.wrap_hang(
+            "  why  ",
+            "turso reports initialized from the file-existence proxy, so a header write that \
+             landed before the sync failed still reads as present even though it is not durable.",
+            Style::new(),
+        );
+        let rendered = c.render();
+        // Every rendered line — rules and content alike — is exactly WIDTH
+        // columns, so the borders align in a monospace terminal.
+        for line in rendered.lines() {
+            assert_eq!(
+                display_width(line),
+                WIDTH,
+                "every card line must be exactly {WIDTH} cols; got {:?}",
+                line
+            );
+        }
+        // No word was split: "wal-header" and "file-existence" survive whole.
+        assert!(rendered.contains("wal-header"));
+        assert!(rendered.contains("file-existence"));
+    }
+
+    #[test]
+    fn borders_align_for_styled_and_plain_rows() {
+        // A styled row and a plain row of the same visible text pad to the
+        // same right-border column (width is measured on the plain text).
+        let bold = Style::new().bold();
+        let mut a = Card::new();
+        a.line("initialized = false", bold, 2);
+        let mut b = Card::new();
+        b.line("initialized = false", Style::new(), 2);
+        let a_line = a.render().lines().nth(1).unwrap().to_string();
+        let b_line = b.render().lines().nth(1).unwrap().to_string();
+        assert_eq!(display_width(&a_line), display_width(&b_line));
+        assert_eq!(display_width(&b_line), WIDTH);
+    }
+}

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -29,6 +29,7 @@ use crate::{CliError, CliResult};
 
 pub(crate) mod apply;
 pub(crate) mod canon_dispatch;
+pub(crate) mod card;
 pub(crate) mod pending;
 pub(crate) mod session_kind;
 pub(crate) mod submit;

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod pending;
 pub(crate) mod session_kind;
 pub(crate) mod submit;
 pub(crate) mod validator;
+pub(crate) mod waiver;
 
 #[allow(
     clippy::too_many_arguments,
@@ -53,6 +54,9 @@ pub(crate) fn run(
     wait: bool,
     view: Option<String>,
     tags: &[String],
+    accept: Option<String>,
+    because: Option<String>,
+    tracking: Option<String>,
 ) -> CliResult<()> {
     let _ = (check, strict); // wired for forward-compat; no behavior yet (see module doc)
 
@@ -75,6 +79,17 @@ pub(crate) fn run(
     let ws = workspace_or_error()?;
     emit_advisory_if_stale(&freshness_check(&ws));
     let index = read_index(&ws.index_path())?;
+
+    // Phase 16 (c): `--accept <canon-id> --because <reason>` records a
+    // user-side known-failure waiver in `.aristo/expectations.toml` and
+    // returns. Write-only — no dispatch, and no session guard: an
+    // accepted gap is an independent sidecar, not an index/proof
+    // mutation, so it shouldn't block on an open critique session.
+    if let Some(canon_id) = accept {
+        let reason =
+            because.expect("--because is required with --accept (enforced by clap `requires`)");
+        return waiver::run_accept(&ws, &index, &canon_id, &reason, tracking.as_deref());
+    }
 
     // Reads (pop_next, queue_status) bypass the session guard;
     // workers must keep functioning so an open critique-review
@@ -178,6 +193,7 @@ pub(crate) fn run(
     let dispatched = canon_dispatch::run_canon_dispatch(
         &ws.root,
         &ws.canon_matches_path(),
+        &ws.expectations_path(),
         &canon_full,
         tags_filter,
         wait,

--- a/crates/aristo-cli/src/commands/verify/waiver.rs
+++ b/crates/aristo-cli/src/commands/verify/waiver.rs
@@ -15,7 +15,10 @@
 //! e.g. `aristos:foo`) so it survives re-stamps — see
 //! [`aristo_core::expectations`].
 
-use aristo_core::canon_verify::{AnnotationOutcomeStatus, GetVerifySessionResponse};
+use aristo_core::canon_verify::{
+    AnnotationOutcomeStatus, GetVerifySessionResponse, SessionStatus, TestOutcome,
+    TestOutcomeStatus,
+};
 use aristo_core::expectations::ExpectationsFile;
 use aristo_core::index::{AnnotationId, IndexFile};
 
@@ -24,10 +27,31 @@ use crate::workspace::Workspace;
 use crate::{CliError, CliResult};
 
 /// The stable waiver key for a server-sent annotation: `{tier}{canon_id}`
-/// (e.g. `aristos:foo`). `None` if the pair doesn't parse as a valid id
-/// (defensive — server tiers are always `aristos:` / `kanon:`).
+/// (e.g. `aristos:foo`). Returns `None` for anything that isn't one of the
+/// two real canon tiers, so a malformed/colon-less server `tier` yields a
+/// true non-match instead of a *wrong* (Local-namespaced) key that would
+/// silently fail to match. `canon_id` is trimmed to mirror the write side.
 pub(crate) fn waiver_key(tier: &str, canon_id: &str) -> Option<AnnotationId> {
-    AnnotationId::parse(&format!("{tier}{canon_id}")).ok()
+    if tier != "aristos:" && tier != "kanon:" {
+        return None;
+    }
+    AnnotationId::parse(&format!("{tier}{}", canon_id.trim())).ok()
+}
+
+/// True iff any test row carries an *operational* failure (build / clone
+/// failure, timeout, error) as opposed to a property `fail`. Operational
+/// failures are never waivable — a property waiver must not mask a broken
+/// build hiding in the same annotation's test set.
+pub(crate) fn tests_operationally_broken(tests: &[TestOutcome]) -> bool {
+    tests.iter().any(|t| {
+        matches!(
+            t.status,
+            TestOutcomeStatus::BuildFailed
+                | TestOutcomeStatus::CloneFailed
+                | TestOutcomeStatus::Timeout
+                | TestOutcomeStatus::Error
+        )
+    })
 }
 
 /// `aristo verify --accept <canon-id> --because "<reason>"` — write-only.
@@ -40,6 +64,16 @@ pub(crate) fn run_accept(
     reason: &str,
     tracking: Option<&str>,
 ) -> CliResult<()> {
+    // A reasonless waiver is how baselines rot — reject an empty / blank
+    // reason even though clap already enforced the flag's *presence*.
+    if reason.trim().is_empty() {
+        return Err(CliError::Other {
+            message: "--because requires a non-empty reason. A reasonless waiver is how \
+                      baselines rot; explain why this gap is accepted."
+                .into(),
+            exit_code: 2,
+        });
+    }
     let id = resolve_canon_id(index, requested)?;
     let path = ws.expectations_path();
     let mut file = ExpectationsFile::read(&path).map_err(|e| CliError::Other {
@@ -109,9 +143,15 @@ fn resolve_canon_id(index: &IndexFile, requested: &str) -> CliResult<AnnotationI
 }
 
 /// The waiver-aware verdict over a terminal session snapshot. Drives the
-/// `--wait` exit code: red iff any genuine (un-waived) failure, any
-/// operational failure (build/inconclusive — never waivable), or any
-/// ratchet breach (a waived property that now passes).
+/// `--wait` exit code.
+///
+/// Crucially this reconciles against the **authoritative session summary**,
+/// not just the per-annotation fold: `unwaived_failed` is the summary's
+/// failure count minus the gaps the user *cleanly* waived, so a snapshot
+/// with an empty / partial `annotations` array but a non-zero
+/// `summary.failed` still goes red. A session that didn't reach `Done`, or
+/// any operational failure (build / inconclusive — never waivable), is red
+/// independently.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WaiverVerdict {
     pub unwaived_failed: u32,
@@ -119,6 +159,7 @@ pub(crate) struct WaiverVerdict {
     pub ratchet_breaches: u32,
     pub build_failed: u32,
     pub inconclusive: u32,
+    pub incomplete_session: bool,
 }
 
 impl WaiverVerdict {
@@ -127,47 +168,90 @@ impl WaiverVerdict {
             || self.build_failed > 0
             || self.inconclusive > 0
             || self.ratchet_breaches > 0
+            || self.incomplete_session
     }
 }
 
-/// Fold the user's accepted gaps over the session results. Only a
-/// property `Failed` is waivable; `BuildFailed` / `Inconclusive` are
-/// operational and always count. A waived `Verified` is a ratchet breach.
+/// Whether an annotation is a *cleanly* waived gap: the user waived it, it
+/// failed at the property level, and it carries no operational test
+/// failure. Only these are subtracted from the red exit.
+fn is_clean_accepted_gap(
+    ann: &aristo_core::canon_verify::AnnotationVerification,
+    expectations: &ExpectationsFile,
+) -> bool {
+    matches!(ann.status, AnnotationOutcomeStatus::Failed)
+        && !tests_operationally_broken(&ann.tests)
+        && waiver_key(&ann.tier, &ann.canon_id)
+            .map(|id| expectations.is_waived(&id))
+            .unwrap_or(false)
+}
+
+/// Fold the user's accepted gaps over the session results. Only a *cleanly*
+/// waived property `Failed` is forgiven; `BuildFailed` / `Inconclusive`
+/// (and an operational test hiding under a waived `Failed`) always count. A
+/// waived `Verified` is a ratchet breach.
 pub(crate) fn evaluate(
     snapshot: &GetVerifySessionResponse,
     expectations: &ExpectationsFile,
 ) -> WaiverVerdict {
-    let mut v = WaiverVerdict::default();
+    let mut accepted_gaps = 0u32;
+    let mut ratchet_breaches = 0u32;
     for ann in &snapshot.annotations {
+        if is_clean_accepted_gap(ann, expectations) {
+            accepted_gaps += 1;
+            continue;
+        }
         let waived = waiver_key(&ann.tier, &ann.canon_id)
             .map(|id| expectations.is_waived(&id))
             .unwrap_or(false);
-        match ann.status {
-            AnnotationOutcomeStatus::Failed => {
-                if waived {
-                    v.accepted_gaps += 1;
-                } else {
-                    v.unwaived_failed += 1;
-                }
-            }
-            AnnotationOutcomeStatus::Verified => {
-                if waived {
-                    v.ratchet_breaches += 1;
-                }
-            }
-            AnnotationOutcomeStatus::BuildFailed => v.build_failed += 1,
-            AnnotationOutcomeStatus::Inconclusive => v.inconclusive += 1,
-            AnnotationOutcomeStatus::NoCoverage => {}
+        if waived && matches!(ann.status, AnnotationOutcomeStatus::Verified) {
+            ratchet_breaches += 1;
         }
     }
-    v
+    let s = &snapshot.summary;
+    WaiverVerdict {
+        // The summary is authoritative for failures; only the gaps we
+        // cleanly waived are forgiven. A partial/empty annotations array
+        // can never hide a non-zero summary.failed.
+        unwaived_failed: s.failed.saturating_sub(accepted_gaps),
+        accepted_gaps,
+        ratchet_breaches,
+        build_failed: s.build_failed,
+        inconclusive: s.inconclusive,
+        incomplete_session: !matches!(snapshot.status, SessionStatus::Done),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn snapshot_with(ann_status: &str, canon_id: &str, tier: &str) -> GetVerifySessionResponse {
+    fn summary_for(ann_status: &str) -> &'static str {
+        match ann_status {
+            "verified" => {
+                r#"{ "total_annotations": 1, "verified": 1, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#
+            }
+            "failed" => {
+                r#"{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#
+            }
+            "build_failed" => {
+                r#"{ "total_annotations": 1, "verified": 0, "failed": 0, "build_failed": 1, "inconclusive": 0, "no_coverage": 0 }"#
+            }
+            _ => {
+                r#"{ "total_annotations": 1, "verified": 0, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#
+            }
+        }
+    }
+
+    /// One-annotation terminal (`done`) snapshot whose summary is kept
+    /// consistent with the annotation status (as the server guarantees).
+    fn snapshot_with(
+        ann_status: &str,
+        canon_id: &str,
+        tier: &str,
+        tests: &str,
+    ) -> GetVerifySessionResponse {
+        let summary = summary_for(ann_status);
         let json = format!(
             r#"{{
               "session_id": "s", "status": "done", "user_commit_sha": "x",
@@ -175,10 +259,9 @@ mod tests {
               "annotations": [{{
                 "annotation_id": "arta_x", "canon_id": "{canon_id}", "version": "v",
                 "scope": "turso", "tier": "{tier}", "source_path": "p",
-                "status": "{ann_status}", "tests": []
+                "status": "{ann_status}", "tests": {tests}
               }}],
-              "summary": {{ "total_annotations": 1, "verified": 0, "failed": 0,
-                "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }}
+              "summary": {summary}
             }}"#
         );
         serde_json::from_str(&json).unwrap()
@@ -197,7 +280,7 @@ mod tests {
 
     #[test]
     fn unwaived_failure_is_red() {
-        let snap = snapshot_with("failed", "foo", "aristos:");
+        let snap = snapshot_with("failed", "foo", "aristos:", "[]");
         let v = evaluate(&snap, &ExpectationsFile::default());
         assert_eq!(v.unwaived_failed, 1);
         assert_eq!(v.accepted_gaps, 0);
@@ -206,7 +289,7 @@ mod tests {
 
     #[test]
     fn waived_failure_is_an_accepted_gap_not_red() {
-        let snap = snapshot_with("failed", "foo", "aristos:");
+        let snap = snapshot_with("failed", "foo", "aristos:", "[]");
         let v = evaluate(&snap, &waived("aristos:foo"));
         assert_eq!(v.accepted_gaps, 1);
         assert_eq!(v.unwaived_failed, 0);
@@ -215,7 +298,7 @@ mod tests {
 
     #[test]
     fn waived_pass_trips_the_ratchet_and_is_red() {
-        let snap = snapshot_with("verified", "foo", "aristos:");
+        let snap = snapshot_with("verified", "foo", "aristos:", "[]");
         let v = evaluate(&snap, &waived("aristos:foo"));
         assert_eq!(v.ratchet_breaches, 1);
         assert!(v.is_red());
@@ -223,7 +306,7 @@ mod tests {
 
     #[test]
     fn unwaived_pass_is_green() {
-        let snap = snapshot_with("verified", "foo", "aristos:");
+        let snap = snapshot_with("verified", "foo", "aristos:", "[]");
         let v = evaluate(&snap, &ExpectationsFile::default());
         assert_eq!(v.ratchet_breaches, 0);
         assert!(!v.is_red());
@@ -232,10 +315,71 @@ mod tests {
     #[test]
     fn build_failure_is_red_even_when_waived() {
         // Operational failures are never waivable.
-        let snap = snapshot_with("build_failed", "foo", "aristos:");
+        let snap = snapshot_with("build_failed", "foo", "aristos:", "[]");
         let v = evaluate(&snap, &waived("aristos:foo"));
         assert_eq!(v.build_failed, 1);
         assert_eq!(v.accepted_gaps, 0);
         assert!(v.is_red());
+    }
+
+    #[test]
+    fn empty_annotations_with_summary_failure_is_still_red() {
+        // Regression guard: the exit verdict must trust the authoritative
+        // summary, not just the per-annotation fold. A terminal snapshot
+        // with no annotation detail but summary.failed > 0 is RED.
+        let json = r#"{
+          "session_id": "s", "status": "done", "user_commit_sha": "x",
+          "canon_version": "v", "started_at": "t", "annotations": [],
+          "summary": { "total_annotations": 1, "verified": 0, "failed": 1,
+            "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }
+        }"#;
+        let snap: GetVerifySessionResponse = serde_json::from_str(json).unwrap();
+        let v = evaluate(&snap, &ExpectationsFile::default());
+        assert_eq!(v.unwaived_failed, 1);
+        assert!(v.is_red());
+    }
+
+    #[test]
+    fn non_done_terminal_session_is_red() {
+        // A session that failed / timed out / was cancelled is red even
+        // when it carries no annotation detail and a zeroed summary.
+        for status in ["failed", "timed_out", "cancelled"] {
+            let json = format!(
+                r#"{{
+                  "session_id": "s", "status": "{status}", "user_commit_sha": "x",
+                  "canon_version": "v", "started_at": "t", "annotations": [],
+                  "summary": {{ "total_annotations": 0, "verified": 0, "failed": 0,
+                    "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }}
+                }}"#
+            );
+            let snap: GetVerifySessionResponse = serde_json::from_str(&json).unwrap();
+            let v = evaluate(&snap, &ExpectationsFile::default());
+            assert!(v.incomplete_session, "{status} must be incomplete");
+            assert!(v.is_red(), "{status} session must be red");
+        }
+    }
+
+    #[test]
+    fn waived_failed_with_operational_test_is_not_forgiven() {
+        // A property waiver must not mask an operational (build) failure
+        // hiding in the same annotation's test set.
+        let tests = r#"[{ "test_binary": "t1", "status": "fail" },
+                        { "test_binary": "t2", "status": "build_failed" }]"#;
+        let snap = snapshot_with("failed", "foo", "aristos:", tests);
+        let v = evaluate(&snap, &waived("aristos:foo"));
+        assert_eq!(v.accepted_gaps, 0, "operational break is not a clean gap");
+        assert_eq!(v.unwaived_failed, 1);
+        assert!(v.is_red());
+    }
+
+    #[test]
+    fn waiver_key_rejects_colonless_tier() {
+        // A malformed (colon-less) tier yields None, not a wrong Local key.
+        assert!(waiver_key("aristos", "foo").is_none());
+        assert_eq!(
+            waiver_key("aristos:", "foo").unwrap().as_str(),
+            "aristos:foo"
+        );
+        assert_eq!(waiver_key("kanon:", "bar").unwrap().as_str(), "kanon:bar");
     }
 }

--- a/crates/aristo-cli/src/commands/verify/waiver.rs
+++ b/crates/aristo-cli/src/commands/verify/waiver.rs
@@ -1,0 +1,241 @@
+//! Phase 16 (c) — user-side known-failure waivers.
+//!
+//! Two halves of one mechanism:
+//!
+//! 1. **Write** — `aristo verify --accept <canon-id> --because "<reason>"`
+//!    records an accepted gap in `.aristo/expectations.toml`
+//!    ([`run_accept`]). Validates the id against the live index so a
+//!    typo can't write a dead waiver.
+//! 2. **Join** — at verify time, [`evaluate`] folds the loaded
+//!    expectations over the terminal session snapshot to decide the
+//!    process exit code: a waived failure is an *accepted gap* (green); a
+//!    waived annotation that now *passes* trips the strict ratchet (red).
+//!
+//! The waiver keys on the stable prefixed canon id (`{tier}{canon_id}`,
+//! e.g. `aristos:foo`) so it survives re-stamps — see
+//! [`aristo_core::expectations`].
+
+use aristo_core::canon_verify::{AnnotationOutcomeStatus, GetVerifySessionResponse};
+use aristo_core::expectations::ExpectationsFile;
+use aristo_core::index::{AnnotationId, IndexFile};
+
+use crate::commands::index::now_rfc3339;
+use crate::workspace::Workspace;
+use crate::{CliError, CliResult};
+
+/// The stable waiver key for a server-sent annotation: `{tier}{canon_id}`
+/// (e.g. `aristos:foo`). `None` if the pair doesn't parse as a valid id
+/// (defensive — server tiers are always `aristos:` / `kanon:`).
+pub(crate) fn waiver_key(tier: &str, canon_id: &str) -> Option<AnnotationId> {
+    AnnotationId::parse(&format!("{tier}{canon_id}")).ok()
+}
+
+/// `aristo verify --accept <canon-id> --because "<reason>"` — write-only.
+/// Resolves the id against the index, then upserts the accepted gap into
+/// `.aristo/expectations.toml`. Does not dispatch a verification.
+pub(crate) fn run_accept(
+    ws: &Workspace,
+    index: &IndexFile,
+    requested: &str,
+    reason: &str,
+    tracking: Option<&str>,
+) -> CliResult<()> {
+    let id = resolve_canon_id(index, requested)?;
+    let path = ws.expectations_path();
+    let mut file = ExpectationsFile::read(&path).map_err(|e| CliError::Other {
+        message: format!("failed to read {}: {e}", path.display()),
+        exit_code: 1,
+    })?;
+    file.accept(
+        id.clone(),
+        reason.to_string(),
+        tracking.map(str::to_string),
+        now_rfc3339(),
+    );
+    file.write_atomic(&path).map_err(CliError::Io)?;
+
+    println!("accepted known gap: {}", id.as_str());
+    println!("  reason: {reason}");
+    if let Some(t) = tracking {
+        println!("  tracking: {t}");
+    }
+    println!();
+    println!(
+        "  Recorded in .aristo/expectations.toml — commit it. `aristo verify` will report this as a"
+    );
+    println!(
+        "  known gap (not a failure) until the property holds; when it does, verify goes red so you"
+    );
+    println!("  remember to remove the stale waiver.");
+    Ok(())
+}
+
+/// Resolve a user-supplied canon id to a canon-bound entry present in the
+/// index. Accepts a prefixed id (`aristos:foo`) or a bare suffix (`foo`,
+/// tried against both tiers). Rejects opaque `arta_*` refs and ids absent
+/// from the index.
+fn resolve_canon_id(index: &IndexFile, requested: &str) -> CliResult<AnnotationId> {
+    let raw = requested.trim();
+    if raw.starts_with("arta_") {
+        return Err(CliError::Other {
+            message: format!(
+                "--accept rejects opaque server ids (got `{raw}`). Pass the source-form canon id, \
+                 e.g. `aristos:foo` or just `foo`."
+            ),
+            exit_code: 2,
+        });
+    }
+    // A prefixed id is tried as-is; a bare suffix is tried against both
+    // canon tiers (a workspace never binds the same suffix to both).
+    let candidates: Vec<String> = if raw.contains(':') {
+        vec![raw.to_string()]
+    } else {
+        vec![format!("aristos:{raw}"), format!("kanon:{raw}")]
+    };
+    for cand in &candidates {
+        if let Ok(id) = AnnotationId::parse(cand) {
+            if id.is_canon_bound() && index.entries.contains_key(&id) {
+                return Ok(id);
+            }
+        }
+    }
+    Err(CliError::Other {
+        message: format!(
+            "`{raw}` is not a canon-bound (`aristos:` / `kanon:`) entry in this workspace's index. \
+             Only canon-bound properties can be waived — run `aristo list` to see eligible ids."
+        ),
+        exit_code: 1,
+    })
+}
+
+/// The waiver-aware verdict over a terminal session snapshot. Drives the
+/// `--wait` exit code: red iff any genuine (un-waived) failure, any
+/// operational failure (build/inconclusive — never waivable), or any
+/// ratchet breach (a waived property that now passes).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WaiverVerdict {
+    pub unwaived_failed: u32,
+    pub accepted_gaps: u32,
+    pub ratchet_breaches: u32,
+    pub build_failed: u32,
+    pub inconclusive: u32,
+}
+
+impl WaiverVerdict {
+    pub fn is_red(&self) -> bool {
+        self.unwaived_failed > 0
+            || self.build_failed > 0
+            || self.inconclusive > 0
+            || self.ratchet_breaches > 0
+    }
+}
+
+/// Fold the user's accepted gaps over the session results. Only a
+/// property `Failed` is waivable; `BuildFailed` / `Inconclusive` are
+/// operational and always count. A waived `Verified` is a ratchet breach.
+pub(crate) fn evaluate(
+    snapshot: &GetVerifySessionResponse,
+    expectations: &ExpectationsFile,
+) -> WaiverVerdict {
+    let mut v = WaiverVerdict::default();
+    for ann in &snapshot.annotations {
+        let waived = waiver_key(&ann.tier, &ann.canon_id)
+            .map(|id| expectations.is_waived(&id))
+            .unwrap_or(false);
+        match ann.status {
+            AnnotationOutcomeStatus::Failed => {
+                if waived {
+                    v.accepted_gaps += 1;
+                } else {
+                    v.unwaived_failed += 1;
+                }
+            }
+            AnnotationOutcomeStatus::Verified => {
+                if waived {
+                    v.ratchet_breaches += 1;
+                }
+            }
+            AnnotationOutcomeStatus::BuildFailed => v.build_failed += 1,
+            AnnotationOutcomeStatus::Inconclusive => v.inconclusive += 1,
+            AnnotationOutcomeStatus::NoCoverage => {}
+        }
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_with(ann_status: &str, canon_id: &str, tier: &str) -> GetVerifySessionResponse {
+        let json = format!(
+            r#"{{
+              "session_id": "s", "status": "done", "user_commit_sha": "x",
+              "canon_version": "v", "started_at": "t",
+              "annotations": [{{
+                "annotation_id": "arta_x", "canon_id": "{canon_id}", "version": "v",
+                "scope": "turso", "tier": "{tier}", "source_path": "p",
+                "status": "{ann_status}", "tests": []
+              }}],
+              "summary": {{ "total_annotations": 1, "verified": 0, "failed": 0,
+                "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }}
+            }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    fn waived(id: &str) -> ExpectationsFile {
+        let mut f = ExpectationsFile::default();
+        f.accept(
+            AnnotationId::parse(id).unwrap(),
+            "reason".into(),
+            None,
+            "t".into(),
+        );
+        f
+    }
+
+    #[test]
+    fn unwaived_failure_is_red() {
+        let snap = snapshot_with("failed", "foo", "aristos:");
+        let v = evaluate(&snap, &ExpectationsFile::default());
+        assert_eq!(v.unwaived_failed, 1);
+        assert_eq!(v.accepted_gaps, 0);
+        assert!(v.is_red());
+    }
+
+    #[test]
+    fn waived_failure_is_an_accepted_gap_not_red() {
+        let snap = snapshot_with("failed", "foo", "aristos:");
+        let v = evaluate(&snap, &waived("aristos:foo"));
+        assert_eq!(v.accepted_gaps, 1);
+        assert_eq!(v.unwaived_failed, 0);
+        assert!(!v.is_red());
+    }
+
+    #[test]
+    fn waived_pass_trips_the_ratchet_and_is_red() {
+        let snap = snapshot_with("verified", "foo", "aristos:");
+        let v = evaluate(&snap, &waived("aristos:foo"));
+        assert_eq!(v.ratchet_breaches, 1);
+        assert!(v.is_red());
+    }
+
+    #[test]
+    fn unwaived_pass_is_green() {
+        let snap = snapshot_with("verified", "foo", "aristos:");
+        let v = evaluate(&snap, &ExpectationsFile::default());
+        assert_eq!(v.ratchet_breaches, 0);
+        assert!(!v.is_red());
+    }
+
+    #[test]
+    fn build_failure_is_red_even_when_waived() {
+        // Operational failures are never waivable.
+        let snap = snapshot_with("build_failed", "foo", "aristos:");
+        let v = evaluate(&snap, &waived("aristos:foo"));
+        assert_eq!(v.build_failed, 1);
+        assert_eq!(v.accepted_gaps, 0);
+        assert!(v.is_red());
+    }
+}

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -282,8 +282,9 @@ enum Commands {
             value_name = "CANON_ID",
             requires = "because",
             conflicts_with_all = [
-                "view", "wait", "tags", "rerun", "apply_verdicts",
-                "submit_verdict", "pop_next", "queue_status"
+                "view", "wait", "tags", "rerun", "check", "strict", "filters",
+                "apply_verdicts", "rewrite_hashes", "submit_verdict", "id",
+                "json", "pop_next", "queue_status"
             ]
         )]
         accept: Option<String>,

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -269,6 +269,33 @@ enum Commands {
         /// — those are not user-facing.
         #[arg(long = "tags", value_name = "id1,id2,...", value_delimiter = ',')]
         tags: Vec<String>,
+        /// Phase 16 (c): record a user-side known-failure waiver for a
+        /// canon-bound property your code currently violates. Write-only
+        /// — does NOT dispatch a verification. Requires `--because`. The
+        /// gap lands in `.aristo/expectations.toml` (commit it); at
+        /// verify time it renders as a "known gap (accepted)" instead of
+        /// a failure, and the strict ratchet flips it back to red if the
+        /// property ever starts passing — so stale waivers can't rot.
+        /// Accepts a bare canon-id suffix (e.g. `foo`) as shorthand.
+        #[arg(
+            long = "accept",
+            value_name = "CANON_ID",
+            requires = "because",
+            conflicts_with_all = [
+                "view", "wait", "tags", "rerun", "apply_verdicts",
+                "submit_verdict", "pop_next", "queue_status"
+            ]
+        )]
+        accept: Option<String>,
+        /// Reason the gap is accepted (mandatory with `--accept`).
+        /// Recorded verbatim and shown on the verify card. A reasonless
+        /// waiver is how baselines rot, so it is required.
+        #[arg(long = "because", value_name = "REASON", requires = "accept")]
+        because: Option<String>,
+        /// Optional tracking reference (issue URL, ticket id) for the
+        /// accepted gap. Only meaningful with `--accept`.
+        #[arg(long = "tracking", value_name = "REF", requires = "accept")]
+        tracking: Option<String>,
     },
 
     /// Run the critique skill against annotation prose — opinionated
@@ -815,6 +842,9 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
             wait,
             view,
             tags,
+            accept,
+            because,
+            tracking,
         } => commands::verify::run(
             &filters,
             rerun,
@@ -830,6 +860,9 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
             wait,
             view,
             &tags,
+            accept,
+            because,
+            tracking,
         ),
         Commands::Critique {
             filters,

--- a/crates/aristo-cli/src/workspace.rs
+++ b/crates/aristo-cli/src/workspace.rs
@@ -81,6 +81,14 @@ impl Workspace {
         self.aristo_dir().join("canon-matches.toml")
     }
 
+    /// Path to `.aristo/expectations.toml` — the user-side known-failure
+    /// waiver sidecar (Phase 16 (c); committed by default). See
+    /// `aristo_core::expectations` for the schema. Written by
+    /// `aristo verify --accept`; read at verify time as a join.
+    pub fn expectations_path(&self) -> PathBuf {
+        self.aristo_dir().join("expectations.toml")
+    }
+
     /// Path to `.aristo/specs/`.
     pub fn specs_dir(&self) -> PathBuf {
         self.aristo_dir().join("specs")
@@ -221,6 +229,10 @@ mod tests {
         };
         assert_eq!(ws.aristo_dir(), PathBuf::from("/proj/.aristo"));
         assert_eq!(ws.index_path(), PathBuf::from("/proj/.aristo/index.toml"));
+        assert_eq!(
+            ws.expectations_path(),
+            PathBuf::from("/proj/.aristo/expectations.toml")
+        );
         assert_eq!(ws.specs_dir(), PathBuf::from("/proj/.aristo/specs"));
         assert_eq!(ws.doc_dir(), PathBuf::from("/proj/.aristo/doc"));
         assert_eq!(ws.config_path(), PathBuf::from("/proj/aristo.toml"));

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -23,6 +23,7 @@
 //! - Output prints session_id + view_url in detach default.
 
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -538,13 +539,18 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
         // The diff rows with -/+ markers (ANSI auto-stripped off-TTY).
         .stdout(contains("- initialized = false"))
         .stdout(contains("+ initialized = true"))
-        // Verdict frame: CR id + the unblock reason substring + reworded label.
-        .stdout(contains("CR-03"))
-        .stdout(contains("wal_initialized_atomic"))
-        .stdout(contains("Clears when"))
+        // The internal conformance verdict frame is NOT rendered — `CR-03`
+        // and `EXPECTED TO FAIL` are Aretta-side bookkeeping, confusing on a
+        // user surface.
+        .stdout(contains("CR-03").not())
+        .stdout(contains("EXPECTED TO FAIL").not())
         // Reproduce section is a real command scoped to this annotation.
         .stdout(contains(
             "aristo verify --filter id=aristos:wal_initialized_reflects_sync_outcome --rerun",
+        ))
+        // An un-waived property failure offers the one-liner to accept it.
+        .stdout(contains(
+            "aristo verify --accept aristos:wal_initialized_reflects_sync_outcome --because",
         ));
 }
 

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -528,11 +528,11 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
         .args(["verify", "--wait"])
         .assert()
         .failure()
-        // Headline: canon id + the plain-language statement.
+        // Headline: canon id + the plain-language statement. The statement
+        // is word-wrapped into the card, so assert a fragment that stays
+        // within one wrapped line rather than the whole sentence.
         .stdout(contains("wal_initialized_reflects_sync_outcome"))
-        .stdout(contains(
-            "The WAL initialized flag is set true only after a successful sync of the wal-header.",
-        ))
+        .stdout(contains("The WAL initialized flag is set true"))
         // Lean-redacted, user-framed snapshot labels.
         .stdout(contains("reference"))
         .stdout(contains("turso (observed)"))

--- a/crates/aristo-cli/tests/verify_expectations.rs
+++ b/crates/aristo-cli/tests/verify_expectations.rs
@@ -1,0 +1,496 @@
+//! `aristo verify` known-failure waiver — Phase 16 (c) — end-to-end
+//! integration tests.
+//!
+//! These tests are THE SPEC for the user-side "expected to fail"
+//! mechanism: a git-tracked `.aristo/expectations.toml` sidecar that
+//! records property gaps the user has explicitly accepted, keyed on the
+//! stable canon id. Authored via `aristo verify --accept <canon-id>
+//! --because "<reason>"`; applied as a read-time join when verify
+//! renders + computes its exit code.
+//!
+//! What we pin:
+//!
+//! - `--accept` writes `.aristo/expectations.toml` with the reason
+//!   (mandatory) + optional tracking ref, keyed on the prefixed canon id.
+//! - `--accept` requires `--because`, rejects unknown / opaque ids, and
+//!   accepts a bare canon-id suffix as shorthand. It's idempotent.
+//! - Read-time join (`--wait`): a WAIVED + still-FAILING annotation
+//!   renders "known gap (accepted)" and the run exits 0 (the failure is
+//!   excluded from the red exit). The internal `EXPECTED TO FAIL` frame
+//!   is not shown.
+//! - Strict ratchet: a WAIVED annotation that now PASSES makes verify go
+//!   RED ("accepted gap now passes — remove the waiver") and exit
+//!   non-zero. This is what keeps waivers from rotting.
+//! - An UN-waived failure is unchanged (still red, exit 1) — the waiver
+//!   layer never leaks into un-waived annotations.
+
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::contains;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ZERO_HASH: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd.env_remove("ARETTA_TOKEN");
+    cmd
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Lean workspace (no git, no `aristo init`): just `aristo.toml` + a
+/// `.aristo/index.toml` carrying one canon-bound (`aristos:foo`) entry.
+/// Enough to drive the write-only `--accept` flow, which only needs the
+/// index to validate the canon id.
+fn lean_workspace_with_canon_entry(dir: &Path) {
+    fs::write(dir.join("aristo.toml"), "").unwrap();
+    fs::create_dir_all(dir.join(".aristo")).unwrap();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    let body = format!(
+        "[__meta__]\nschema_version = 1\n\n\
+         [\"aristos:foo\"]\nkind = \"intent\"\ntext = \"the property\"\n\
+         verify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/foo.rs\"\nsite = \"fn foo (line 42)\"\n\
+         covered_region = \"function\"\n\
+         linked = \"arta_op4q3z9NbV\"\n",
+    );
+    fs::write(dir.join(".aristo/index.toml"), body).unwrap();
+}
+
+/// Full workspace for the dispatch+wait path: git repo pushed to a bare
+/// origin, `.aristo/index.toml` + `.aristo/canon-matches.toml` for one
+/// canon-bound entry. Mirrors `verify_canon_dispatch.rs`.
+fn init_repo_with_pushed_head(dir: &Path) -> tempfile::TempDir {
+    let bare = tempfile::tempdir().unwrap();
+    run_git(bare.path(), &["init", "--bare", "-q"]);
+    run_git(dir, &["init", "-q", "-b", "main"]);
+    run_git(dir, &["config", "user.email", "t@x"]);
+    run_git(dir, &["config", "user.name", "t"]);
+    run_git(dir, &["config", "commit.gpgsign", "false"]);
+    run_git(
+        dir,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    run_git(
+        dir,
+        &["remote", "set-url", "origin", bare.path().to_str().unwrap()],
+    );
+    fs::write(dir.join("README"), b"seed").unwrap();
+    run_git(dir, &["add", "-A"]);
+    run_git(dir, &["commit", "-q", "--no-verify", "-m", "init"]);
+    run_git(dir, &["push", "-q", "origin", "main"]);
+    run_git(
+        dir,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ],
+    );
+    bare
+}
+
+fn workspace_with_one_canon_bound_full_intent(dir: &Path) {
+    aristo_in(dir).arg("init").assert().success();
+    let body = format!(
+        "[__meta__]\nschema_version = 1\n\n\
+         [\"aristos:foo\"]\nkind = \"intent\"\ntext = \"the property\"\n\
+         verify = \"full\"\nstatus = \"unknown\"\n\
+         text_hash = \"{ZERO_HASH}\"\nbody_hash = \"{ZERO_HASH}\"\n\
+         file = \"src/foo.rs\"\nsite = \"fn foo (line 42)\"\n\
+         covered_region = \"function\"\n\
+         linked = \"arta_op4q3z9NbV\"\n",
+    );
+    fs::write(dir.join(".aristo/index.toml"), body).unwrap();
+
+    let matches = r#"
+[__meta__]
+schema_version = 1
+
+["aristos:foo"]
+last_match_text_hash = "blake3:test"
+canon_fetched_at = "2026-05-24T00:00:00Z"
+
+[["aristos:foo".accepted_matches]]
+canon_id = "foo"
+version = "v0.1.0"
+canonical_text = "the property"
+canon_version = "v0.2.0"
+confidence = 0.95
+prefix_tier = "aristos:"
+backed_by = "test backing"
+accepted_at = "2026-05-24T00:00:00Z"
+bound_at = "2026-05-24T00:00:00Z"
+"#;
+    fs::write(dir.join(".aristo/canon-matches.toml"), matches).unwrap();
+}
+
+fn write_aretta_token(home: &Path, server_url: &str) {
+    let creds_dir = home.join(".config/aristo");
+    fs::create_dir_all(&creds_dir).unwrap();
+    let body = format!(
+        r#"
+[aretta]
+token = "arta_test_token_xxx"
+server = "{server_url}"
+user_login = "tester"
+user_id = 1
+repo = "owner/repo"
+issued_at = "2026-05-24T00:00:00Z"
+"#
+    );
+    fs::write(creds_dir.join("credentials"), body).unwrap();
+}
+
+fn write_full_fixture(dir: &Path, body: &str) -> PathBuf {
+    let path = dir.join("verify-fixture.json");
+    fs::write(&path, body).unwrap();
+    path
+}
+
+/// One-annotation terminal GET fixture: `aristos:foo` with the given
+/// annotation status + single test status. No DifferentialReport — the
+/// waiver join keys on the annotation status, not the report body.
+fn one_annotation_fixture(
+    session: &str,
+    ann_status: &str,
+    test_status: &str,
+    summary: &str,
+) -> String {
+    format!(
+        r#"{{
+      "post": {{ "session_id": "{session}", "view_url": "https://x", "plan_size": 1 }},
+      "gets": [
+        {{
+          "session_id": "{session}",
+          "status": "done",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "completed_at": "2026-05-24T00:01:00Z",
+          "annotations": [
+            {{
+              "annotation_id": "arta_op4q3z9NbV",
+              "canon_id": "foo",
+              "version": "v0.1.0",
+              "scope": "turso",
+              "tier": "aristos:",
+              "source_path": "src/foo.rs:42",
+              "status": "{ann_status}",
+              "tests": [{{ "test_binary": "foo_conform", "status": "{test_status}", "duration_ms": 12 }}]
+            }}
+          ],
+          "summary": {summary}
+        }}
+      ]
+    }}"#
+    )
+}
+
+fn expectations_toml(dir: &Path) -> String {
+    fs::read_to_string(dir.join(".aristo/expectations.toml"))
+        .unwrap_or_else(|e| panic!("expected .aristo/expectations.toml to exist: {e}"))
+}
+
+// ─── --accept write flow ────────────────────────────────────────────────────
+
+#[test]
+fn accept_writes_expectations_file_keyed_on_prefixed_canon_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "turso reports initialized from a file-existence proxy",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("aristos:foo"));
+
+    let toml = expectations_toml(tmp.path());
+    assert!(
+        toml.contains("[\"aristos:foo\"]"),
+        "keyed on prefixed id; got:\n{toml}"
+    );
+    assert!(
+        toml.contains("turso reports initialized from a file-existence proxy"),
+        "reason recorded verbatim; got:\n{toml}"
+    );
+    // The schema-version meta header, mirroring the other sidecars.
+    assert!(
+        toml.contains("schema_version"),
+        "meta header present; got:\n{toml}"
+    );
+}
+
+#[test]
+fn accept_records_optional_tracking_ref() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "tracked upstream",
+            "--tracking",
+            "https://github.com/tursodatabase/turso/issues/1234",
+        ])
+        .assert()
+        .success();
+
+    let toml = expectations_toml(tmp.path());
+    assert!(
+        toml.contains("https://github.com/tursodatabase/turso/issues/1234"),
+        "tracking ref recorded; got:\n{toml}"
+    );
+}
+
+#[test]
+fn accept_requires_a_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    // No --because: clap usage error (exit 2). A reasonless waiver is
+    // how baselines rot, so the reason is mandatory at the arg layer.
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "aristos:foo"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(contains("because"));
+
+    assert!(
+        !tmp.path().join(".aristo/expectations.toml").exists(),
+        "a rejected --accept must not write the expectations file"
+    );
+}
+
+#[test]
+fn accept_bare_canon_suffix_resolves_to_prefixed_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    // Bare `foo` is shorthand for the canon-bound `aristos:foo`.
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "foo", "--because", "shorthand works"])
+        .assert()
+        .success();
+
+    let toml = expectations_toml(tmp.path());
+    assert!(
+        toml.contains("[\"aristos:foo\"]"),
+        "bare suffix resolves to the prefixed id; got:\n{toml}"
+    );
+}
+
+#[test]
+fn accept_rejects_unknown_canon_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:nonexistent",
+            "--because",
+            "x",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("nonexistent"));
+
+    assert!(
+        !tmp.path().join(".aristo/expectations.toml").exists(),
+        "unknown id must not write the expectations file"
+    );
+}
+
+#[test]
+fn accept_rejects_opaque_server_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    // `arta_*` is the server-side opaque ref; users never waive by it.
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "arta_op4q3z9NbV", "--because", "x"])
+        .assert()
+        .failure()
+        .stderr(contains("arta_"));
+}
+
+#[test]
+fn accept_is_idempotent_and_updates_the_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "foo", "--because", "first reason"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "foo", "--because", "second reason"])
+        .assert()
+        .success();
+
+    let toml = expectations_toml(tmp.path());
+    assert!(
+        toml.contains("second reason"),
+        "reason updated; got:\n{toml}"
+    );
+    assert!(
+        !toml.contains("first reason"),
+        "old reason replaced; got:\n{toml}"
+    );
+    assert_eq!(
+        toml.matches("[\"aristos:foo\"]").count(),
+        1,
+        "exactly one entry after re-accept; got:\n{toml}"
+    );
+}
+
+// ─── read-time join (--wait) ────────────────────────────────────────────────
+
+#[test]
+fn waived_failing_annotation_renders_accepted_gap_and_exits_zero() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    // Accept the gap first.
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "turso uses a file-existence proxy; tracked upstream",
+        ])
+        .assert()
+        .success();
+
+    let fixture = one_annotation_fixture(
+        "01HMGAP",
+        "failed",
+        "fail",
+        r#"{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#,
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        // The waiver suppresses the red exit: a known, accepted gap is
+        // not a build failure.
+        .assert()
+        .success()
+        .stdout(contains("known gap (accepted)"))
+        .stdout(contains(
+            "turso uses a file-existence proxy; tracked upstream",
+        ))
+        // The internal conformance frame is never shown for a waived gap.
+        .stdout(contains("EXPECTED TO FAIL").not());
+}
+
+#[test]
+fn waived_annotation_that_now_passes_trips_the_strict_ratchet() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "stale gap",
+        ])
+        .assert()
+        .success();
+
+    // The property now HOLDS (verified / pass) but the waiver is still
+    // on disk → the ratchet fires.
+    let fixture = one_annotation_fixture(
+        "01HMRATCHET",
+        "verified",
+        "pass",
+        r#"{ "total_annotations": 1, "verified": 1, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#,
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        .stdout(contains("accepted gap now passes"))
+        .stdout(contains("expectations.toml"))
+        .stdout(contains("aristos:foo"));
+}
+
+#[test]
+fn unwaived_failure_is_unchanged_and_still_red() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    // No --accept: the expectations file does not exist.
+    let fixture = one_annotation_fixture(
+        "01HMRED",
+        "failed",
+        "fail",
+        r#"{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#,
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        .stdout(contains("known gap (accepted)").not());
+}

--- a/crates/aristo-cli/tests/verify_expectations.rs
+++ b/crates/aristo-cli/tests/verify_expectations.rs
@@ -421,8 +421,10 @@ fn waived_failing_annotation_renders_accepted_gap_and_exits_zero() {
         .stdout(contains(
             "turso uses a file-existence proxy; tracked upstream",
         ))
-        // The internal conformance frame is never shown for a waived gap.
-        .stdout(contains("EXPECTED TO FAIL").not());
+        // The internal conformance frame is never shown for a waived gap, and
+        // an already-accepted gap doesn't re-offer the accept hint.
+        .stdout(contains("EXPECTED TO FAIL").not())
+        .stdout(contains("Known limitation").not());
 }
 
 #[test]
@@ -492,7 +494,9 @@ fn unwaived_failure_is_unchanged_and_still_red() {
         .args(["verify", "--wait"])
         .assert()
         .failure()
-        .stdout(contains("known gap (accepted)").not());
+        .stdout(contains("known gap (accepted)").not())
+        // A failing, un-waived property points the user at how to accept it.
+        .stdout(contains("aristo verify --accept aristos:foo --because"));
 }
 
 // ─── hardening (from the adversarial review) ─────────────────────────────────

--- a/crates/aristo-cli/tests/verify_expectations.rs
+++ b/crates/aristo-cli/tests/verify_expectations.rs
@@ -15,7 +15,7 @@
 //! - `--accept` requires `--because`, rejects unknown / opaque ids, and
 //!   accepts a bare canon-id suffix as shorthand. It's idempotent.
 //! - Read-time join (`--wait`): a WAIVED + still-FAILING annotation
-//!   renders "known gap (accepted)" and the run exits 0 (the failure is
+//!   renders "KNOWN PROPERTY FAILURE" and the run exits 0 (the failure is
 //!   excluded from the red exit). The internal `EXPECTED TO FAIL` frame
 //!   is not shown.
 //! - Strict ratchet: a WAIVED annotation that now PASSES makes verify go
@@ -417,7 +417,7 @@ fn waived_failing_annotation_renders_accepted_gap_and_exits_zero() {
         // not a build failure.
         .assert()
         .success()
-        .stdout(contains("known gap (accepted)"))
+        .stdout(contains("KNOWN PROPERTY FAILURE"))
         .stdout(contains(
             "turso uses a file-existence proxy; tracked upstream",
         ))
@@ -425,6 +425,83 @@ fn waived_failing_annotation_renders_accepted_gap_and_exits_zero() {
         // an already-accepted gap doesn't re-offer the accept hint.
         .stdout(contains("EXPECTED TO FAIL").not())
         .stdout(contains("Known limitation").not());
+}
+
+#[test]
+fn waived_failure_with_a_report_renders_the_full_known_failure_card() {
+    // An accepted gap keeps ALL the violation detail (statement + diff +
+    // provenance) — just reframed as an orange KNOWN PROPERTY FAILURE with
+    // the user's reason as a footer, not the red PROPERTY VIOLATED.
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "turso file-existence proxy is the root cause",
+        ])
+        .assert()
+        .success();
+
+    let report = r#"{
+      "property": {
+        "canon_id": "foo",
+        "statement": "The initialized flag is set true only after a successful header sync.",
+        "impl_source": { "path": "src/foo.rs", "line": 42, "snippet": "prepare" }
+      },
+      "scenario": { "op_trace": [], "seed": "seed" },
+      "verdict": {},
+      "relation": {
+        "kind": "state_eq", "description": "StateEq", "compared": ["initialized"], "ignored": ["max_frame"]
+      },
+      "finding": {
+        "kind": "state_eq",
+        "expected": { "label": "reference", "fields": [ { "field": "initialized", "value": "false" } ] },
+        "actual": { "label": "turso (observed)", "fields": [ { "field": "initialized", "value": "true" } ] },
+        "divergence": [ { "field": "initialized", "expected": "false", "actual": "true", "provenance": "non-durable header reads as present" } ]
+      }
+    }"#;
+    let fixture = format!(
+        r#"{{
+      "post": {{ "session_id": "01HMFULL", "view_url": "https://x", "plan_size": 1 }},
+      "gets": [{{
+        "session_id": "01HMFULL", "status": "done", "user_commit_sha": "abc1234567890",
+        "canon_version": "v0.1.0", "started_at": "2026-05-24T00:00:00Z", "completed_at": "2026-05-24T00:01:00Z",
+        "annotations": [{{
+          "annotation_id": "arta_op4q3z9NbV", "canon_id": "foo", "version": "v0.1.0",
+          "scope": "turso", "tier": "aristos:", "source_path": "src/foo.rs:42", "status": "failed",
+          "tests": [{{ "test_binary": "foo_conform", "status": "fail", "report": {report} }}]
+        }}],
+        "summary": {{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }}
+      }}]
+    }}"#
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .success()
+        // Reframed headline + the user's reason footer.
+        .stdout(contains("KNOWN PROPERTY FAILURE"))
+        .stdout(contains("turso file-existence proxy is the root cause"))
+        // The full violation body is still shown.
+        .stdout(contains("The initialized flag is set true"))
+        .stdout(contains("- initialized = false"))
+        .stdout(contains("+ initialized = true"))
+        // Not the red failure frame, not the internal conformance tag.
+        .stdout(contains("PROPERTY VIOLATED").not())
+        .stdout(contains("EXPECTED TO FAIL").not());
 }
 
 #[test]
@@ -494,7 +571,7 @@ fn unwaived_failure_is_unchanged_and_still_red() {
         .args(["verify", "--wait"])
         .assert()
         .failure()
-        .stdout(contains("known gap (accepted)").not())
+        .stdout(contains("KNOWN PROPERTY FAILURE").not())
         // A failing, un-waived property points the user at how to accept it.
         .stdout(contains("aristo verify --accept aristos:foo --because"));
 }
@@ -622,7 +699,7 @@ fn waived_annotation_with_an_operational_test_is_red_not_an_accepted_gap() {
         .args(["verify", "--wait"])
         .assert()
         .failure()
-        .stdout(contains("known gap (accepted)").not());
+        .stdout(contains("KNOWN PROPERTY FAILURE").not());
 }
 
 #[test]

--- a/crates/aristo-cli/tests/verify_expectations.rs
+++ b/crates/aristo-cli/tests/verify_expectations.rs
@@ -494,3 +494,173 @@ fn unwaived_failure_is_unchanged_and_still_red() {
         .failure()
         .stdout(contains("known gap (accepted)").not());
 }
+
+// ─── hardening (from the adversarial review) ─────────────────────────────────
+
+#[test]
+fn accept_rejects_an_empty_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    // clap enforces flag PRESENCE; the command enforces a non-empty value
+    // (a reasonless waiver is how baselines rot).
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "foo", "--because", "   "])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(contains("non-empty reason"));
+
+    assert!(
+        !tmp.path().join(".aristo/expectations.toml").exists(),
+        "a blank reason must not write the expectations file"
+    );
+}
+
+#[test]
+fn accept_conflicts_with_dispatch_and_ci_flags() {
+    let tmp = tempfile::tempdir().unwrap();
+    lean_workspace_with_canon_entry(tmp.path());
+
+    // --accept is write-only; combining it with the no-write CI mode (or any
+    // dispatch flag) is a clap usage error, never a silent write.
+    aristo_in(tmp.path())
+        .args(["verify", "--accept", "foo", "--because", "x", "--check"])
+        .assert()
+        .failure()
+        .code(2);
+
+    assert!(
+        !tmp.path().join(".aristo/expectations.toml").exists(),
+        "a rejected flag combo must not write the expectations file"
+    );
+}
+
+#[test]
+fn malformed_expectations_hard_errors_verify_wait() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    // A malformed committed sidecar surfaces LOUDLY rather than silently
+    // dropping the user's waivers (and flipping accepted gaps to red).
+    fs::write(
+        tmp.path().join(".aristo/expectations.toml"),
+        "this is = = not valid toml [[[",
+    )
+    .unwrap();
+
+    let fixture = one_annotation_fixture(
+        "01HMBAD",
+        "failed",
+        "fail",
+        r#"{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }"#,
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        .stderr(contains("expectations.toml"));
+}
+
+#[test]
+fn waived_annotation_with_an_operational_test_is_red_not_an_accepted_gap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "the property gap",
+        ])
+        .assert()
+        .success();
+
+    // Annotation aggregates to `failed` (precedence), but one of its tests
+    // is a build failure — an operational break the waiver must NOT mask.
+    let fixture = r#"{
+      "post": { "session_id": "01HMOP", "view_url": "https://x", "plan_size": 1 },
+      "gets": [{
+        "session_id": "01HMOP", "status": "done", "user_commit_sha": "abc1234567890",
+        "canon_version": "v0.1.0", "started_at": "2026-05-24T00:00:00Z", "completed_at": "2026-05-24T00:01:00Z",
+        "annotations": [{
+          "annotation_id": "arta_op4q3z9NbV", "canon_id": "foo", "version": "v0.1.0",
+          "scope": "turso", "tier": "aristos:", "source_path": "src/foo.rs:42", "status": "failed",
+          "tests": [
+            { "test_binary": "foo_conform", "status": "fail" },
+            { "test_binary": "foo_build", "status": "build_failed" }
+          ]
+        }],
+        "summary": { "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }
+      }]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        .stdout(contains("known gap (accepted)").not());
+}
+
+#[test]
+fn orphan_waiver_warns_when_it_matches_no_annotation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    aristo_in(tmp.path())
+        .args([
+            "verify",
+            "--accept",
+            "aristos:foo",
+            "--because",
+            "drifted gap",
+        ])
+        .assert()
+        .success();
+
+    // The session returns no annotation for the waived id (renamed / removed
+    // upstream) → the stale waiver is surfaced, not silently rotting.
+    let fixture = r#"{
+      "post": { "session_id": "01HMORPH", "view_url": "https://x", "plan_size": 1 },
+      "gets": [{
+        "session_id": "01HMORPH", "status": "done", "user_commit_sha": "abc1234567890",
+        "canon_version": "v0.1.0", "started_at": "2026-05-24T00:00:00Z", "completed_at": "2026-05-24T00:01:00Z",
+        "annotations": [],
+        "summary": { "total_annotations": 0, "verified": 0, "failed": 0, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }
+      }]
+    }"#;
+    let fixture_path = write_full_fixture(tmp.path(), fixture);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .success()
+        .stderr(contains("aristos:foo"))
+        .stderr(contains("matched no annotation"));
+}

--- a/crates/aristo-core/src/expectations.rs
+++ b/crates/aristo-core/src/expectations.rs
@@ -1,0 +1,226 @@
+//! `.aristo/expectations.toml` — the user-side known-failure waiver
+//! sidecar (Phase 16 (c)).
+//!
+//! Records property gaps the user has explicitly accepted: "my code
+//! currently violates this canon property, and I acknowledge it." The
+//! *property check* is Aretta's; the *acknowledgment that this repo
+//! currently fails it* is the user's, so it lives here in their repo —
+//! git-tracked, hand-readable, and reviewable in a diff.
+//!
+//! ## Shape (mirrors the other `.aristo/` sidecars)
+//!
+//! ```toml
+//! [__meta__]
+//! schema_version = 1
+//!
+//! ["aristos:wal_initialized_reflects_sync_outcome"]
+//! reason = "turso reports initialized from a file-existence proxy; tracked upstream"
+//! tracking = "https://github.com/tursodatabase/turso/issues/1234"   # optional
+//! accepted_at = "2026-06-01T12:34:56Z"
+//! ```
+//!
+//! ## Why key on the stable canon id, not the opaque `aret_*`
+//!
+//! The opaque id churns on every `aristo stamp` / rebind. The stable
+//! prefixed canon id (`aristos:…` / `kanon:…`) survives re-stamps, so a
+//! waiver written today is still matched after the next stamp with zero
+//! migration logic.
+//!
+//! ## Ownership
+//!
+//! `aristo stamp` never touches this file (unlike `index.toml`, which is
+//! machine-regenerated). It is written only by `aristo verify --accept`
+//! and read at verify time as a join against the live results.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::{fs, io};
+
+use serde::{Deserialize, Serialize};
+
+use crate::index::AnnotationId;
+
+/// The parsed `.aristo/expectations.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ExpectationsFile {
+    #[serde(rename = "__meta__", default)]
+    pub meta: ExpectationsMeta,
+
+    /// `canon_id → Expectation`. Keyed on the **stable prefixed canon
+    /// id** (`aristos:foo` / `kanon:bar`). `BTreeMap` for deterministic
+    /// serialization — this file is committed, so a stable order keeps
+    /// git diffs clean.
+    #[serde(flatten)]
+    pub entries: BTreeMap<AnnotationId, Expectation>,
+}
+
+/// `[__meta__]` header. Matches the `index.toml` / `canon-matches.toml`
+/// convention so all sidecars read the same way.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpectationsMeta {
+    pub schema_version: u32,
+}
+
+impl Default for ExpectationsMeta {
+    fn default() -> Self {
+        Self { schema_version: 1 }
+    }
+}
+
+/// One accepted gap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Expectation {
+    /// Why the gap is accepted — recorded verbatim and shown on the
+    /// verify card. Mandatory: a reasonless waiver is how baselines rot.
+    pub reason: String,
+    /// Optional tracking reference (issue URL, ticket id).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracking: Option<String>,
+    /// RFC3339 timestamp the gap was accepted.
+    pub accepted_at: String,
+}
+
+impl ExpectationsFile {
+    /// Read + parse the file. A **missing** file is not an error — it
+    /// means "no gaps accepted" and returns the default (empty). A
+    /// malformed file propagates a parse error so a hand-edit typo
+    /// surfaces loudly rather than silently dropping the user's waivers.
+    pub fn read(path: &Path) -> io::Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(raw) => toml::from_str(&raw)
+                .map_err(|e| io::Error::other(format!("parse {}: {e}", path.display()))),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Serialize + write atomically (temp-then-rename), creating parent
+    /// dirs as needed. Mirrors the other sidecars' write path.
+    pub fn write_atomic(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let toml_text = toml::to_string_pretty(self)
+            .map_err(|e| io::Error::other(format!("serialize expectations: {e}")))?;
+        let tmp = path.with_extension("toml.tmp");
+        fs::write(&tmp, toml_text.as_bytes())?;
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// The accepted gap for `id`, if any.
+    pub fn get(&self, id: &AnnotationId) -> Option<&Expectation> {
+        self.entries.get(id)
+    }
+
+    /// True iff `id` has an accepted gap.
+    pub fn is_waived(&self, id: &AnnotationId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    /// Record (or replace) an accepted gap. Idempotent: re-accepting the
+    /// same id overwrites the reason / tracking / timestamp rather than
+    /// accumulating duplicates.
+    pub fn accept(
+        &mut self,
+        id: AnnotationId,
+        reason: String,
+        tracking: Option<String>,
+        accepted_at: String,
+    ) {
+        self.entries.insert(
+            id,
+            Expectation {
+                reason,
+                tracking,
+                accepted_at,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn id(s: &str) -> AnnotationId {
+        AnnotationId::parse(s).unwrap()
+    }
+
+    #[test]
+    fn missing_file_reads_as_empty_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".aristo/expectations.toml");
+        let f = ExpectationsFile::read(&path).unwrap();
+        assert_eq!(f, ExpectationsFile::default());
+        assert!(f.entries.is_empty());
+        assert_eq!(f.meta.schema_version, 1);
+    }
+
+    #[test]
+    fn accept_then_write_then_read_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".aristo/expectations.toml");
+
+        let mut f = ExpectationsFile::default();
+        f.accept(
+            id("aristos:wal_initialized_reflects_sync_outcome"),
+            "turso uses a file-existence proxy".into(),
+            Some("https://example/issues/1".into()),
+            "2026-06-01T12:34:56Z".into(),
+        );
+        f.write_atomic(&path).unwrap();
+
+        let back = ExpectationsFile::read(&path).unwrap();
+        assert_eq!(back, f);
+
+        let exp = back
+            .get(&id("aristos:wal_initialized_reflects_sync_outcome"))
+            .expect("entry present");
+        assert_eq!(exp.reason, "turso uses a file-existence proxy");
+        assert_eq!(exp.tracking.as_deref(), Some("https://example/issues/1"));
+        assert!(back.is_waived(&id("aristos:wal_initialized_reflects_sync_outcome")));
+    }
+
+    #[test]
+    fn serialized_form_has_meta_header_and_prefixed_key() {
+        let mut f = ExpectationsFile::default();
+        f.accept(
+            id("aristos:foo"),
+            "because reasons".into(),
+            None,
+            "2026-06-01T00:00:00Z".into(),
+        );
+        let text = toml::to_string_pretty(&f).unwrap();
+        assert!(text.contains("[__meta__]"), "meta header; got:\n{text}");
+        assert!(text.contains("schema_version = 1"), "version; got:\n{text}");
+        assert!(
+            text.contains("[\"aristos:foo\"]"),
+            "prefixed key; got:\n{text}"
+        );
+        assert!(text.contains("because reasons"), "reason; got:\n{text}");
+        // Absent tracking must not serialize as a key.
+        assert!(
+            !text.contains("tracking"),
+            "no tracking key when None; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn accept_is_idempotent_overwrite() {
+        let mut f = ExpectationsFile::default();
+        f.accept(id("aristos:foo"), "first".into(), None, "t1".into());
+        f.accept(id("aristos:foo"), "second".into(), None, "t2".into());
+        assert_eq!(f.entries.len(), 1);
+        assert_eq!(f.get(&id("aristos:foo")).unwrap().reason, "second");
+    }
+
+    #[test]
+    fn malformed_file_surfaces_a_parse_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("expectations.toml");
+        fs::write(&path, "this is not = = valid toml [[[").unwrap();
+        assert!(ExpectationsFile::read(&path).is_err());
+    }
+}

--- a/crates/aristo-core/src/lib.rs
+++ b/crates/aristo-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod canon_verify;
 pub mod config;
 pub mod critique;
 pub mod cycle;
+pub mod expectations;
 pub mod git;
 pub mod hash;
 pub mod id;


### PR DESCRIPTION
## Phase 16 — (c) user-side known-failure waivers

Lets a developer **accept** a known conformance gap so it stops failing their build, without weakening the signal for anything else. The waiver lives in the user's repo (`.aristo/expectations.toml`), is keyed on the stable canon id, and is reconciled at verify time against the live run.

### What's in it

- **`.aristo/expectations.toml` waiver sidecar** (`aristo-core`) — typed `ExpectationsFile` (`__meta__` + per-id `{reason, tracking?, accepted_at}`); missing file = no waivers, malformed file = hard error (never silently ignored).
- **`aristo verify --accept <canon-id> --because "<reason>" [--tracking <url>]`** — writes/updates the waiver atomically; rejects an empty reason; idempotent; resolves a bare canon-id suffix as shorthand.
- **Read-time join + strict ratchet** at verify time:
  - waived **and** still failing → reported as a **known gap**, build stays green.
  - waived **but now passing** → **red** ("delete the stale waiver") — the ratchet won't let a fixed property hide behind an accept.
  - exit code is reconciled against the run **summary** (`unwaived_failed = summary.failed − accepted_gaps`), with guards for incomplete sessions and operational-test failures — so a partial/empty `annotations[]` can never produce a false green.
- **Card UX** (the rendered failure):
  - failing card **drops the internal verdict frame** (the old CR‑03 · EXPECTED TO FAIL block — server-side noise) and instead **offers the exact `--accept` command** as a hint.
  - an **accepted gap** renders the full bordered card with an orange **⚠ KNOWN PROPERTY FAILURE** header (replacing the red PROPERTY FAILED), plus a bottom field rendering the **reason** and **tracker**.
  - the card is a real **88‑column bordered card** wrapped via `textwrap` (`WordSplitter::NoHyphenation`, widths measured on plain text) — no hand-rolled wrapping, no mid-word cuts.

### Scope

- **aristo-only.** No harness or proxy change — the waiver is a read-time join over the report the proxy already returns. Confirmed against ground truth (harness panics regardless of any expected-to-fail flag; the proxy passes status verbatim).
- The in-annotation `expect="fail"` field and Aretta-seeded demo waivers are **out of scope** (deferred).

### Tests (the spec — written first)

- `tests/verify_expectations.rs` — **16** integration tests (accept write, read-time join, both ratchet directions, malformed = hard error, empty-`--because` rejection, flag conflicts, orphan waiver, rich accepted-gap card).
- `tests/verify_canon_dispatch.rs` — **13** (frozen card updated: EXPECTED‑TO‑FAIL absent, accept hint present).
- `card.rs` unit tests pin every card line to exactly 88 columns.
- Full `aristo-core` + `aristo-cli` suite green (439 + 309 lib, all integration suites), clippy clean.

> One fix here (`fix(cli): harden the verify waiver from adversarial review`) closes a self-introduced exit-code regression found in adversarial review: an annotations-only fold could exit 0 with `summary.failed > 0`. Now reconciled against the summary.

Stacked on Slice 2.1 (#21, merged); rebased onto `main` (the redact+color commit dropped as a duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
