### PR TITLE
feat(cli): render fault banner + numbered IO timeline (Phase 16 Slice 3)

### DIFF
--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -1132,7 +1132,13 @@ mod tests {
             ev(2, "pwrite", "db-wal @0 len=32", false, "ok"),
             ev(3, "sync", "db-wal", true, "EIO"),
             // A deliberately long detail to stress the width bound.
-            ev(4, "truncate", "db-journal @18446744073709551615 len=4096", false, "ok"),
+            ev(
+                4,
+                "truncate",
+                "db-journal @18446744073709551615 len=4096",
+                false,
+                "ok",
+            ),
         ];
 
         let mut card = Card::new();

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -29,9 +29,9 @@ use anstyle::{Ansi256Color, AnsiColor, Color, Style};
 
 use aristo_core::canon::CanonMatchesFile;
 use aristo_core::canon_verify::{
-    AnnotationOutcomeStatus, DifferentialReport, Finding, GetVerifySessionResponse,
-    HttpVerifyClient, PostVerifySessionResponse, SessionStatus, TestOutcome, TestOutcomeStatus,
-    VerifyClient, VerifyError, VerifySessionRequest, VerifySessionTag,
+    AnnotationOutcomeStatus, DifferentialReport, FaultSpec, Finding, GetVerifySessionResponse,
+    HttpVerifyClient, OpEvent, PostVerifySessionResponse, SessionStatus, TestOutcome,
+    TestOutcomeStatus, VerifyClient, VerifyError, VerifySessionRequest, VerifySessionTag,
 };
 use aristo_core::expectations::{Expectation, ExpectationsFile};
 use aristo_core::index::{AnnotationId, IndexEntry, IndexFile, IntentEntry};
@@ -760,6 +760,18 @@ fn render_violation_card(report: &DifferentialReport, repro_id: &str, kind: Card
         card.blank();
         card.line(&loc, C_DIM, 0);
     }
+
+    // Scenario (Slice 3): the injected fault + the IO timeline that led
+    // to the divergence. Additive — both are absent in a Slice-1 report,
+    // so older reports render exactly as before.
+    if let Some(fault) = &report.scenario.fault {
+        card.blank();
+        render_fault_banner(&mut card, fault);
+    }
+    if !report.scenario.op_trace.is_empty() {
+        card.blank();
+        render_op_trace(&mut card, &report.scenario.op_trace);
+    }
     card.blank();
 
     // The mask: compared fields + how many were ignored.
@@ -807,6 +819,48 @@ fn render_violation_card(report: &DifferentialReport, repro_id: &str, kind: Card
         anstream::println!("    {C_DIM}aristo verify --filter id={repro_id} --rerun{C_DIM:#}");
     }
     anstream::println!();
+}
+
+/// The fault banner (Slice 3): the named, parameterized injected fault,
+/// e.g. `fault   fail_nth · sync #1 → EIO   (fired 1×)`. Turso-observable
+/// only — the policy identity + the injected error, never the model.
+fn render_fault_banner(card: &mut Card, fault: &FaultSpec) {
+    let op = fault.op.to_lowercase();
+    let plain = format!(
+        "fault   {} · {op} #{} → {}   (fired {}×)",
+        fault.kind, fault.nth, fault.error, fault.fired_count
+    );
+    let styled = format!(
+        "{C_WARN}fault{C_WARN:#}   {} · {op} #{} → {C_WARN}{}{C_WARN:#}   {C_DIM}(fired {}×){C_DIM:#}",
+        fault.kind, fault.nth, fault.error, fault.fired_count
+    );
+    card.raw(styled, &plain);
+}
+
+/// The numbered IO timeline (Slice 3): the ordered op stream the harness
+/// recorded, the injected event marked. `ok` results are elided as noise;
+/// the injected event shows its error + a `← injected` marker in orange.
+/// Every op the run issued is shown (the real cr_03 trace is 3 ops).
+fn render_op_trace(card: &mut Card, op_trace: &[OpEvent]) {
+    let injected_seq = op_trace.iter().find(|e| e.injected).map(|e| e.seq);
+    let suffix = match injected_seq {
+        Some(k) => format!("{} I/O ops, fault at op {k}", op_trace.len()),
+        None => format!("{} I/O ops", op_trace.len()),
+    };
+    card.raw(
+        format!("{C_BOLD}what we tested{C_BOLD:#}   {C_DIM}·   {suffix}{C_DIM:#}"),
+        &format!("what we tested   ·   {suffix}"),
+    );
+    for ev in op_trace {
+        let mut text = format!("{:>2}  {:<8} {}", ev.seq, ev.op, ev.detail);
+        if ev.injected {
+            text.push_str(&format!("   {}  ← injected", ev.result));
+        } else if ev.result != "ok" {
+            text.push_str(&format!("   {}", ev.result));
+        }
+        let style = if ev.injected { C_WARN } else { C_DIM };
+        card.line(&text, style, 2);
+    }
 }
 
 /// The report on the first failing test of an annotation, if any.
@@ -1056,6 +1110,60 @@ mod tests {
 
     fn arta(s: &str) -> ArtaId {
         ArtaId::parse(s).unwrap()
+    }
+
+    /// The fault banner + numbered IO timeline must stay inside the
+    /// 88-column card frame — every rendered line exactly the card width,
+    /// even with a deliberately long detail. Also pins the injected
+    /// marker. (Prints the card under `--nocapture` for eyeballing.)
+    #[test]
+    fn op_trace_timeline_fits_88_cols() {
+        use textwrap::core::display_width;
+
+        let fault = FaultSpec {
+            kind: "fail_nth".into(),
+            op: "Sync".into(),
+            nth: 1,
+            error: "EIO".into(),
+            fired_count: 1,
+        };
+        let op_trace = vec![
+            ev(1, "pwrite", "db @0 len=4096", false, "ok"),
+            ev(2, "pwrite", "db-wal @0 len=32", false, "ok"),
+            ev(3, "sync", "db-wal", true, "EIO"),
+            // A deliberately long detail to stress the width bound.
+            ev(4, "truncate", "db-journal @18446744073709551615 len=4096", false, "ok"),
+        ];
+
+        let mut card = Card::new();
+        render_fault_banner(&mut card, &fault);
+        card.blank();
+        render_op_trace(&mut card, &op_trace);
+        let rendered = card.render();
+
+        for line in rendered.lines() {
+            assert_eq!(
+                display_width(line),
+                88,
+                "every card line must be 88 cols; got {line:?}"
+            );
+        }
+        // `render()` keeps ANSI (anstream strips it only at print time), so
+        // assert substrings that don't cross a style boundary: the banner's
+        // unstyled middle, and the injected op line (one uniform style).
+        assert!(rendered.contains("fail_nth · sync #1 →"));
+        assert!(rendered.contains("EIO  ← injected"));
+        eprintln!("\n{rendered}");
+    }
+
+    fn ev(seq: u64, op: &str, detail: &str, injected: bool, result: &str) -> OpEvent {
+        OpEvent {
+            seq,
+            op: op.into(),
+            detail: detail.into(),
+            injected,
+            result: result.into(),
+        }
     }
 
     fn intent(

--- a/crates/aristo-cli/tests/verify_canon_dispatch.rs
+++ b/crates/aristo-cli/tests/verify_canon_dispatch.rs
@@ -555,6 +555,109 @@ fn wait_renders_structured_card_when_test_carries_phase16_report() {
 }
 
 #[test]
+fn wait_renders_fault_banner_and_io_timeline_for_enriched_report() {
+    // Phase 16 Slice 3: a failing TestOutcome carrying the ENRICHED
+    // cr03.full report (populated scenario.fault + scenario.op_trace)
+    // must render a fault banner + a numbered IO timeline with the
+    // injected event marked. Report body is a byte-copy of the
+    // cross-repo cr03.full contract fixture's salient fields.
+    let tmp = tempfile::tempdir().unwrap();
+    let _bare = init_repo_with_pushed_head(tmp.path());
+    workspace_with_one_canon_bound_full_intent(tmp.path());
+
+    let home = tempfile::tempdir().unwrap();
+    write_aretta_token(home.path(), "https://example.test");
+
+    let report = r#"{
+      "property": {
+        "canon_id": "wal_initialized_reflects_sync_outcome",
+        "statement": "The WAL initialized flag is set true only after a successful sync of the wal-header.",
+        "impl_source": { "path": "core/storage/wal.rs", "line": 3989, "snippet": "prepare_wal_finish" }
+      },
+      "scenario": {
+        "fault": { "kind": "fail_nth", "op": "Sync", "nth": 1, "error": "EIO", "fired_count": 1 },
+        "op_trace": [
+          { "seq": 1, "op": "pwrite", "detail": "db @0 len=4096", "injected": false, "result": "ok" },
+          { "seq": 2, "op": "pwrite", "detail": "db-wal @0 len=32", "injected": false, "result": "ok" },
+          { "seq": 3, "op": "sync", "detail": "db-wal", "injected": true, "result": "EIO" }
+        ],
+        "seed": "cr_03_initialized_under_sync_eio/fail_nth(Sync,1,EIO)/pragma+create"
+      },
+      "verdict": {
+        "cr_id": "CR-03",
+        "expected_to_fail": { "tag": "CR-03", "reason": "turso rolls back the partial header write on sync failure." }
+      },
+      "relation": {
+        "kind": "state_eq",
+        "description": "StateEq under ProjectionMask { initialized }",
+        "compared": ["initialized"],
+        "ignored": ["max_frame", "nbackfills"]
+      },
+      "finding": {
+        "kind": "state_eq",
+        "expected": { "label": "reference", "fields": [ { "field": "initialized", "value": "false" } ] },
+        "actual": { "label": "turso (observed)", "fields": [ { "field": "initialized", "value": "true" } ] },
+        "divergence": [ { "field": "initialized", "expected": "false", "actual": "true", "provenance": "turso reports initialized from the *.db-wal file-existence proxy; a non-durable header reads as present." } ]
+      }
+    }"#;
+
+    let fixture_body = format!(
+        r#"{{
+      "post": {{ "session_id": "01HMFULL", "view_url": "https://x", "plan_size": 1 }},
+      "gets": [
+        {{
+          "session_id": "01HMFULL",
+          "status": "done",
+          "user_commit_sha": "abc1234567890",
+          "canon_version": "v0.1.0",
+          "started_at": "2026-05-24T00:00:00Z",
+          "completed_at": "2026-05-24T00:01:00Z",
+          "annotations": [
+            {{
+              "annotation_id": "arta_op4q3z9NbV",
+              "canon_id": "wal_initialized_reflects_sync_outcome",
+              "version": "v0.1.0",
+              "scope": "turso",
+              "tier": "aristos:",
+              "source_path": "core/storage/wal.rs:3989",
+              "status": "failed",
+              "tests": [
+                {{ "test_binary": "cr_03_conform", "test_kind": "differential", "relation": "tight", "status": "fail", "duration_ms": 4210, "report": {report} }}
+              ]
+            }}
+          ],
+          "summary": {{ "total_annotations": 1, "verified": 0, "failed": 1, "build_failed": 0, "inconclusive": 0, "no_coverage": 0 }}
+        }}
+      ]
+    }}"#
+    );
+    let fixture_path = write_full_fixture(tmp.path(), &fixture_body);
+
+    aristo_in(tmp.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("ARISTO_CANON_VERIFY_FIXTURE", &fixture_path)
+        .env("ARISTO_VERIFY_POLL_MS", "1")
+        .args(["verify", "--wait"])
+        .assert()
+        .failure()
+        // The fault banner: the named, parameterized injected fault.
+        .stdout(contains("fault"))
+        .stdout(contains("fail_nth · sync #1 → EIO"))
+        .stdout(contains("(fired 1×)"))
+        // The numbered IO timeline header + the ops that ran.
+        .stdout(contains("what we tested"))
+        .stdout(contains("3 I/O ops, fault at op 3"))
+        .stdout(contains("pwrite"))
+        .stdout(contains("db-wal @0 len=32"))
+        // The injected event is marked.
+        .stdout(contains("← injected"))
+        // Still no model/Lean identity on the user surface (IP).
+        .stdout(contains("lean").not())
+        .stdout(contains("Lean").not());
+}
+
+#[test]
 fn view_attaches_to_existing_session_without_post() {
     // --view <id> skips POST entirely — no workspace, no git, no auth-
     // sourced repo. Only a single GET. We deliberately don't init a


### PR DESCRIPTION
## Phase 16 Slice 3 (CLI side) — render the fault banner + numbered IO timeline

The consumer half of [aretta-books #49](https://github.com/CampanileSkyForge/aretta-books/pull/49). The verify violation card now renders the two `DifferentialReport` scenario fields the harness populates in Slice 3:

- **`scenario.fault`** → a fault banner: `fault   fail_nth · sync #1 → EIO   (fired 1×)`
- **`scenario.op_trace`** → a numbered IO timeline, the injected event marked `← injected` (orange), `ok` results elided as noise

slotted below the impl anchor per the README §B order (header → statement → impl → **fault → timeline** → mask → divergence). The developer now sees *what we injected* and *the exact IO sequence to the violation*, in turso's own terms.

```
fault   fail_nth · sync #1 → EIO   (fired 1×)

what we tested   ·   3 I/O ops, fault at op 3
   1  pwrite   db @0 len=4096
   2  pwrite   db-wal @0 len=32
   3  sync     db-wal   EIO  ← injected
```

### Properties
- **Additive + back-compat.** A Slice-1 report (empty `op_trace`, no `fault`) renders exactly as before — both blocks are guarded.
- **No SDK change.** `FaultSpec` + `OpEvent` were already typed in `aristo-core` (Track A); this only renders them.
- **IP-clean.** Turso-observable only (op kind, file-suffix tag, offset/len, the injected error) — no model/Lean identity on the user surface.
- **Width-bounded.** Built with the existing 88-col `Card`; anstream strips color off-TTY.

### Tests
An enriched-report integration test (fault banner + timeline + `← injected` marker + asserts no Lean string) and a width unit test pinning every card line to 88 cols (incl. a stress-width op). Full `aristo-core` + `aristo-cli` suite green, clippy clean, `stamp --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
