### PR TITLE
feat(cli): notify when a newer aristo is available on crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+- feat(cli): `aristo` now tells you when a newer release is on crates.io. After a command finishes it prints a one-line notice to stderr — `A new release of aristo is available: X -> Y` — with the `cargo install aristo-cli --locked --force` command to update. The check hits crates.io at most once every 24 hours (cached under your config dir) and stays completely silent in CI, when output is piped/redirected, and when `ARISTO_NO_UPDATE_NOTIFIER` is set — so it never touches machine-readable stdout or changes a command's exit code. Updating stays your decision; nothing self-updates.
+
 ## [0.2.0] — 2026-06-04
 
 The verify failure card. When `aristo verify` finds a violated property, the verdict now reads like a great assertion failure — and a known, documented gap can be accepted instead of blocking the run. This release also moves badge rendering to the `badge-maker` crate, makes `aristo init` CI opt-in, and adds `aristo auth token` + crates.io trusted-publishing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "globset",
  "proc-macro2",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ aristo install-skills --agent claude-code   # also: cursor, codex, opencode, ant
 Then `aristo init` your project and code with your agent — the
 [walkthrough](./docs/GETTING-STARTED.md) has the rest.
 
+**Updating.** `aristo` checks crates.io at most once a day and prints a
+one-line notice when a newer release is out; update with `cargo install
+aristo-cli --locked --force` (or `cargo install-update aristo-cli` if you
+have [cargo-update](https://github.com/nabijaczleweli/cargo-update)).
+Nothing self-updates — the version stays pinned until you choose. The
+check is silent in CI and when output is piped; set
+`ARISTO_NO_UPDATE_NOTIFIER=1` to turn it off entirely.
+
 ## What a claim looks like
 
 ```rust

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -13,6 +13,7 @@ mod pipeline;
 mod preflight;
 mod session;
 mod skills;
+mod update_notify;
 mod workspace;
 
 pub use error::{CliError, CliResult};
@@ -785,7 +786,7 @@ pub(crate) enum BucketArg {
 /// `CliError`.
 pub fn run() -> ExitCode {
     let cli = Cli::parse();
-    match dispatch(cli.command) {
+    let code = match dispatch(cli.command) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             if !e.is_silent() {
@@ -793,7 +794,12 @@ pub fn run() -> ExitCode {
             }
             ExitCode::from(e.exit_code())
         }
-    }
+    };
+    // Best-effort "newer aristo available" notice, printed after the
+    // command's own output and never affecting its exit code. Silent in
+    // CI / pipes / on opt-out (see `update_notify`).
+    update_notify::maybe_notify();
+    code
 }
 
 /// Maps a parsed `Commands` variant to its handler.

--- a/crates/aristo-cli/src/update_notify.rs
+++ b/crates/aristo-cli/src/update_notify.rs
@@ -1,0 +1,66 @@
+//! Interactive "a newer aristo is available" notice.
+//!
+//! Wraps [`aristo_core::update_check`] with the gating a CLI needs: the
+//! check runs only when stderr is a terminal, `CI` is unset, and the
+//! user hasn't opted out via `ARISTO_NO_UPDATE_NOTIFIER`. The notice
+//! prints to stderr *after* the command's real output, so
+//! machine-readable stdout is never touched and pipelines stay
+//! deterministic.
+
+use std::io::IsTerminal;
+
+/// Env var that disables the update notice entirely (set to any value).
+const OPT_OUT_ENV: &str = "ARISTO_NO_UPDATE_NOTIFIER";
+
+/// Print an upgrade notice to stderr if one is due. Best-effort and
+/// silent on every failure — never affects the command's exit code.
+pub fn maybe_notify() {
+    if !enabled() {
+        return;
+    }
+    if let Some(msg) = aristo_core::update_check::check(env!("CARGO_PKG_VERSION")) {
+        eprintln!("{msg}");
+    }
+}
+
+/// Read the real environment and stderr, then defer to [`enabled_with`].
+fn enabled() -> bool {
+    enabled_with(
+        std::env::var_os(OPT_OUT_ENV).is_some(),
+        std::env::var_os("CI").is_some(),
+        std::io::stderr().is_terminal(),
+    )
+}
+
+/// Pure gate decision: notify only on an interactive terminal, with no
+/// opt-out and no `CI` marker. Keeping this separate lets the matrix be
+/// tested without mutating process env (the workspace forbids
+/// `unsafe_code`, which `set_var` requires).
+fn enabled_with(opt_out: bool, ci: bool, stderr_is_terminal: bool) -> bool {
+    !opt_out && !ci && stderr_is_terminal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notifies_on_interactive_terminal_without_optout_or_ci() {
+        assert!(enabled_with(false, false, true));
+    }
+
+    #[test]
+    fn suppressed_when_stderr_not_a_terminal() {
+        assert!(!enabled_with(false, false, false));
+    }
+
+    #[test]
+    fn suppressed_in_ci_even_on_a_terminal() {
+        assert!(!enabled_with(false, true, true));
+    }
+
+    #[test]
+    fn suppressed_when_opted_out() {
+        assert!(!enabled_with(true, false, true));
+    }
+}

--- a/crates/aristo-core/Cargo.toml
+++ b/crates/aristo-core/Cargo.toml
@@ -22,6 +22,7 @@ getrandom = "0.2"
 globset = "0.4"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 schemars = "0.8"
+semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/aristo-core/src/lib.rs
+++ b/crates/aristo-core/src/lib.rs
@@ -28,4 +28,5 @@ pub mod id;
 pub mod index;
 pub mod proof;
 pub mod spec;
+pub mod update_check;
 pub mod walk;

--- a/crates/aristo-core/src/update_check.rs
+++ b/crates/aristo-core/src/update_check.rs
@@ -1,0 +1,308 @@
+//! Best-effort "a newer `aristo` is available" check against crates.io.
+//!
+//! This module is deliberately non-fatal: every failure mode — offline,
+//! a slow endpoint, a malformed response, a missing `$HOME`, a corrupt
+//! cache file — collapses to "emit no notice". It never touches stdout
+//! and never returns an error to the caller. The worst case is that the
+//! user simply isn't told an update exists.
+//!
+//! The network is hit at most once per [`CHECK_INTERVAL`]. Between
+//! checks the last-seen latest version is read from a small cache file
+//! under the per-user config dir, so the steady-state cost is one file
+//! read plus a timestamp comparison.
+//!
+//! ## Layering
+//!
+//! Gating — is stderr a TTY? is `CI` set? did the user opt out? — is the
+//! caller's concern (see the CLI's `update_notify` module). This module
+//! only answers "given the clock and the cache, is there a newer
+//! version, and what should the cache now hold?". The decision logic is
+//! split into pure functions ([`should_fetch`], [`next_cache`],
+//! [`notice`], [`is_newer`]) so it is unit-testable without a clock,
+//! filesystem, or network.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::auth::config_dir;
+
+/// The crate that owns the `aristo` binary on crates.io. Users run
+/// `cargo install aristo-cli` even though the installed command is
+/// `aristo`, so the lookup and the upgrade hint both name `aristo-cli`.
+pub const CRATE_NAME: &str = "aristo-cli";
+
+/// Minimum spacing between network checks. A check more recent than this
+/// reuses the cached `latest_seen` version instead of hitting the
+/// network.
+pub const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Per-request timeout for the crates.io lookup. The notice is never
+/// worth stalling the user for long; this matches the canon client's
+/// conservative budget.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Filename of the throttle/cache file inside the config dir.
+const CACHE_FILENAME: &str = "update-check.toml";
+
+/// On-disk throttle state.
+///
+/// `last_check_unix` records when we last *attempted* a network check
+/// (success or failure), so a flaky network can't make us poll on every
+/// invocation. `latest_seen` is the most recent stable version
+/// crates.io reported; it is carried forward across failed checks so the
+/// reminder persists until the user actually updates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cache {
+    /// Unix seconds of the last network attempt.
+    pub last_check_unix: u64,
+    /// Last stable version crates.io reported, if any has been seen.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_seen: Option<String>,
+}
+
+/// Returns the one-line upgrade notice to print to stderr, or `None` if
+/// there's nothing to say. Performs all I/O (cache read, optional
+/// network fetch, cache write); every failure is swallowed.
+///
+/// `current` is the running binary's version
+/// (`env!("CARGO_PKG_VERSION")`).
+pub fn check(current: &str) -> Option<String> {
+    let path = cache_path()?;
+    let now = now_unix()?;
+    let cache = read_cache(&path);
+
+    let latest = if should_fetch(now, cache.as_ref()) {
+        let fetched = fetch_latest_stable();
+        let next = next_cache(now, fetched, cache);
+        // Best-effort persist; a write failure just means we re-check
+        // sooner next time.
+        let _ = write_cache(&path, &next);
+        next.latest_seen
+    } else {
+        cache.and_then(|c| c.latest_seen)
+    };
+
+    notice(current, latest.as_deref())
+}
+
+/// Has enough time elapsed since the last attempt to check again? No
+/// cache (first run) always checks.
+pub fn should_fetch(now_unix: u64, cache: Option<&Cache>) -> bool {
+    match cache {
+        None => true,
+        Some(c) => now_unix.saturating_sub(c.last_check_unix) >= CHECK_INTERVAL.as_secs(),
+    }
+}
+
+/// The cache to persist after an attempt. A successful fetch updates
+/// `latest_seen`; a failed one (`fetched == None`) carries the previous
+/// value forward so a transient outage doesn't erase a known-newer
+/// version.
+pub fn next_cache(now_unix: u64, fetched: Option<String>, prev: Option<Cache>) -> Cache {
+    let latest_seen = fetched.or_else(|| prev.and_then(|c| c.latest_seen));
+    Cache {
+        last_check_unix: now_unix,
+        latest_seen,
+    }
+}
+
+/// Render the upgrade notice if `latest` is a valid semver strictly
+/// greater than `current`. Unparseable versions yield `None` — better
+/// silent than wrong.
+pub fn notice(current: &str, latest: Option<&str>) -> Option<String> {
+    let latest = latest?;
+    if !is_newer(current, latest) {
+        return None;
+    }
+    Some(format!(
+        "\nA new release of aristo is available: {current} -> {latest}\n\
+         Update with: cargo install {CRATE_NAME} --locked --force"
+    ))
+}
+
+/// Is `latest` a strictly-greater semver than `current`? Either side
+/// failing to parse yields `false`.
+pub fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(cur), Ok(new)) => new > cur,
+        _ => false,
+    }
+}
+
+// ─── I/O boundary ──────────────────────────────────────────────────────────
+// Thin wrappers around the clock, filesystem, and network. The decision
+// logic above is pure and carries the test coverage; these are exercised
+// end-to-end by the CLI.
+
+fn cache_path() -> Option<PathBuf> {
+    config_dir().ok().map(|d| d.join(CACHE_FILENAME))
+}
+
+fn now_unix() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+fn read_cache(path: &Path) -> Option<Cache> {
+    let text = std::fs::read_to_string(path).ok()?;
+    toml::from_str(&text).ok()
+}
+
+fn write_cache(path: &Path, cache: &Cache) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let text = toml::to_string_pretty(cache)
+        .map_err(|e| std::io::Error::other(format!("serialize update cache: {e}")))?;
+    // Atomic write: <path>.tmp then rename, mirroring the credentials
+    // store so a crash can't leave a half-written cache.
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, text.as_bytes())?;
+    std::fs::rename(&tmp, path)
+}
+
+/// Hit crates.io for the latest stable version of [`CRATE_NAME`]. Any
+/// failure — transport, non-success status, decode — yields `None`.
+fn fetch_latest_stable() -> Option<String> {
+    let url = format!("https://crates.io/api/v1/crates/{CRATE_NAME}");
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(FETCH_TIMEOUT))
+        // crates.io's crawler policy asks for an identifying UA with a
+        // contact/repo. Default error-on-status is left on, so any
+        // non-2xx surfaces as Err and is swallowed below.
+        .user_agent(format!(
+            "aristo-cli/{} (+https://github.com/aretta-ai/aristo)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .into();
+
+    let mut resp = agent.get(&url).call().ok()?;
+    if resp.status().as_u16() != 200 {
+        return None;
+    }
+    let body = resp.body_mut().read_to_string().ok()?;
+    let parsed: CratesIoResponse = serde_json::from_str(&body).ok()?;
+    parsed.krate.max_stable_version
+}
+
+/// Minimal projection of the crates.io `GET /api/v1/crates/{name}`
+/// response — we only need the latest stable version.
+#[derive(Deserialize)]
+struct CratesIoResponse {
+    #[serde(rename = "crate")]
+    krate: CrateInfo,
+}
+
+#[derive(Deserialize)]
+struct CrateInfo {
+    /// Highest non-prerelease, non-yanked version. `null` if every
+    /// published version is a prerelease.
+    max_stable_version: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_run_with_no_cache_triggers_fetch() {
+        assert!(should_fetch(1_000_000, None));
+    }
+
+    #[test]
+    fn fetch_skipped_within_interval() {
+        let cache = Cache {
+            last_check_unix: 1_000_000,
+            latest_seen: Some("0.2.0".into()),
+        };
+        // One second later — well within 24h.
+        assert!(!should_fetch(1_000_001, Some(&cache)));
+    }
+
+    #[test]
+    fn fetch_resumes_exactly_at_interval_boundary() {
+        let cache = Cache {
+            last_check_unix: 1_000_000,
+            latest_seen: None,
+        };
+        let boundary = 1_000_000 + CHECK_INTERVAL.as_secs();
+        assert!(should_fetch(boundary, Some(&cache)));
+        assert!(!should_fetch(boundary - 1, Some(&cache)));
+    }
+
+    #[test]
+    fn next_cache_records_attempt_and_new_version() {
+        let c = next_cache(42, Some("0.3.0".into()), None);
+        assert_eq!(c.last_check_unix, 42);
+        assert_eq!(c.latest_seen.as_deref(), Some("0.3.0"));
+    }
+
+    #[test]
+    fn next_cache_carries_previous_version_when_fetch_fails() {
+        let prev = Cache {
+            last_check_unix: 1,
+            latest_seen: Some("0.3.0".into()),
+        };
+        let c = next_cache(99, None, Some(prev));
+        assert_eq!(c.last_check_unix, 99);
+        // A failed fetch must not erase a known-newer version.
+        assert_eq!(c.latest_seen.as_deref(), Some("0.3.0"));
+    }
+
+    #[test]
+    fn notice_emitted_only_when_strictly_newer() {
+        let n = notice("0.2.0", Some("0.3.0")).expect("newer -> notice");
+        assert!(n.contains("0.2.0 -> 0.3.0"));
+        assert!(n.contains("cargo install aristo-cli --locked --force"));
+    }
+
+    #[test]
+    fn no_notice_when_equal_older_or_absent() {
+        assert!(notice("0.2.0", Some("0.2.0")).is_none());
+        assert!(notice("0.2.0", Some("0.1.9")).is_none());
+        assert!(notice("0.2.0", None).is_none());
+    }
+
+    #[test]
+    fn no_notice_on_unparseable_versions() {
+        assert!(notice("not-semver", Some("0.3.0")).is_none());
+        assert!(notice("0.2.0", Some("garbage")).is_none());
+    }
+
+    #[test]
+    fn is_newer_across_patch_minor_major() {
+        assert!(is_newer("0.2.0", "0.2.1"));
+        assert!(is_newer("0.2.0", "0.3.0"));
+        assert!(is_newer("0.9.0", "1.0.0"));
+        assert!(!is_newer("1.0.0", "0.9.9"));
+        assert!(!is_newer("0.2.0", "0.2.0"));
+    }
+
+    #[test]
+    fn cache_round_trips_through_toml() {
+        let c = Cache {
+            last_check_unix: 1_717_000_000,
+            latest_seen: Some("0.4.2".into()),
+        };
+        let back: Cache = toml::from_str(&toml::to_string_pretty(&c).unwrap()).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn cache_without_latest_seen_round_trips() {
+        let c = Cache {
+            last_check_unix: 5,
+            latest_seen: None,
+        };
+        let back: Cache = toml::from_str(&toml::to_string_pretty(&c).unwrap()).unwrap();
+        assert_eq!(c, back);
+    }
+}


### PR DESCRIPTION
## What

Adds a **notify-only** update check to the `aristo` CLI. After a command finishes, if a newer `aristo-cli` release is on crates.io, it prints one line to stderr:

```
A new release of aristo is available: 0.2.0 -> 0.2.1
Update with: cargo install aristo-cli --locked --force
```

Nothing self-updates — the version stays pinned until the user chooses to update. This deliberately rejects the shell-wrapper / auto-`cargo install --force`-on-run approach: `cargo install` can't put a script on PATH, a recompile-on-run is minutes of CPU, and silently mutating a **verification** tool's version mid-run would break reproducibility and deterministic CI.

## How

- **`aristo-core::update_check`** — the mechanism. Network is hit at most **once per 24h**; the last-seen stable version is cached under the per-user config dir (`auth::config_dir()`, atomic tmp+rename like the credentials store). The crates.io lookup reuses the canon client's `ureq` idiom (2s timeout, identifying UA) and reads `crate.max_stable_version` from `GET /api/v1/crates/aristo-cli` (verified against the live API). Decision logic — throttle, cache carry-forward on a failed fetch, `semver` compare, notice rendering — is split into pure, unit-tested functions. Every failure mode (offline, non-2xx, bad body, missing `$HOME`, corrupt cache) collapses to "no notice"; it never errors and never touches stdout.
- **`aristo-cli::update_notify`** — the gating. Suppressed when stderr isn't a terminal (pipes/redirects), when `CI` is set, and when `ARISTO_NO_UPDATE_NOTIFIER` is set. Hooked into `run()` after the command's output; never affects the exit code.

Only new runtime dep is `semver` (already in the lockfile transitively → no new compile).

## Tradeoffs / notes

- The check is **synchronous** with a 2s timeout, run at most once/24h on interactive use — so a fresh check adds ≤2s after a command once a day. Kept simple over a background thread for the first slice.
- `--version` / `--help` exit inside clap before the hook, so they never show the notice (matches `gh`).
- Concurrent invocations share one `.tmp` path (same pattern as the existing credentials store) — atomic rename means no corruption, worst case a swallowed rename error.

## Tests

- 11 new unit tests in `update_check` (throttle boundary, cache carry-forward, semver compare, notice rendering, TOML round-trip) + 4 in `update_notify` (gating matrix).
- Full suite green: **1093 passed, 0 failed**; `fmt --check`, `clippy --workspace --all-targets` (workspace denies all clippy) clean.
- Manual smoke: piped stderr → notice correctly suppressed (0 bytes).

## Docs

- README "Updating" note (opt-out env + `cargo install-update` alternative).
- CHANGELOG `[Unreleased]` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)