### PR TITLE
feat(canon): proof-tree suggestions — queue, intent-review session, modes, skill (§17)

### DIFF
--- a/crates/aristo-cli/src/commands/canon/migrate.rs
+++ b/crates/aristo-cli/src/commands/canon/migrate.rs
@@ -135,6 +135,7 @@ pub(crate) fn run() -> CliResult<()> {
         // still surfaces during migration (better than missing a patch
         // bump because confidence dipped 0.01 below the stamp threshold).
         confidence_threshold: 0.65,
+        include_suggestions: false,
     };
     let response = client
         .match_annotations(&request)

--- a/crates/aristo-cli/src/commands/canon/mod.rs
+++ b/crates/aristo-cli/src/commands/canon/mod.rs
@@ -16,5 +16,7 @@ pub(crate) mod refresh;
 pub(crate) mod reject;
 pub(crate) mod request_verify;
 pub(crate) mod runner;
+pub(crate) mod session_kind;
 pub(crate) mod show;
+pub(crate) mod suggestions;
 pub(crate) mod unbind;

--- a/crates/aristo-cli/src/commands/canon/runner.rs
+++ b/crates/aristo-cli/src/commands/canon/runner.rs
@@ -42,6 +42,8 @@ use aristo_core::canon::{
 use aristo_core::config::CanonConfig;
 use aristo_core::index::{AnnotationId, IndexEntry, IndexFile};
 
+use crate::commands::canon::suggestions as suggestions_mod;
+use crate::pipeline::queue;
 use crate::{CliError, CliResult, Workspace};
 
 /// What happened in the canon-step. Stamp/critique render this for
@@ -144,6 +146,10 @@ pub(crate) fn run_canon_step(args: RunnerArgs) -> CliResult<CanonStepOutcome> {
             })
             .collect(),
         confidence_threshold: args.threshold,
+        // §17: opt in to the proof-tree suggestions channel. The server
+        // attaches `suggestions[]` aligned by annotation index; we route
+        // them into the canon-suggestions queue after the primary merge.
+        include_suggestions: true,
     };
     let response = match client.match_annotations(&req) {
         Ok(r) => r,
@@ -165,6 +171,22 @@ pub(crate) fn run_canon_step(args: RunnerArgs) -> CliResult<CanonStepOutcome> {
             message: format!("write {}: {e}", cache_path.display()),
             exit_code: 1,
         })?;
+
+    // ── §17: route proof-tree suggestions into the canon-suggestions
+    //    queue. Dedup ② (vs local index/cache/rejection-log state) +
+    //    dedup ③ (collapse clusters sharing an objective) happen inside
+    //    the router. Local state is read AFTER the primary merge so a
+    //    sibling that just landed as a pending primary is filtered out. ──
+    if let Some(suggestions) = &response.suggestions {
+        let qdir = queue::QueueDir::for_pipeline(args.ws, suggestions_mod::PIPELINE);
+        let local = suggestions_mod::local_state(args.ws, &cache)?;
+        suggestions_mod::route_suggestions_into_queue(
+            &qdir,
+            suggestions,
+            &local,
+            &now_rfc3339(),
+        )?;
+    }
 
     Ok(CanonStepOutcome::Ok {
         findings_added,
@@ -730,6 +752,7 @@ mod tests {
             effective_scopes: vec![":vanilla".into()],
             canon_version: "v0.2.0".into(),
             matched_at: "2026-06-15T09:14:22Z".into(),
+            suggestions: None,
         }
     }
 

--- a/crates/aristo-cli/src/commands/canon/session_kind.rs
+++ b/crates/aristo-cli/src/commands/canon/session_kind.rs
@@ -1,0 +1,378 @@
+//! `IntentReviewSession` — the third concrete `SessionKind` impl
+//! (§17 Slice 3).
+//!
+//! The `intent-review` session is the orchestrator's review surface
+//! (D3/D9). Unlike `critique-review` / `proof-review`, which each
+//! review one homogeneous artifact, this session carries **two item
+//! types**:
+//!
+//! - **Primary match** (`match:<annotation-id>#<canon-id>`) — a pending
+//!   match the user's own annotation produced, living in
+//!   `canon-matches.toml`. Accept rewrites the annotation to canonical +
+//!   binds (reuse `canon::accept`); reject fingerprints the `canon_id`.
+//! - **Suggestion cluster** (`cluster:<key>`) + its **siblings**
+//!   (`sibling:<key>#<canon-id>`) — the dragged-in proof-objective
+//!   cluster queued by the matcher (Slice 2). The **parent is decided
+//!   first** (D6): accepting the parent opens its siblings for individual
+//!   decision; **rejecting the parent discards the cluster's DRAGGED-IN
+//!   siblings only — any member that independently matched on its own
+//!   (is/became a primary, or is already bound) is KEPT** in the normal
+//!   accept/reject flow.
+//!
+//! ## Adoption goes through the existing write path (D4)
+//!
+//! Accepting a cluster parent or a sibling does **not** mutate source
+//! here. Adoption funnels back through `agent writes #[aristo::intent]
+//! → aristo stamp → aristo canon accept` (the skill, Slice 4). So the
+//! per-kind `on_accept` for clusters/siblings is a validating no-op at
+//! the file level; the session's closed-state audit trail captures the
+//! decision. Only the **primary match** `on_accept` performs an
+//! immediate rewrite+bind (the annotation already exists — accept
+//! rewrites it).
+
+use aristo_core::canon::cache::CanonMatchesFile;
+
+use crate::commands::canon::{accept, suggestions};
+use crate::session::kind::SessionKind;
+use crate::session::rejections::{self, RejectionEntry};
+use crate::session::types::{ItemRef, NestingPolicy};
+use crate::workspace::Workspace;
+use crate::{CliError, CliResult};
+
+/// Concrete kind for the §17 intent-review loop (primary matches +
+/// suggestion clusters).
+pub struct IntentReviewSession;
+
+/// Parsed shape of an `intent-review` item ref. The substrate stores
+/// opaque ref strings; this kind owns the grammar.
+enum IntentItem {
+    /// A pending primary match: `match:<annotation-id>#<canon-id>`.
+    Match {
+        annotation_id: String,
+        canon_id: String,
+    },
+    /// A cluster's parent (objective) decision: `cluster:<key>`.
+    Cluster { key: String },
+    /// A dragged-in sibling within a cluster: `sibling:<key>#<canon-id>`.
+    Sibling { key: String, canon_id: String },
+}
+
+impl IntentItem {
+    fn parse(item_ref: &ItemRef) -> CliResult<Self> {
+        let s = item_ref.as_str();
+        if let Some(rest) = s.strip_prefix("match:") {
+            let (annotation_id, canon_id) =
+                rest.rsplit_once('#').ok_or_else(|| bad_ref(item_ref))?;
+            return Ok(IntentItem::Match {
+                annotation_id: annotation_id.to_string(),
+                canon_id: canon_id.to_string(),
+            });
+        }
+        if let Some(rest) = s.strip_prefix("sibling:") {
+            let (key, canon_id) = rest.rsplit_once('#').ok_or_else(|| bad_ref(item_ref))?;
+            return Ok(IntentItem::Sibling {
+                key: key.to_string(),
+                canon_id: canon_id.to_string(),
+            });
+        }
+        if let Some(key) = s.strip_prefix("cluster:") {
+            return Ok(IntentItem::Cluster {
+                key: key.to_string(),
+            });
+        }
+        Err(bad_ref(item_ref))
+    }
+}
+
+fn bad_ref(item_ref: &ItemRef) -> CliError {
+    CliError::Other {
+        message: format!(
+            "intent-review item ref `{item_ref}` is not in `match:<id>#<canon-id>`, \
+             `cluster:<key>`, or `sibling:<key>#<canon-id>` form"
+        ),
+        exit_code: 2,
+    }
+}
+
+impl SessionKind for IntentReviewSession {
+    fn name(&self) -> &'static str {
+        suggestions::INTENT_REVIEW_KIND
+    }
+
+    fn nesting_policy(&self) -> NestingPolicy {
+        NestingPolicy::Disallow
+    }
+
+    fn on_accept(&self, item_ref: &ItemRef, _note: Option<&str>, ws: &Workspace) -> CliResult<()> {
+        match IntentItem::parse(item_ref)? {
+            // Stage A: the user's own annotation already exists — accept
+            // rewrites it to canonical + binds (reuse canon::accept).
+            IntentItem::Match {
+                annotation_id,
+                canon_id,
+            } => {
+                let now = now_rfc3339();
+                accept::apply_acceptance(ws, &annotation_id, &canon_id, &now)
+            }
+            // Stage B: adopting a cluster parent / sibling writes a NEW
+            // annotation through `stamp → canon accept` (the skill, D4).
+            // No file-level mutation here — validate the cluster exists
+            // so the audit-trail "accepted" line is meaningful.
+            IntentItem::Cluster { key } => {
+                validate_cluster_exists(ws, &key)?;
+                Ok(())
+            }
+            IntentItem::Sibling { key, canon_id } => {
+                validate_sibling_exists(ws, &key, &canon_id)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn on_reject(
+        &self,
+        item_ref: &ItemRef,
+        note: Option<&str>,
+        ws: &Workspace,
+    ) -> CliResult<serde_json::Value> {
+        match IntentItem::parse(item_ref)? {
+            // Primary / sibling reject: fingerprint the bare canon_id so
+            // dedup ②/④ suppress it on future runs.
+            IntentItem::Match { canon_id, .. } => {
+                Ok(suggestions::rejection_fingerprint(&canon_id))
+            }
+            IntentItem::Sibling { canon_id, .. } => {
+                Ok(suggestions::rejection_fingerprint(&canon_id))
+            }
+            // Parent reject: the load-bearing D6 cascade. Discard the
+            // cluster's DRAGGED-IN siblings only, KEEPING any member that
+            // independently matched (bound in the index, or pending /
+            // accepted in the cache). Fingerprints for the discarded
+            // members so they don't re-surface.
+            IntentItem::Cluster { key } => {
+                let obj_canon_id = discard_dragged_in_only(ws, &key, note)?;
+                Ok(suggestions::rejection_fingerprint(&obj_canon_id))
+            }
+        }
+    }
+
+    fn on_pending(
+        &self,
+        item_ref: &ItemRef,
+        _note: Option<&str>,
+        _ws: &Workspace,
+    ) -> CliResult<serde_json::Value> {
+        // Backlog snapshot — enough to render the deferred item without
+        // re-running the match. Avoid serde_json::Value::Null in any
+        // field (the substrate's backlog serializer is TOML, which has
+        // no null type).
+        match IntentItem::parse(item_ref)? {
+            IntentItem::Match {
+                annotation_id,
+                canon_id,
+            } => Ok(serde_json::json!({
+                "kind": "match",
+                "annotation_id": annotation_id,
+                "canon_id": canon_id,
+            })),
+            IntentItem::Cluster { key } => Ok(serde_json::json!({
+                "kind": "cluster",
+                "objective": key,
+            })),
+            IntentItem::Sibling { key, canon_id } => Ok(serde_json::json!({
+                "kind": "sibling",
+                "objective": key,
+                "canon_id": canon_id,
+            })),
+        }
+    }
+
+    fn matches_prior_rejection(
+        &self,
+        item_ref: &ItemRef,
+        prior_fingerprint: &serde_json::Value,
+    ) -> bool {
+        // The fingerprint is the bare canon_id; "same suggestion" ⇔ same
+        // canon_id. Matches against match / sibling refs (cluster parents
+        // are decided per-run, not auto-suppressed).
+        let Ok(item) = IntentItem::parse(item_ref) else {
+            return false;
+        };
+        let canon_id = match item {
+            IntentItem::Match { canon_id, .. } | IntentItem::Sibling { canon_id, .. } => canon_id,
+            IntentItem::Cluster { .. } => return false,
+        };
+        prior_fingerprint.as_str() == Some(canon_id.as_str())
+    }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+/// D6 — reject the cluster's parent. Discard the DRAGGED-IN siblings
+/// only; KEEP any member that is independently held (bound in the index,
+/// or pending / accepted in the cache). Returns the rejected objective's
+/// canon_id (for the substrate's rejection-log fingerprint).
+///
+/// The discarded members are fingerprinted into the rejection log so
+/// they stay suppressed; the kept members are spliced back into a
+/// rewritten task (or, if every member survives, the task is left
+/// intact). When nothing survives, the task file is removed entirely.
+fn discard_dragged_in_only(ws: &Workspace, key: &str, note: Option<&str>) -> CliResult<String> {
+    let (mut task, path) =
+        suggestions::find_task_by_key(ws, key)?.ok_or_else(|| CliError::Other {
+            message: format!(
+                "no queued suggestion cluster `{key}` to reject.\n\
+                 hint: list clusters with `aristo canon suggestions`."
+            ),
+            exit_code: 2,
+        })?;
+
+    let obj_canon_id = task.key().to_string();
+    let cache = CanonMatchesFile::read(&ws.canon_matches_path()).map_err(CliError::Io)?;
+    let now = now_rfc3339();
+
+    let mut kept = Vec::new();
+    let mut discarded = Vec::new();
+    for sibling in std::mem::take(&mut task.siblings) {
+        if suggestions::member_independently_held(ws, &cache, &sibling.canon_id)? {
+            // Independently asserted — never discard it (D6).
+            kept.push(sibling);
+        } else {
+            discarded.push(sibling);
+        }
+    }
+
+    // Fingerprint each discarded member so it doesn't re-surface.
+    for sibling in &discarded {
+        rejections::append(
+            ws,
+            &RejectionEntry {
+                ts: now.clone(),
+                kind: suggestions::INTENT_REVIEW_KIND.to_string(),
+                item_ref: suggestions::rejection_item_ref(&sibling.canon_id),
+                note: note.map(str::to_string),
+                fingerprint: suggestions::rejection_fingerprint(&sibling.canon_id),
+            },
+        )?;
+    }
+
+    if kept.is_empty() {
+        // Nothing the user independently holds — drop the whole task.
+        std::fs::remove_file(&path).map_err(CliError::Io)?;
+    } else {
+        // Splice the surviving (independently-held) members back and
+        // rewrite the task in place. The objective is dropped — the
+        // parent was rejected — so the kept members keep their own
+        // accept/reject flow keyed by the seeding primary.
+        task.siblings = kept;
+        task.objective = None;
+        let toml_text = toml::to_string_pretty(&task).map_err(|e| CliError::Other {
+            message: format!("serialize suggestion task: {e}"),
+            exit_code: 1,
+        })?;
+        std::fs::write(&path, toml_text).map_err(CliError::Io)?;
+    }
+
+    Ok(obj_canon_id)
+}
+
+/// Validate that a cluster with `key` is queued (so an accept's audit
+/// line is meaningful). Returns an actionable error otherwise.
+fn validate_cluster_exists(ws: &Workspace, key: &str) -> CliResult<()> {
+    suggestions::find_task_by_key(ws, key)?
+        .map(|_| ())
+        .ok_or_else(|| CliError::Other {
+            message: format!(
+                "no queued suggestion cluster `{key}`.\n\
+                 hint: list clusters with `aristo canon suggestions`."
+            ),
+            exit_code: 2,
+        })
+}
+
+/// Validate that `canon_id` is a sibling of the queued cluster `key`.
+fn validate_sibling_exists(ws: &Workspace, key: &str, canon_id: &str) -> CliResult<()> {
+    let (task, _) = suggestions::find_task_by_key(ws, key)?.ok_or_else(|| CliError::Other {
+        message: format!("no queued suggestion cluster `{key}`."),
+        exit_code: 2,
+    })?;
+    if task.siblings.iter().any(|s| s.canon_id == canon_id) {
+        Ok(())
+    } else {
+        Err(CliError::Other {
+            message: format!("cluster `{key}` has no sibling `{canon_id}`."),
+            exit_code: 2,
+        })
+    }
+}
+
+fn now_rfc3339() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is post-1970");
+    crate::session::id_gen::format_rfc3339(now.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_match_cluster_and_sibling_refs() {
+        // Match: the canon_id is the LAST `#`-segment; annotation ids may
+        // themselves contain `:` (e.g. aristos:foo).
+        match IntentItem::parse(&ItemRef::from_opaque("match:aristos:foo#some_canon")).unwrap() {
+            IntentItem::Match {
+                annotation_id,
+                canon_id,
+            } => {
+                assert_eq!(annotation_id, "aristos:foo");
+                assert_eq!(canon_id, "some_canon");
+            }
+            _ => panic!("expected Match"),
+        }
+        match IntentItem::parse(&ItemRef::from_opaque("cluster:wal_protocol")).unwrap() {
+            IntentItem::Cluster { key } => assert_eq!(key, "wal_protocol"),
+            _ => panic!("expected Cluster"),
+        }
+        match IntentItem::parse(&ItemRef::from_opaque("sibling:wal_protocol#wal_find")).unwrap() {
+            IntentItem::Sibling { key, canon_id } => {
+                assert_eq!(key, "wal_protocol");
+                assert_eq!(canon_id, "wal_find");
+            }
+            _ => panic!("expected Sibling"),
+        }
+    }
+
+    #[test]
+    fn rejects_unprefixed_ref() {
+        assert!(IntentItem::parse(&ItemRef::from_opaque("just_an_id")).is_err());
+        // A `cluster:`/`match:` prefix missing the `#` is only invalid for
+        // match/sibling (which need a canon_id).
+        assert!(IntentItem::parse(&ItemRef::from_opaque("match:no_hash")).is_err());
+        assert!(IntentItem::parse(&ItemRef::from_opaque("sibling:no_hash")).is_err());
+    }
+
+    #[test]
+    fn matches_prior_rejection_compares_bare_canon_id() {
+        let kind = IntentReviewSession;
+        let fp = suggestions::rejection_fingerprint("wal_find");
+        // Same canon_id (match or sibling) ⇒ matches.
+        assert!(kind.matches_prior_rejection(
+            &ItemRef::from_opaque("sibling:obj#wal_find"),
+            &fp,
+        ));
+        assert!(kind.matches_prior_rejection(
+            &ItemRef::from_opaque("match:ann#wal_find"),
+            &fp,
+        ));
+        // Different canon_id ⇒ no match.
+        assert!(!kind.matches_prior_rejection(
+            &ItemRef::from_opaque("sibling:obj#other"),
+            &fp,
+        ));
+        // Cluster parents are decided per-run, never auto-suppressed.
+        assert!(!kind.matches_prior_rejection(&ItemRef::from_opaque("cluster:wal_find"), &fp));
+    }
+}

--- a/crates/aristo-cli/src/commands/canon/suggestions.rs
+++ b/crates/aristo-cli/src/commands/canon/suggestions.rs
@@ -1,0 +1,699 @@
+//! §17 proof-tree suggestions queue + `aristo canon suggestions`.
+//!
+//! The suggestions channel is **parallel** to `canon-matches.toml`: a
+//! primary match keeps its existing accept/reject flow; the proof-tree
+//! siblings dragged in alongside it are queued here for a separate
+//! review pass (the `intent-review` session, Slice 3).
+//!
+//! ## Store
+//!
+//! The queue lives at `.aristo/canon-suggestions-queue/` and reuses the
+//! generic atomic-claim [`pipeline::queue`](crate::pipeline::queue).
+//! **One task = one cluster** (`{ objective?, siblings[] }`) — the
+//! parent-reject cascade (D6) needs the cluster grouped, so the unit of
+//! work is the cluster, not the individual sibling.
+//!
+//! The task is keyed by its **objective** canon_id when present (so
+//! several primaries that roll up to the same objective collapse into
+//! one task — "dedup ③"), else by the seeding primary's `for_canon_id`
+//! (siblings-only / pre-0b mode).
+//!
+//! ## Read paths
+//!
+//! - `aristo canon suggestions` — list the queued clusters (read-only).
+//! - `aristo canon suggestions <objective>` — show one cluster's
+//!   detail.
+//! - `aristo canon suggestions --counts` — machine-readable
+//!   `{matches:{new,pending}, suggestions:{new,pending}}` for the
+//!   menu/skill entry Q&A (§6A).
+
+use serde::{Deserialize, Serialize};
+
+use aristo_core::canon::cache::CanonMatchesFile;
+use aristo_core::canon::{ClusterSuggestion, Disposition, PrefixTier, SuggestedEntry};
+use aristo_core::index::AnnotationId;
+
+use crate::commands::index::workspace_or_error;
+use crate::filter::Filter;
+use crate::pipeline::queue::{self, QueueDir};
+use crate::session::types::ItemRef;
+use crate::{CliError, CliResult, Workspace};
+
+/// Pipeline name for the suggestions queue (under `.aristo/`).
+pub(crate) const PIPELINE: &str = "canon-suggestions";
+
+/// One queued proof-objective cluster awaiting review.
+///
+/// Mirrors a [`ClusterSuggestion`] from the wire, lifted into the
+/// client store: the objective + siblings become [`SuggestedMatch`]es
+/// (entry fields + a local [`Disposition`]), and the task records which
+/// primaries dragged this cluster in (`for_canon_ids`, plural because
+/// dedup ③ may collapse several into one).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SuggestionTask {
+    /// The primary matched canon_ids whose clusters collapsed into this
+    /// task (dedup ③). At least one; more when several primaries in a
+    /// batch share an objective.
+    pub for_canon_ids: Vec<String>,
+    /// The kanon: proof-objective parent. `None` in siblings-only mode
+    /// (pre-Slice-0b — no objective entry authored yet).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub objective: Option<SuggestedMatch>,
+    /// The co-member leaf suggestions, after dedup ② filtering.
+    pub siblings: Vec<SuggestedMatch>,
+    /// RFC 3339 timestamp the cluster was first queued.
+    pub discovered_at: String,
+}
+
+/// A suggested canon entry in the queue — entry fields carried verbatim
+/// from the wire [`SuggestedEntry`], plus a local review [`Disposition`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SuggestedMatch {
+    pub canon_id: String,
+    pub version: String,
+    pub canonical_text: String,
+    pub scope: String,
+    pub prefix_tier: PrefixTier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backed_by: Option<String>,
+    /// Review state — `"open"` until the user decides in `intent-review`.
+    pub disposition: Disposition,
+}
+
+impl SuggestedMatch {
+    fn from_entry(entry: &SuggestedEntry) -> Self {
+        Self {
+            canon_id: entry.canon_id.clone(),
+            version: entry.version.clone(),
+            canonical_text: entry.canonical_text.clone(),
+            scope: entry.scope.clone(),
+            prefix_tier: entry.prefix_tier,
+            backed_by: entry.backed_by.clone(),
+            disposition: Disposition::Open,
+        }
+    }
+}
+
+impl SuggestionTask {
+    /// The task's stable queue key: the objective canon_id when present,
+    /// else the seeding primary's id. Dedup ③ collapses clusters that
+    /// share an objective by sharing this key.
+    pub(crate) fn key(&self) -> &str {
+        match &self.objective {
+            Some(obj) => &obj.canon_id,
+            None => self
+                .for_canon_ids
+                .first()
+                .map(String::as_str)
+                .unwrap_or(""),
+        }
+    }
+
+    /// Build a task from a wire [`ClusterSuggestion`]. Siblings are
+    /// taken verbatim (dedup ② is applied by the caller before this).
+    fn from_cluster(cluster: &ClusterSuggestion, siblings: &[SuggestedEntry], now: &str) -> Self {
+        Self {
+            for_canon_ids: vec![cluster.for_canon_id.clone()],
+            objective: cluster.objective.as_ref().map(SuggestedMatch::from_entry),
+            siblings: siblings.iter().map(SuggestedMatch::from_entry).collect(),
+            discovered_at: now.to_string(),
+        }
+    }
+}
+
+// ─── Merge routing (dedup ②③) ─────────────────────────────────────────────
+
+/// Set of canon_ids the client already "knows about" — used by dedup ②
+/// to drop suggestions the user has already bound, surfaced, or rejected.
+pub(crate) struct LocalState {
+    /// canon_ids bound in the index (`aristos:`/`kanon:` entries).
+    pub bound: std::collections::BTreeSet<String>,
+    /// canon_ids pending or accepted in `canon-matches.toml`.
+    pub in_cache: std::collections::BTreeSet<String>,
+    /// canon_ids fingerprinted in the rejection log.
+    pub rejected: std::collections::BTreeSet<String>,
+}
+
+impl LocalState {
+    fn contains(&self, canon_id: &str) -> bool {
+        self.bound.contains(canon_id)
+            || self.in_cache.contains(canon_id)
+            || self.rejected.contains(canon_id)
+    }
+}
+
+/// Filter a wire cluster's siblings + objective through dedup ②: drop
+/// any member already bound in the index, pending/accepted in the cache,
+/// or in the rejection log. Returns the surviving sibling entries (the
+/// objective is kept regardless — its adoption is decided in-session).
+fn dedup_two<'a>(cluster: &'a ClusterSuggestion, local: &LocalState) -> Vec<&'a SuggestedEntry> {
+    cluster
+        .siblings
+        .iter()
+        .filter(|s| !local.contains(&s.canon_id))
+        .collect()
+}
+
+/// Route a match response's `suggestions` into the queue, applying
+/// dedup ② (vs local state) and dedup ③ (collapse-by-objective).
+///
+/// Returns the number of distinct cluster tasks written. A cluster whose
+/// siblings are entirely consumed by dedup ② and that has no objective
+/// is dropped (nothing actionable to review).
+pub(crate) fn route_suggestions_into_queue(
+    qdir: &QueueDir,
+    suggestions: &[Option<ClusterSuggestion>],
+    local: &LocalState,
+    now: &str,
+) -> CliResult<usize> {
+    // Dedup ③: collapse clusters that share an objective into one task,
+    // keyed by the task key (objective canon_id, else seeding primary).
+    let mut tasks: std::collections::BTreeMap<String, SuggestionTask> =
+        std::collections::BTreeMap::new();
+
+    for cluster in suggestions.iter().flatten() {
+        // Dedup ② — drop already-known siblings.
+        let siblings: Vec<&SuggestedEntry> = dedup_two(cluster, local);
+        // Nothing left to review for this cluster: no surviving siblings
+        // and no objective to adopt.
+        if siblings.is_empty() && cluster.objective.is_none() {
+            continue;
+        }
+
+        let owned: Vec<SuggestedEntry> = siblings.into_iter().cloned().collect();
+        let task = SuggestionTask::from_cluster(cluster, &owned, now);
+        let key = task.key().to_string();
+
+        match tasks.get_mut(&key) {
+            Some(existing) => {
+                // Collapse: merge the seeding primary + any new siblings.
+                if !existing.for_canon_ids.contains(&cluster.for_canon_id) {
+                    existing.for_canon_ids.push(cluster.for_canon_id.clone());
+                }
+                for s in task.siblings {
+                    if !existing.siblings.iter().any(|e| e.canon_id == s.canon_id) {
+                        existing.siblings.push(s);
+                    }
+                }
+            }
+            None => {
+                tasks.insert(key, task);
+            }
+        }
+    }
+
+    qdir.ensure_dirs()?;
+    let mut written = 0usize;
+    for (key, task) in tasks {
+        let id = AnnotationId::parse(&key).map_err(|e| CliError::Other {
+            message: format!("suggestion cluster key `{key}` is not a valid id: {e}"),
+            exit_code: 1,
+        })?;
+        let toml_text = toml::to_string_pretty(&task).map_err(|e| CliError::Other {
+            message: format!("serialize suggestion task: {e}"),
+            exit_code: 1,
+        })?;
+        queue::enqueue(qdir, &id, &toml_text)?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+/// Build [`LocalState`] from the workspace: index bindings, cache
+/// pending/accepted, and the shared rejection log (intent-review kind).
+pub(crate) fn local_state(ws: &Workspace, cache: &CanonMatchesFile) -> CliResult<LocalState> {
+    use std::collections::BTreeSet;
+
+    // Index-bound canon_ids — strip the prefix to get the bare canon_id.
+    let mut bound = BTreeSet::new();
+    let index_path = ws.index_path();
+    if index_path.is_file() {
+        let raw = std::fs::read_to_string(&index_path).map_err(CliError::Io)?;
+        if let Ok(index) = toml::from_str::<aristo_core::index::IndexFile>(&raw) {
+            for id in index.entries.keys() {
+                if id.is_canon_bound() {
+                    let bare = id
+                        .as_str()
+                        .strip_prefix("aristos:")
+                        .or_else(|| id.as_str().strip_prefix("kanon:"))
+                        .unwrap_or(id.as_str());
+                    bound.insert(bare.to_string());
+                }
+            }
+        }
+    }
+
+    // Cache pending + accepted canon_ids.
+    let mut in_cache = BTreeSet::new();
+    for entry in cache.entries.values() {
+        for m in &entry.pending_matches {
+            in_cache.insert(m.canon_id.clone());
+        }
+        for m in &entry.accepted_matches {
+            in_cache.insert(m.canon_id.clone());
+        }
+    }
+
+    // Rejection-log fingerprints for the intent-review kind. The
+    // fingerprint is the bare canon_id (string).
+    let mut rejected = BTreeSet::new();
+    for entry in crate::session::rejections::read_for_kind(ws, INTENT_REVIEW_KIND)? {
+        if let Some(canon_id) = entry.fingerprint.as_str() {
+            rejected.insert(canon_id.to_string());
+        }
+    }
+
+    Ok(LocalState {
+        bound,
+        in_cache,
+        rejected,
+    })
+}
+
+/// Session kind that owns the suggestions rejection fingerprints.
+/// Matches the kind registered in Slice 3 (`session/kind.rs`).
+pub(crate) const INTENT_REVIEW_KIND: &str = "intent-review";
+
+// ─── Read commands ─────────────────────────────────────────────────────────
+
+/// Counts surfaced at the menu / session entry (§6A, D9).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Counts {
+    matches: Bucket,
+    suggestions: Bucket,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Bucket {
+    /// Items first surfaced this run (queued/pending, not yet reviewed).
+    new: usize,
+    /// Items carried over from prior runs (still open).
+    pending: usize,
+}
+
+/// `aristo canon suggestions [<objective>] [--counts] [--filter ...]`.
+pub(crate) fn run(objective: Option<String>, counts: bool, filter: Vec<Filter>) -> CliResult<()> {
+    let ws = workspace_or_error()?;
+    if counts {
+        return run_counts(&ws);
+    }
+    match objective {
+        Some(obj) => run_show(&ws, &obj),
+        None => run_list(&ws, &filter),
+    }
+}
+
+/// Strip an `aristos:` / `kanon:` prefix so a `--filter parent=<id>`
+/// value (which may carry the tier prefix, e.g. the §6B `cluster
+/// <objective>` recipe `parent=kanon:wal_protocol_correctness`) matches
+/// the bare cluster key.
+fn bare(id: &str) -> &str {
+    id.strip_prefix("aristos:")
+        .or_else(|| id.strip_prefix("kanon:"))
+        .unwrap_or(id)
+}
+
+/// Does this cluster task pass every `--filter` clause? Only `parent=`
+/// is meaningful for the suggestions queue — it scopes to one cluster by
+/// objective key (the §6B `cluster <objective>` mode). Other keys
+/// (`id=`/`file=`/`status=`) don't apply to a clusterized queue and pass
+/// through (the seeding/match stages honor them). Clauses AND together.
+fn task_passes_filter(task: &SuggestionTask, filter: &[Filter]) -> bool {
+    filter.iter().all(|f| match f {
+        Filter::Parent(p) => task.key() == bare(p),
+        _ => true,
+    })
+}
+
+fn read_all_tasks(ws: &Workspace) -> CliResult<Vec<SuggestionTask>> {
+    Ok(read_all_tasks_with_paths(ws)?
+        .into_iter()
+        .map(|(t, _)| t)
+        .collect())
+}
+
+/// Like [`read_all_tasks`] but pairs each task with its on-disk path, so
+/// the intent-review session (Slice 3) can rewrite or remove a specific
+/// cluster task after the parent-reject cascade (D6).
+pub(crate) fn read_all_tasks_with_paths(
+    ws: &Workspace,
+) -> CliResult<Vec<(SuggestionTask, std::path::PathBuf)>> {
+    let qdir = QueueDir::for_pipeline(ws, PIPELINE);
+    let mut out = Vec::new();
+    for dir in [qdir.pending_dir(), qdir.claimed_dir()] {
+        if !dir.is_dir() {
+            continue;
+        }
+        let mut paths: Vec<_> = std::fs::read_dir(&dir)?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.is_file())
+            .collect();
+        paths.sort();
+        for p in paths {
+            let raw = std::fs::read_to_string(&p).map_err(CliError::Io)?;
+            let task: SuggestionTask = toml::from_str(&raw).map_err(|e| CliError::Other {
+                message: format!("parse suggestion task {}: {e}", p.display()),
+                exit_code: 1,
+            })?;
+            out.push((task, p));
+        }
+    }
+    Ok(out)
+}
+
+/// Find one queued cluster task by its key (objective canon_id, else
+/// seeding primary), returning the task and its on-disk path.
+pub(crate) fn find_task_by_key(
+    ws: &Workspace,
+    key: &str,
+) -> CliResult<Option<(SuggestionTask, std::path::PathBuf)>> {
+    Ok(read_all_tasks_with_paths(ws)?
+        .into_iter()
+        .find(|(t, _)| t.key() == key))
+}
+
+/// True iff `canon_id` is held by an *independent* primary match or
+/// binding — i.e. it appears bound in the index, or pending/accepted in
+/// `canon-matches.toml`. This is the D6 guard: a dragged-in sibling that
+/// the user has independently asserted (or accepted in Stage A) must NOT
+/// be discarded when its cluster's parent is rejected.
+pub(crate) fn member_independently_held(
+    ws: &Workspace,
+    cache: &CanonMatchesFile,
+    canon_id: &str,
+) -> CliResult<bool> {
+    let local = local_state(ws, cache)?;
+    // `bound` (index) and `in_cache` (pending/accepted) are the
+    // "independently asserted" signals. `rejected` is NOT — a member the
+    // user already rejected has no independent assertion to protect.
+    Ok(local.bound.contains(canon_id) || local.in_cache.contains(canon_id))
+}
+
+fn run_list(ws: &Workspace, filter: &[Filter]) -> CliResult<()> {
+    let tasks: Vec<SuggestionTask> = read_all_tasks(ws)?
+        .into_iter()
+        .filter(|t| task_passes_filter(t, filter))
+        .collect();
+    if tasks.is_empty() {
+        println!(
+            "ok: no proof-tree suggestions queued. Run `aristo stamp` (signed in) \
+             to populate the queue."
+        );
+        return Ok(());
+    }
+    println!("proof-tree suggestions ({} cluster(s)):", tasks.len());
+    for task in &tasks {
+        let obj = task
+            .objective
+            .as_ref()
+            .map(|o| o.canon_id.as_str())
+            .unwrap_or("(siblings-only — no objective yet)");
+        println!(
+            "  {obj}  ({} sibling(s), for {})",
+            task.siblings.len(),
+            task.for_canon_ids.join(", ")
+        );
+    }
+    println!();
+    println!(
+        "review with `aristo session start intent-review`, or inspect one with \
+         `aristo canon suggestions <objective>`."
+    );
+    Ok(())
+}
+
+fn run_show(ws: &Workspace, objective: &str) -> CliResult<()> {
+    let tasks = read_all_tasks(ws)?;
+    let task = tasks
+        .iter()
+        .find(|t| t.key() == objective)
+        .ok_or_else(|| CliError::Other {
+            message: format!(
+                "no queued suggestion cluster `{objective}`.\n\
+                 hint: list clusters with `aristo canon suggestions`."
+            ),
+            exit_code: 1,
+        })?;
+
+    match &task.objective {
+        Some(obj) => {
+            println!("objective: {} {} ({} tier)", obj.canon_id, obj.version, obj.prefix_tier.as_prefix());
+            println!("  {}", obj.canonical_text);
+        }
+        None => println!("objective: (siblings-only — no objective entry yet)"),
+    }
+    println!("dragged in by: {}", task.for_canon_ids.join(", "));
+    println!("siblings ({}):", task.siblings.len());
+    for s in &task.siblings {
+        println!(
+            "  {} {} ({} tier)",
+            s.canon_id,
+            s.version,
+            s.prefix_tier.as_prefix()
+        );
+        println!("    {}", s.canonical_text);
+        if let Some(backed_by) = &s.backed_by {
+            println!("    backed by: {backed_by}");
+        }
+    }
+    println!();
+    println!("card detail for any entry: `aristo canon show <canon_id>`.");
+    Ok(())
+}
+
+fn run_counts(ws: &Workspace) -> CliResult<()> {
+    let cache_path = ws.canon_matches_path();
+    let cache = CanonMatchesFile::read(&cache_path).map_err(CliError::Io)?;
+
+    // Matches: pending = open primary matches in the cache. We don't
+    // distinguish new-vs-carried here (no prior snapshot to diff
+    // against in the read-only path), so everything open is "pending"
+    // and "new" is 0 — Slice 3's session seeding does the new/carried
+    // split. Reported here for the menu's at-a-glance count.
+    let mut match_pending = 0usize;
+    for entry in cache.entries.values() {
+        for m in &entry.pending_matches {
+            if matches!(m.disposition, Disposition::Open) {
+                match_pending += 1;
+            }
+        }
+    }
+
+    let tasks = read_all_tasks(ws)?;
+    let qdir = QueueDir::for_pipeline(ws, PIPELINE);
+    let pending_in_queue = if qdir.pending_dir().is_dir() {
+        std::fs::read_dir(qdir.pending_dir())?
+            .filter_map(Result::ok)
+            .filter(|e| e.path().is_file())
+            .count()
+    } else {
+        0
+    };
+    let claimed_in_queue = tasks.len().saturating_sub(pending_in_queue);
+
+    let counts = Counts {
+        matches: Bucket {
+            new: 0,
+            pending: match_pending,
+        },
+        suggestions: Bucket {
+            new: pending_in_queue,
+            pending: claimed_in_queue,
+        },
+    };
+    println!(
+        "{}",
+        serde_json::to_string(&counts).map_err(|e| CliError::Other {
+            message: format!("serialize counts: {e}"),
+            exit_code: 1,
+        })?
+    );
+    Ok(())
+}
+
+/// Build a rejection-log fingerprint for a suggested canon entry. The
+/// fingerprint is the bare canon_id (a JSON string); dedup ② / ④ match
+/// on it. Co-located here so the producer (the intent-review reject
+/// path) and the consumer ([`local_state`]) agree on the shape.
+pub(crate) fn rejection_fingerprint(canon_id: &str) -> serde_json::Value {
+    serde_json::Value::String(canon_id.to_string())
+}
+
+pub(crate) fn rejection_item_ref(canon_id: &str) -> ItemRef {
+    ItemRef::from_opaque(canon_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aristo_core::canon::{Relationship, SuggestedEntry, VerificationMetadata};
+    use std::collections::BTreeSet;
+
+    fn entry(canon_id: &str, rel: Relationship, tier: PrefixTier) -> SuggestedEntry {
+        SuggestedEntry {
+            canon_id: canon_id.into(),
+            version: "v0.1.0".into(),
+            canonical_text: format!("text for {canon_id}"),
+            scope: "turso".into(),
+            prefix_tier: tier,
+            backed_by: match tier {
+                PrefixTier::Aristos => Some("golden model + proofs".into()),
+                PrefixTier::Kanon => None,
+            },
+            verification: VerificationMetadata::default(),
+            relationship: rel,
+        }
+    }
+
+    fn cluster(primary: &str, objective: Option<&str>, siblings: &[&str]) -> ClusterSuggestion {
+        ClusterSuggestion {
+            for_canon_id: primary.into(),
+            objective: objective.map(|o| entry(o, Relationship::Parent, PrefixTier::Kanon)),
+            siblings: siblings
+                .iter()
+                .map(|s| entry(s, Relationship::Sibling, PrefixTier::Aristos))
+                .collect(),
+        }
+    }
+
+    fn empty_local() -> LocalState {
+        LocalState {
+            bound: BTreeSet::new(),
+            in_cache: BTreeSet::new(),
+            rejected: BTreeSet::new(),
+        }
+    }
+
+    fn fresh_qdir() -> (tempfile::TempDir, QueueDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = Workspace {
+            root: tmp.path().to_path_buf(),
+        };
+        let qdir = QueueDir::for_pipeline(&ws, PIPELINE);
+        (tmp, qdir)
+    }
+
+    fn read_queue(qdir: &QueueDir) -> Vec<SuggestionTask> {
+        let mut out = Vec::new();
+        let mut paths: Vec<_> = std::fs::read_dir(qdir.pending_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .collect();
+        paths.sort();
+        for p in paths {
+            let raw = std::fs::read_to_string(p).unwrap();
+            out.push(toml::from_str::<SuggestionTask>(&raw).unwrap());
+        }
+        out
+    }
+
+    #[test]
+    fn route_writes_one_task_per_cluster() {
+        let (_tmp, qdir) = fresh_qdir();
+        let suggestions = vec![Some(cluster("p1", Some("obj_a"), &["s1", "s2"]))];
+        let n =
+            route_suggestions_into_queue(&qdir, &suggestions, &empty_local(), "2026-06-05T00:00:00Z")
+                .unwrap();
+        assert_eq!(n, 1);
+        let tasks = read_queue(&qdir);
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].objective.as_ref().unwrap().canon_id, "obj_a");
+        assert_eq!(tasks[0].siblings.len(), 2);
+        assert_eq!(tasks[0].for_canon_ids, vec!["p1"]);
+    }
+
+    #[test]
+    fn dedup_two_drops_bound_pending_and_rejected_members() {
+        let (_tmp, qdir) = fresh_qdir();
+        let mut local = empty_local();
+        local.bound.insert("s1".into()); // already bound in index
+        local.in_cache.insert("s2".into()); // already pending/accepted
+        local.rejected.insert("s3".into()); // in the rejection log
+        let suggestions = vec![Some(cluster(
+            "p1",
+            Some("obj_a"),
+            &["s1", "s2", "s3", "s4"],
+        ))];
+        route_suggestions_into_queue(&qdir, &suggestions, &local, "2026-06-05T00:00:00Z").unwrap();
+        let tasks = read_queue(&qdir);
+        assert_eq!(tasks.len(), 1);
+        // Only s4 survives dedup ②.
+        let surviving: Vec<&str> = tasks[0].siblings.iter().map(|s| s.canon_id.as_str()).collect();
+        assert_eq!(surviving, vec!["s4"]);
+    }
+
+    #[test]
+    fn dedup_three_collapses_clusters_sharing_an_objective() {
+        let (_tmp, qdir) = fresh_qdir();
+        // Two primaries (p1, p2) both roll up to obj_a, with disjoint
+        // siblings → must collapse into ONE task.
+        let suggestions = vec![
+            Some(cluster("p1", Some("obj_a"), &["s1", "s2"])),
+            Some(cluster("p2", Some("obj_a"), &["s2", "s3"])),
+        ];
+        let n =
+            route_suggestions_into_queue(&qdir, &suggestions, &empty_local(), "2026-06-05T00:00:00Z")
+                .unwrap();
+        assert_eq!(n, 1, "two primaries, same objective → one task");
+        let tasks = read_queue(&qdir);
+        assert_eq!(tasks.len(), 1);
+        let mut ids: Vec<&str> = tasks[0].siblings.iter().map(|s| s.canon_id.as_str()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["s1", "s2", "s3"], "siblings union, deduped");
+        let mut primaries = tasks[0].for_canon_ids.clone();
+        primaries.sort();
+        assert_eq!(primaries, vec!["p1", "p2"]);
+    }
+
+    #[test]
+    fn distinct_objectives_stay_separate_tasks() {
+        let (_tmp, qdir) = fresh_qdir();
+        let suggestions = vec![
+            Some(cluster("p1", Some("obj_a"), &["s1"])),
+            Some(cluster("p2", Some("obj_b"), &["s2"])),
+        ];
+        let n =
+            route_suggestions_into_queue(&qdir, &suggestions, &empty_local(), "2026-06-05T00:00:00Z")
+                .unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn cluster_fully_consumed_by_dedup_and_no_objective_is_dropped() {
+        let (_tmp, qdir) = fresh_qdir();
+        let mut local = empty_local();
+        local.bound.insert("s1".into());
+        // siblings-only cluster (no objective); its single sibling is
+        // already bound → nothing to review → dropped entirely.
+        let suggestions = vec![Some(cluster("p1", None, &["s1"]))];
+        let n =
+            route_suggestions_into_queue(&qdir, &suggestions, &local, "2026-06-05T00:00:00Z")
+                .unwrap();
+        assert_eq!(n, 0);
+        assert!(read_queue(&qdir).is_empty());
+    }
+
+    #[test]
+    fn siblings_only_cluster_keyed_by_primary() {
+        let (_tmp, qdir) = fresh_qdir();
+        let suggestions = vec![Some(cluster("p1", None, &["s1"]))];
+        route_suggestions_into_queue(&qdir, &suggestions, &empty_local(), "2026-06-05T00:00:00Z")
+            .unwrap();
+        let tasks = read_queue(&qdir);
+        assert_eq!(tasks.len(), 1);
+        assert!(tasks[0].objective.is_none());
+        assert_eq!(tasks[0].key(), "p1");
+    }
+
+    #[test]
+    fn null_cluster_entries_are_skipped() {
+        let (_tmp, qdir) = fresh_qdir();
+        let suggestions = vec![None, Some(cluster("p1", Some("obj_a"), &["s1"]))];
+        let n =
+            route_suggestions_into_queue(&qdir, &suggestions, &empty_local(), "2026-06-05T00:00:00Z")
+                .unwrap();
+        assert_eq!(n, 1);
+    }
+}

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -696,6 +696,36 @@ pub(crate) enum CanonAction {
     /// re-stamp). Currently diagnostic-only; automatic patch-bump
     /// application is planned.
     Migrate,
+
+    /// List or inspect queued §17 proof-tree suggestions (the related
+    /// canon entries dragged in alongside a primary match). Read-only:
+    /// it does not open a review session or mutate the queue. To review
+    /// and adopt suggestions, run `aristo session start intent-review`.
+    ///
+    /// With no argument, lists every queued cluster. With an
+    /// `<objective>` (the cluster's objective canon_id, or the seeding
+    /// primary id for siblings-only clusters), shows that cluster's
+    /// detail. With `--counts`, emits a machine-readable JSON summary
+    /// `{matches:{new,pending}, suggestions:{new,pending}}` for the
+    /// menu / skill entry Q&A.
+    Suggestions {
+        /// Objective canon_id (or seeding primary id) of the cluster to
+        /// show. Omit to list all queued clusters.
+        objective: Option<String>,
+        /// Emit counts only (`{matches:{...}, suggestions:{...}}`) as
+        /// JSON; no per-cluster detail. Mutually exclusive with
+        /// passing an `<objective>`.
+        #[arg(long = "counts", conflicts_with = "objective")]
+        counts: bool,
+        /// Scope the listing with the shared `--filter` grammar
+        /// (`id=`, `file=[:LO-HI]`, `parent=`, `status=`). The
+        /// `cluster <objective>` mode (§6B) is `--filter
+        /// parent=<kanon:objective>` — it scopes the list to one proof
+        /// cluster (leaves carry `parent=`). Multiple `--filter` flags
+        /// AND together. No new grammar — reuses `filter.rs` verbatim.
+        #[arg(long = "filter", value_name = "KEY=VALUE", conflicts_with = "objective")]
+        filter: Vec<Filter>,
+    },
 }
 
 /// Subcommands under `aristo session`. Each maps to one substrate
@@ -961,6 +991,11 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
                 commands::canon::request_verify::run(&canon_id, notes)
             }
             CanonAction::Migrate => commands::canon::migrate::run(),
+            CanonAction::Suggestions {
+                objective,
+                counts,
+                filter,
+            } => commands::canon::suggestions::run(objective, counts, filter),
         },
     }
 }

--- a/crates/aristo-cli/src/session/kind.rs
+++ b/crates/aristo-cli/src/session/kind.rs
@@ -91,7 +91,7 @@ pub trait SessionKind {
 /// Look up the kind implementation by its wire name. Returns `None`
 /// for unknown kinds — the substrate treats unknown kinds as
 /// substrate-only (no per-kind callbacks fire). Currently registered
-/// kinds: `critique-review`, `proof-review`. Future: `author-review`.
+/// kinds: `critique-review`, `proof-review`, `intent-review`.
 pub fn kind_for(name: &str) -> Option<Box<dyn SessionKind>> {
     match name {
         "critique-review" => Some(Box::new(
@@ -99,6 +99,9 @@ pub fn kind_for(name: &str) -> Option<Box<dyn SessionKind>> {
         )),
         "proof-review" => Some(Box::new(
             crate::commands::verify::session_kind::ProofReviewSession,
+        )),
+        "intent-review" => Some(Box::new(
+            crate::commands::canon::session_kind::IntentReviewSession,
         )),
         _ => None,
     }

--- a/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
+++ b/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
@@ -1,0 +1,290 @@
+---
+name: aristo-intent-suggestions
+description: Orchestrates the §17 proof-tree review loop. A choice-based explorer that (1) initiates the canon match, (2) reviews pending PRIMARY matches (your own annotations), and (3) reviews dragged-in SUGGESTIONS (the sibling invariants of the same proof objective). Drives the user through `AskUserQuestion` menus, finds placement sites, confirms each write, and adopts via the existing `stamp → canon accept` pipeline. All state lands in an `intent-review` session; the SDK is the sole writer.
+sdk_version: {{SDK_VERSION}}
+---
+
+# Aristo intent-suggestions orchestrator
+
+When the user invokes this skill (typically by typing `/aristo-intent-suggestions`, or
+asking to "review canon matches / suggestions", "adopt the related invariants", or "what's
+in the suggestions backlog?"), follow this orchestration exactly.
+
+This skill is a **choice-based explorer**: you drive the user through `AskUserQuestion` menus
+rather than free-form prose. The structure below was playtested and approved (§6A). You never
+write `.aristo/` state files directly — every decision goes through `aristo session decide` and
+every adoption goes through `agent writes #[aristo::intent] → aristo stamp → aristo canon accept`.
+The CLI is the single write path; the agent writes source, the SDK manages state.
+
+The skill is the **orchestrator for the whole loop**, not just a suggestions consumer (D9):
+1. **initiate** the canon match (run the stamp/critique match step),
+2. review **pending PRIMARY matches** — your own annotations the match flagged (new + carried-over),
+3. review **SUGGESTIONS** — the proof-objective cluster dragged in alongside each primary.
+
+## Two channels, one session
+
+- **PRIMARY match** = a pending match for an annotation *you already wrote*. **Accepting it
+  REWRITES** your wording to the canonical text and binds. The item ref is
+  `match:<annotation-id>#<canon-id>`.
+- **SUGGESTION cluster** = the *rest of the proof* the matched entry belongs to — the
+  objective (parent) plus its sibling leaf invariants. **Adopting one ADDS a new annotation**
+  (pure addition; nothing of yours is replaced). Item refs are `cluster:<key>` for the parent
+  and `sibling:<key>#<canon-id>` for each dragged-in sibling.
+
+Both are reviewed inside a single **`intent-review`** session, gated by the single-active-session
+guard.
+
+## Step 0 — check for an active review session (FIRST, BEFORE ANY WORK)
+
+Run `aristo session active`. Three cases:
+
+- **Empty stdout** → no active session; proceed normally.
+- **Stdout shows a session id with `kind: intent-review`** → a prior intent-review session is
+  in flight (e.g., a previous turn that didn't reach exit). Resume it: jump to the ROOT menu
+  (Step 3) with that session id; do NOT re-run the match — the user has unfinished triage first.
+- **Stdout shows a session id with a different `kind` (e.g., `critique-review`, `proof-review`)**
+  → REFUSE. Print: "an aristo `<kind>` session is currently active (id=<id>, subject=<subject>).
+  Exit it first with `aristo session exit` (or `aristo session exit --defer-undecided` to park
+  open items), then re-invoke `/aristo-intent-suggestions`." Stop here. Do not run the match,
+  start a session, or touch state.
+
+This check is Layer 3 of the three-layer enforcement (Layer 1 is the SDK pre-check that refuses
+mutations while a session is active; Layer 2 is the `UserPromptSubmit` hook). Always run it first.
+
+## Step 1 — route to a mode (NL or menu) — §6B
+
+The skill is a **zero-argument slash command** (`/aristo-intent-suggestions`), exactly like
+`/aristo-critique`. There is no `/skill --flag`. A **mode** is reached two ways: (a) the user
+states intent when invoking and you route, or (b) the ROOT menu (Step 3) offers it. Each mode is
+just a **recipe of existing CLI flags** — no new machinery, no new grammar.
+
+| Mode | When the user says… | Recipe (existing primitives) |
+|---|---|---|
+| *(default)* full | (nothing special) | initiate match → Stage A → Stage B |
+| **backlog** | "just the backlog", "carried-over only", "don't re-match" | `aristo stamp --skip-canon` (no match) → seed session from cached/backlog items only |
+| **status** | "what's pending?", "just the counts" | `aristo canon suggestions --counts` → print the table, **no session, no writes**, done |
+| **matches** | "only the matches", "review my own annotations" | run **Stage A only** (skip Stage B) |
+| **suggestions** | "only the suggestions" | run **Stage B only** (skip Stage A) |
+| **for `<file>`** | "for src/storage/wal.rs" | add `--filter file=<path>[:LO-HI]` across both stages |
+| **cluster `<objective>`** | "only the WAL cluster" | add `--filter parent=<kanon:objective>` across both stages (free — leaves carry `parent=`) |
+
+Modes are **orthogonal and compose** (e.g. "backlog suggestions for src/storage/wal.rs"
+= `--skip-canon` + Stage B only + `--filter file=core/storage/wal.rs`). Reuse the **existing
+`--filter` grammar verbatim** (`id=`, `file=[:LO-HI]`, `parent=`, `status=`) — it already exists
+for `critique`/`canon`; wire it through, don't reinvent.
+
+- **status** short-circuits before any session: print the counts table from
+  `aristo canon suggestions --counts`, then stop.
+- **backlog** sets `--skip-canon` so Step 2 is skipped; the session seeds purely from
+  carried-over items, and the entry Q&A then only offers the "carried-over" bucket.
+- **matches** / **suggestions** drop the other stage from the run.
+
+*(Deferred fast-follow modes — `staged`, `new`, `triage`, `resume` — are not in v1. If the user
+asks for one, say it's not yet available and offer the closest v1 mode.)*
+
+## Step 2 — initiate the match (skipped in backlog/status modes)
+
+Unless the user chose **status** (short-circuit) or **backlog** (`--skip-canon`), run the match
+step so the cache + suggestions queue are fresh:
+
+```bash
+aristo stamp            # default; matches new/changed annotations, fills the cache + queue
+aristo stamp --skip-canon   # backlog mode: NO match — review only what's already queued
+```
+
+`aristo stamp` (or `aristo critique`) runs `POST /canon/match`; primaries land in
+`canon-matches.toml`, dragged-in clusters land in the `.aristo/canon-suggestions-queue/`
+(after the client-side dedup: drop members already bound / pending / rejected, and collapse
+clusters sharing one objective into one task).
+
+## Step 3 — open the session and show the ROOT menu
+
+Read the at-a-glance counts (these gate the entry Q&A — new vs carried-over, D9):
+
+```bash
+aristo canon suggestions --counts
+# → {"matches":{"new":N,"pending":N},"suggestions":{"new":N,"pending":N}}
+```
+
+If both channels are empty, report "nothing to review" and stop (no session needed).
+
+Otherwise start the session (skip if Step 0 found a resumable one):
+
+```bash
+aristo session start intent-review --subject "<short description of the scope being reviewed>"
+```
+
+Then present the ROOT menu. **Every menu shows new vs pending counts in the option sub-line —
+never silently hide capped items.**
+
+```
+ROOT — "Aristo Intent Suggestions — what would you like to do next?"
+  1. Review canon matches        · "X new · Y pending"   → STAGE A
+  2. Review canon suggestions     · "X new · Y pending"   → STAGE B
+  3. Exit — leave everything pending
+```
+
+### The batch / multi-Q convention (used by both stages)
+
+Same-kind items (N pending matches, N siblings) are presented as a **navigable batch** — one
+`AskUserQuestion` call with multiple questions, where the user arrows left/right between items
+and decides each, then you act on the whole batch. The picker caps at **4 questions per page**,
+so larger sets **paginate** (e.g. 5 siblings = a page of 4 + a page of 1); say "page 1 of 2".
+
+- Each **option** is an action; its **description** is the gray sub-line (counts, target site,
+  confidence).
+- An option's **preview** (monospace) carries the rich context: the `aristo canon show` card for
+  decisions, or the code snippet for placements. Putting alternate sites on sibling options lets
+  the user **compare candidate sites side-by-side** by arrowing between options.
+- **Reuse, don't reinvent:** the decision card is literally the output of `aristo canon show <id>`
+  — no bespoke card layout.
+
+### The snippet rule (locked) — −/+ vs pure-+
+
+- **Stage A accept = REWRITE** an annotation that already exists → render a `−`/`+` diff
+  (your text out, canonical text in).
+- **Stage B adopt = ADD** a new annotation → render a **pure `+`** addition, with surrounding
+  lines shown as plain context (nothing is replaced).
+- **The canonical text is fixed by canon.** "Edit text/site first" edits the *site* (or hands the
+  site choice to the agent); it does **not** reword the canonical phrasing.
+
+## Stage A — pending PRIMARY matches
+
+Read the open primaries from the match cache:
+
+```bash
+aristo canon list      # the primary-match cache (your own annotations); NOT the suggestions queue
+```
+
+Present them as a **navigable batch** (≤4/page, paginate). For each match the menu offers:
+
+```
+per match:  Accept (rewrite + bind) · Reject (keep your wording) · Skip · Back
+  preview on Accept = the source REWRITE as a −/+ diff (your text out, canonical in)
+  preview on the card = aristo canon show <canon_id>
+```
+
+Record each decision against the session:
+
+- **Accept** → `aristo session decide --item match:<annotation-id>#<canon-id> --bucket accepted`.
+  The kind's `on_accept` rewrites the annotation to canonical + binds (reuse of `aristo canon
+  accept`). The annotation already exists — accept rewrites it.
+- **Reject** → `aristo session decide --item match:<annotation-id>#<canon-id> --bucket rejected
+  [--note "..."]`. Fingerprints the `canon_id` so it's suppressed on future runs.
+- **Skip / defer** → `aristo session decide --item match:<annotation-id>#<canon-id> --bucket
+  pending` (parks it; surfaces in the next session's backlog).
+
+## Stage B — SUGGESTIONS, per cluster (parent-first, D6)
+
+List the queued clusters (honor any `--filter` from the chosen mode):
+
+```bash
+aristo canon suggestions                                   # all queued clusters
+aristo canon suggestions --filter parent=<kanon:objective> # cluster <objective> mode
+aristo canon suggestions <objective>                       # one cluster's detail
+```
+
+**⟳ For each cluster task**, present the cluster gate. The **parent (objective) is decided once
+per cluster** — this is the gate at the top of each cluster's review, asked once (there is no
+global "re-decide the parent" loop):
+
+```
+cluster gate:  Explore cluster · Reject cluster · Skip · Back
+  preview on Explore        = the cluster tree (✓ asserted / ☐ to consider), via aristo canon show
+  preview on Reject cluster = "DISCARD dragged-in only / KEEP your independent match" (D6)
+```
+
+- **Reject cluster** → `aristo session decide --item cluster:<key> --bucket rejected
+  [--note "..."]`. This runs the **D6 cascade**: discard the cluster's DRAGGED-IN siblings only,
+  but **KEEP any member that independently matched on its own** (already bound in the index, or
+  pending/accepted in the cache). The seeding primary is never discarded. Discarded members are
+  fingerprinted so they don't re-surface. Go to the next cluster.
+- **Explore cluster** → `aristo session decide --item cluster:<key> --bucket accepted`, then ADOPT
+  the objective (see ADOPT below; if the objective already exists in source, skip it) and proceed
+  to the three-phase sibling flow.
+
+### The three-phase sibling flow (for an explored cluster)
+
+**PHASE 1 — batch-DECIDE siblings** (multi-Q, navigable, ≤4/page):
+
+```
+per sibling:  Adopt · Reject · Skip      preview = aristo canon show <canon_id> card
+```
+
+Record each: Adopt is buffered (don't write yet); Reject →
+`aristo session decide --item sibling:<key>#<canon-id> --bucket rejected [--note "..."]`
+(fingerprints the canon_id). Siblings matching a prior rejection are auto-suppressed (dedup ④,
+shared rejection log) — surface them in a separate "auto-rejected" group, don't clutter the main
+list.
+
+**PHASE 2 — agent batch-FINDS sites** for every "Adopt." For each adopted entry, the SDK exposes
+its `applies_to` + `canonical_text` + `description` (via `aristo canon show <canon_id>`).
+**Site-finding is YOUR job** (the agent): locate the load-bearing site(s) where the invariant
+should be asserted. Propose a HIGH/MEDIUM-confidence primary site plus alternates.
+
+**PHASE 3 — batch-CONFIRM placements** (multi-Q, navigable, ≤4/page):
+
+```
+per adopt:  Confirm — write here · Try a different site · Edit text/site first · Skip
+  preview on Confirm         = surrounding code with the new intent as a PURE + addition
+  preview on Different site   = the next candidate site (compare by arrowing)
+  each candidate carries a confidence (HIGH/MEDIUM) in its sub-line
+```
+
+### ADOPT(entry) — the shared write micro-flow (D4)
+
+Used for the parent objective AND each confirmed sibling. **Confirm → write → stamp → accept:**
+
+1. `agent finds a candidate site (applies_to + canonical_text + description)`
+2. **AskUserQuestion: confirm this site?** — *no* → re-find another site and re-ask; *yes* →
+3. `agent writes #[aristo::intent(text=<canonical_text>, parent="<kanon:objective>")]` at the site
+   (the canonical text verbatim — do NOT reword it).
+4. `aristo stamp` — re-matches; the new annotation becomes a pending primary.
+5. `aristo canon accept` — binds it.
+6. Record `aristo session decide --item sibling:<key>#<canon-id> --bucket accepted --note "adopted"`.
+
+Adoption funnels back through the **existing `stamp → /canon/match → canon accept` pipeline** —
+there is no new source-mutation command; the agent writes code, the CLI manages state (the same
+seam as the `aristo-authoring` skill).
+
+## EXIT — close the session
+
+When every item is decided, or the user picks "Exit / Stop":
+
+- **All decided** → `aristo session exit` (strict close; succeeds because every item has a bucket).
+- **Stopped early** → `aristo session exit --defer-undecided` (open items move to the per-kind
+  **backlog**; the next session surfaces them — never silently dropped).
+- **Abort entirely** → `aristo session abort --yes` (destructive; discards every decision).
+
+Run `aristo stamp` for any adopted/applied edits **after** the session closes — stamp is a
+mutation and the session guard blocks it while a session is open.
+
+## What this skill does NOT do
+
+- It does NOT write `.aristo/` state files directly. Decisions go through `aristo session decide`;
+  the suggestions queue and rejection log are SDK-owned.
+- It does NOT mutate source on its own for an adoption — the agent writes the annotation, then
+  the CLI's `stamp` + `canon accept` bind it.
+- It does NOT reword canonical text. Adopt uses the canon's phrasing verbatim; "edit" edits the
+  *site*, never the wording.
+- It does NOT re-decide a cluster's parent in a loop. The parent is decided **once per cluster**.
+
+## Anti-patterns
+
+- ❌ Skipping Step 0's `aristo session active` check. Layer-3 enforcement is the last line of
+  defense; some agents jump straight to a decision and bypass the SDK pre-check.
+- ❌ Rendering a Stage B adopt as a `−`/`+` diff. Adopt is a **pure `+`** addition — nothing of
+  the user's is replaced. Only Stage A accept (rewrite of an existing annotation) is a diff.
+- ❌ Inventing a bespoke decision card. The card is `aristo canon show <id>` output, reused.
+- ❌ Cramming more than 4 questions onto one page. The picker caps at 4 — paginate and say
+  "page 1 of 2".
+- ❌ Writing an adopted annotation without the **confirm** AskUserQuestion. Every source edit needs
+  explicit per-site confirmation before it lands.
+- ❌ Rejecting a cluster and silently dropping a sibling the user already asserted. Reject-parent
+  discards **dragged-in only** (D6); the SDK keeps any independently-matched member — trust it.
+- ❌ Re-running the match in **backlog** mode. Backlog means `--skip-canon`: review only what's
+  already queued.
+- ❌ Opening a session for **status** mode. Status is `aristo canon suggestions --counts` only —
+  no session, no writes.
+- ❌ Starting an intent-review session and walking away without `exit` / `exit --defer-undecided`
+  / `abort`. Every other aristo mutation refuses until the session closes; always reach a close.

--- a/crates/aristo-cli/src/skills/mod.rs
+++ b/crates/aristo-cli/src/skills/mod.rs
@@ -96,7 +96,12 @@ const CRITIQUE: Skill = Skill {
     content: include_str!("aristo-critique.md"),
 };
 
-const BUNDLED: &[Skill] = &[AUTHORING, NEURAL_VERIFY, CRITIQUE];
+const INTENT_SUGGESTIONS: Skill = Skill {
+    name: "aristo-intent-suggestions",
+    content: include_str!("aristo-intent-suggestions.md"),
+};
+
+const BUNDLED: &[Skill] = &[AUTHORING, NEURAL_VERIFY, CRITIQUE, INTENT_SUGGESTIONS];
 
 #[cfg(test)]
 mod tests {
@@ -115,6 +120,106 @@ mod tests {
     fn future_skill_names_not_yet_bundled() {
         // Sentinels: these skills land in their consuming slices.
         assert!(find("aristo-mine-assertions").is_none()); // slice 24 (deferred)
+    }
+
+    #[test]
+    fn intent_suggestions_skill_is_bundled() {
+        let s = find("aristo-intent-suggestions")
+            .expect("aristo-intent-suggestions must be bundled (§17 Slice 4)");
+        let body = s.resolved_content();
+        // §17/D3/D9: the loop is owned by the intent-review session kind.
+        assert!(
+            body.contains("intent-review"),
+            "skill body must name the `intent-review` session kind it drives"
+        );
+        // §6A: the decision card is reused, not reinvented.
+        assert!(
+            body.contains("aristo canon show"),
+            "skill body must use `aristo canon show` as the decision card (reuse, not reinvent)"
+        );
+        // §6A: same-kind items are presented as a navigable batch.
+        assert!(
+            body.contains("batch"),
+            "skill body must teach the batch multi-Q decision pattern"
+        );
+        // §6A: the picker caps at 4 questions/page → larger sets paginate.
+        assert!(
+            body.contains("4 questions per page") || body.contains("4/page"),
+            "skill body must call out the ≤4-questions-per-page cap (paginate larger sets)"
+        );
+        // §6A: two-phase batch (decide → agent finds sites → confirm).
+        assert!(
+            body.contains("PHASE 1") && body.contains("PHASE 2") && body.contains("PHASE 3"),
+            "skill body must teach the two-phase batch (decide → find sites → confirm placements)"
+        );
+        // §6A snippet rule: Stage A rewrite = −/+ diff; Stage B adopt = pure +.
+        assert!(
+            body.contains("REWRITE") && body.contains("pure"),
+            "skill body must encode the −/+ rewrite vs pure-+ adopt snippet rule"
+        );
+        // §6B modes: backlog + status must both be taught.
+        assert!(
+            body.contains("backlog"),
+            "skill body must teach the `backlog` mode (--skip-canon, no new match)"
+        );
+        assert!(
+            body.contains("status"),
+            "skill body must teach the `status` mode (--counts, no session, no writes)"
+        );
+        // §6B: matches / suggestions stage selectors.
+        assert!(
+            body.contains("Stage A only") && body.contains("Stage B only"),
+            "skill body must teach the matches-only / suggestions-only stage selectors"
+        );
+        // §6B: subject scope via the reused filter grammar.
+        assert!(
+            body.contains("--filter parent=") && body.contains("--filter file="),
+            "skill body must teach the `cluster <objective>` / `for <file>` scope filters"
+        );
+        // §6B: zero-arg slash command (no /skill --flag).
+        assert!(
+            body.contains("zero-argument slash command"),
+            "skill body must declare it is a zero-arg slash command (NL/menu routing, no flags)"
+        );
+        // D4/D6: write path + parent-reject cascade discipline.
+        assert!(
+            body.contains("aristo stamp") && body.contains("aristo canon accept"),
+            "skill body must funnel adoption through stamp → canon accept (no new source mutator)"
+        );
+        assert!(
+            body.contains("parent-first") || body.contains("once per cluster"),
+            "skill body must encode the parent-first, once-per-cluster decision (D6)"
+        );
+        assert!(
+            body.contains("DRAGGED-IN") && body.contains("KEEP"),
+            "skill body must encode the D6 discard-dragged-in-only / keep-independent rule"
+        );
+        // Layer-3 session-guard discipline (mirrors critique/neural-verify).
+        assert!(
+            body.contains("aristo session active"),
+            "skill body's step 0 must check for an active review session (Layer 3 enforcement)"
+        );
+        assert!(
+            body.contains("aristo session start intent-review"),
+            "skill body must open an intent-review session before interactive review"
+        );
+        assert!(
+            body.contains("aristo session decide --item"),
+            "skill body must record per-item decisions via the substrate"
+        );
+        assert!(
+            body.contains("aristo session exit --defer-undecided"),
+            "skill body must offer defer-undecided so open items go to backlog, not silently dropped"
+        );
+        // Frontmatter sanity (mirrors the authoring-skill check).
+        assert!(
+            body.starts_with("---"),
+            "skill must start with YAML frontmatter"
+        );
+        assert!(
+            body.contains("name: aristo-intent-suggestions"),
+            "frontmatter must include the skill name"
+        );
     }
 
     #[test]

--- a/crates/aristo-cli/tests/canon_suggestions_command.rs
+++ b/crates/aristo-cli/tests/canon_suggestions_command.rs
@@ -1,0 +1,282 @@
+//! End-to-end scenario tests for `aristo canon suggestions` (§17
+//! Slice 2). Pattern mirrors the other `canon_*` command e2e tests.
+//!
+//! The flow: a workspace with one annotation → `aristo stamp` against a
+//! mock canon fixture whose `/canon/match` response carries a §17
+//! `suggestions` cluster → the runner routes the cluster into the
+//! `.aristo/canon-suggestions-queue/` (dedup ②③) → `aristo canon
+//! suggestions {list, <objective>, --counts}` reads it back.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn aristo_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aristo")
+}
+
+fn aristo_in(workspace: &Path) -> Command {
+    let mut c = Command::new(aristo_bin());
+    c.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        c.env("PATH", path);
+    }
+    #[cfg(target_os = "macos")]
+    if let Ok(p) = std::env::var("DYLD_FALLBACK_LIBRARY_PATH") {
+        c.env("DYLD_FALLBACK_LIBRARY_PATH", p);
+    }
+    let home = workspace.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    c.env("HOME", &home);
+    c.env("XDG_CONFIG_HOME", home.join("xdg"));
+    c.current_dir(workspace);
+    c
+}
+
+fn setup_workspace(source_body: &str) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("aristo.toml"), "").unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::create_dir_all(tmp.path().join(".aristo")).unwrap();
+    std::fs::write(tmp.path().join("src").join("lib.rs"), source_body).unwrap();
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"sandbox\"\nversion = \"0.0.1\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    tmp
+}
+
+/// A `/canon/match` mock fixture: one primary match for the annotation,
+/// plus a §17 suggestions cluster (objective + two siblings). One of the
+/// siblings (`wal_commit_requires_fsync`) is the primary itself in the
+/// real golden; here the siblings are distinct co-members to exercise
+/// the queue path. Written as TOML (the mock client's wire format).
+fn write_match_fixture(fixture_dir: &Path) {
+    std::fs::create_dir_all(fixture_dir).unwrap();
+    let body = r#"
+effective_scopes = ["turso", ":vanilla"]
+canon_version = "v0.2.0"
+matched_at = "2026-06-05T00:00:00Z"
+
+results = [
+    [
+        { canon_id = "wal_commit_requires_fsync", version = "v0.1.0", canonical_text = "a commit frame must reach stable storage via fsync", confidence = 0.91, scope = "turso", prefix_tier = "aristos:", backed_by = "golden model + proofs + differential testing", linked = "arta_5b1c9f2a7e3d4068", verification = { coverage_level = "tight", test_binaries = ["wal_conform"] } }
+    ]
+]
+
+[[suggestions]]
+for_canon_id = "wal_commit_requires_fsync"
+objective = { canon_id = "wal_protocol_correctness", version = "v0.1.0", canonical_text = "the WAL subsystem maintains LSN monotonicity and frame commitment ordering", scope = "turso", prefix_tier = "kanon:", backed_by = "", relationship = "parent" }
+siblings = [
+    { canon_id = "wal_find_frame_range_invariant", version = "v0.1.0", canonical_text = "find_frame never reads outside the live frame range", scope = "turso", prefix_tier = "aristos:", backed_by = "golden model + proofs + differential testing", relationship = "sibling" },
+    { canon_id = "wal_checkpoint_error_no_db_leak", version = "v0.1.0", canonical_text = "a checkpoint failure must not leak frames into the main database file", scope = "turso", prefix_tier = "aristos:", backed_by = "golden model + proofs + differential testing", relationship = "sibling" }
+]
+"#;
+    std::fs::write(fixture_dir.join("match.toml"), body).unwrap();
+}
+
+const SOURCE: &str = r#"
+#[aristo::intent(
+    "a commit frame must reach stable storage via fsync before durable",
+    id = "wal_commit_durable_invariant"
+)]
+pub fn commit() {}
+"#;
+
+/// Run `aristo stamp` against the mock fixture so the suggestions queue
+/// is populated. Returns the workspace dir.
+fn stamped_workspace() -> TempDir {
+    let ws = setup_workspace(SOURCE);
+    let fixture_dir = ws.path().join("fixture");
+    write_match_fixture(&fixture_dir);
+    let out = aristo_in(ws.path())
+        .args(["stamp"])
+        .env("ARISTO_CANON_FIXTURE", &fixture_dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stamp failed: {}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    ws
+}
+
+#[test]
+fn suggestions_list_with_empty_queue_reports_none() {
+    let ws = setup_workspace(SOURCE);
+    aristo_in(ws.path())
+        .args(["stamp", "--skip-canon"])
+        .status()
+        .unwrap();
+    let out = aristo_in(ws.path())
+        .args(["canon", "suggestions"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("no proof-tree suggestions"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn stamp_populates_queue_and_list_shows_the_cluster() {
+    let ws = stamped_workspace();
+    let out = aristo_in(ws.path())
+        .args(["canon", "suggestions"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("proof-tree suggestions (1 cluster(s))"),
+        "got: {stdout}"
+    );
+    assert!(stdout.contains("wal_protocol_correctness"), "got: {stdout}");
+    assert!(stdout.contains("2 sibling(s)"), "got: {stdout}");
+    assert!(
+        stdout.contains("for wal_commit_requires_fsync"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn suggestions_show_renders_objective_and_siblings() {
+    let ws = stamped_workspace();
+    let out = aristo_in(ws.path())
+        .args(["canon", "suggestions", "wal_protocol_correctness"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("objective: wal_protocol_correctness"),
+        "got: {stdout}"
+    );
+    assert!(stdout.contains("kanon: tier"), "got: {stdout}");
+    assert!(stdout.contains("wal_find_frame_range_invariant"), "got: {stdout}");
+    assert!(stdout.contains("wal_checkpoint_error_no_db_leak"), "got: {stdout}");
+    // Subject-only: the card describes the user's invariants, never the
+    // Lean model. The primary that dragged the cluster in is shown.
+    assert!(
+        stdout.contains("wal_commit_requires_fsync"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn suggestions_show_unknown_cluster_errors() {
+    let ws = stamped_workspace();
+    let out = aristo_in(ws.path())
+        .args(["canon", "suggestions", "does_not_exist"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no queued suggestion cluster"),
+        "got: {stderr}"
+    );
+}
+
+#[test]
+fn suggestions_counts_emits_machine_readable_json() {
+    let ws = stamped_workspace();
+    let out = aristo_in(ws.path())
+        .args(["canon", "suggestions", "--counts"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|e| panic!("not JSON: {e}\n{stdout}"));
+    // Shape: {matches:{new,pending}, suggestions:{new,pending}}.
+    assert!(v.get("matches").is_some(), "got: {v}");
+    assert!(v.get("suggestions").is_some(), "got: {v}");
+    assert!(v["matches"].get("new").is_some(), "got: {v}");
+    assert!(v["matches"].get("pending").is_some(), "got: {v}");
+    assert!(v["suggestions"].get("new").is_some(), "got: {v}");
+    assert!(v["suggestions"].get("pending").is_some(), "got: {v}");
+    // One cluster queued (still pending in the queue) → new=1.
+    assert_eq!(v["suggestions"]["new"], 1, "got: {v}");
+}
+
+#[test]
+fn dedup_two_drops_member_already_pending_in_cache() {
+    // If a sibling is ALSO a primary match for some annotation (lands in
+    // canon-matches.toml), dedup ② must keep it out of the suggestions
+    // queue. We seed a second annotation whose text matches the sibling
+    // canon_id via a tailored fixture: the second result returns the
+    // sibling as a primary.
+    let ws = setup_workspace(
+        r#"
+#[aristo::intent(
+    "a commit frame must reach stable storage via fsync before durable",
+    id = "wal_commit_durable_invariant"
+)]
+pub fn commit() {}
+
+#[aristo::intent(
+    "find_frame never reads outside the live frame range",
+    id = "wal_find_frame_invariant"
+)]
+pub fn find_frame() {}
+"#,
+    );
+    let fixture_dir = ws.path().join("fixture");
+    std::fs::create_dir_all(&fixture_dir).unwrap();
+    // Two annotations → two results. The SECOND primary IS the sibling
+    // `wal_find_frame_range_invariant`; the suggestions cluster (aligned
+    // to annotation 0) lists it as a sibling. Dedup ② must drop it.
+    let body = r#"
+effective_scopes = ["turso", ":vanilla"]
+canon_version = "v0.2.0"
+matched_at = "2026-06-05T00:00:00Z"
+
+results = [
+    [
+        { canon_id = "wal_commit_requires_fsync", version = "v0.1.0", canonical_text = "a commit frame must reach stable storage via fsync", confidence = 0.91, scope = "turso", prefix_tier = "aristos:", backed_by = "golden model", linked = "arta_5b1c9f2a7e3d4068", verification = { coverage_level = "tight", test_binaries = [] } }
+    ],
+    [
+        { canon_id = "wal_find_frame_range_invariant", version = "v0.1.0", canonical_text = "find_frame never reads outside the live frame range", confidence = 0.88, scope = "turso", prefix_tier = "aristos:", backed_by = "golden model", linked = "arta_aaaa1111bbbb2222", verification = { coverage_level = "tight", test_binaries = [] } }
+    ]
+]
+
+[[suggestions]]
+for_canon_id = "wal_commit_requires_fsync"
+objective = { canon_id = "wal_protocol_correctness", version = "v0.1.0", canonical_text = "the WAL subsystem maintains correctness", scope = "turso", prefix_tier = "kanon:", backed_by = "", relationship = "parent" }
+siblings = [
+    { canon_id = "wal_find_frame_range_invariant", version = "v0.1.0", canonical_text = "find_frame never reads outside the live frame range", scope = "turso", prefix_tier = "aristos:", backed_by = "golden model", relationship = "sibling" },
+    { canon_id = "wal_checkpoint_error_no_db_leak", version = "v0.1.0", canonical_text = "a checkpoint failure must not leak frames", scope = "turso", prefix_tier = "aristos:", backed_by = "golden model", relationship = "sibling" }
+]
+"#;
+    std::fs::write(fixture_dir.join("match.toml"), body).unwrap();
+
+    let out = aristo_in(ws.path())
+        .args(["stamp"])
+        .env("ARISTO_CANON_FIXTURE", &fixture_dir)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+
+    let show = aristo_in(ws.path())
+        .args(["canon", "suggestions", "wal_protocol_correctness"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&show.stdout);
+    // The sibling that is also a primary match was dropped by dedup ②.
+    assert!(
+        !stdout.contains("wal_find_frame_range_invariant"),
+        "dedup ② should drop the sibling that is a primary match; got: {stdout}"
+    );
+    // The other sibling survives.
+    assert!(
+        stdout.contains("wal_checkpoint_error_no_db_leak"),
+        "got: {stdout}"
+    );
+}

--- a/crates/aristo-cli/tests/intent_modes.rs
+++ b/crates/aristo-cli/tests/intent_modes.rs
@@ -1,0 +1,193 @@
+//! §17 Slice 3 — adaptive modes (§6B).
+//!
+//! Modes are recipes of EXISTING CLI primitives — no new grammar. This
+//! suite pins that each mode's underlying flag behaves as the skill
+//! (Slice 4) relies on:
+//!
+//! - **backlog** — `aristo stamp --skip-canon` runs no match (offline;
+//!   the session then seeds purely from cached/backlog state).
+//! - **cluster `<objective>`** — `aristo canon suggestions --filter
+//!   parent=<obj>` scopes to one proof cluster (reuses `filter.rs`).
+//! - **status** — `aristo canon suggestions --counts` prints counts with
+//!   NO session and NO writes.
+//! - **matches / suggestions** — `aristo canon list` (matches read) and
+//!   `aristo canon suggestions` (suggestions read) each surface only one
+//!   stage.
+
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+/// Seed a queued cluster task (objective + one sibling) directly.
+fn seed_cluster(root: &Path, key: &str, sibling: &str) {
+    let dir = root.join(".aristo/canon-suggestions-queue/pending");
+    std::fs::create_dir_all(&dir).unwrap();
+    let body = format!(
+        "for_canon_ids = [\"primary_for_{key}\"]\n\
+         discovered_at = \"2026-06-05T00:00:00Z\"\n\n\
+         [objective]\ncanon_id = \"{key}\"\nversion = \"v0.1.0\"\n\
+         canonical_text = \"objective text\"\nscope = \"turso\"\n\
+         prefix_tier = \"kanon:\"\nbacked_by = \"\"\ndisposition = \"open\"\n\n\
+         [[siblings]]\ncanon_id = \"{sibling}\"\nversion = \"v0.1.0\"\n\
+         canonical_text = \"sibling text\"\nscope = \"turso\"\n\
+         prefix_tier = \"aristos:\"\nbacked_by = \"golden model\"\n\
+         disposition = \"open\"\n"
+    );
+    std::fs::write(dir.join(format!("{key}.toml")), body).unwrap();
+}
+
+const SOURCE: &str = r#"
+#[aristo::intent(
+    "a commit frame must reach stable storage via fsync before durable",
+    id = "wal_commit_durable_invariant"
+)]
+pub fn commit() {}
+"#;
+
+fn setup_source(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), SOURCE).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"sandbox\"\nversion = \"0.0.1\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn skip_canon_mode_runs_no_match() {
+    // backlog mode: `--skip-canon` means no `/canon/match` call — no
+    // network, no cache, no suggestions queue produced. With no canon
+    // fixture set, a non-skip stamp would attempt a match; --skip-canon
+    // makes the run offline.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    setup_source(tmp.path());
+
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("canon-match: skipped"));
+
+    // No suggestions queue and no cache were produced.
+    assert!(
+        !tmp.path()
+            .join(".aristo/canon-suggestions-queue/pending")
+            .exists()
+            || std::fs::read_dir(tmp.path().join(".aristo/canon-suggestions-queue/pending"))
+                .map(|mut d| d.next().is_none())
+                .unwrap_or(true),
+        "skip-canon must not populate the suggestions queue"
+    );
+    assert!(
+        !tmp.path().join(".aristo/canon-matches.toml").exists(),
+        "skip-canon must not write the match cache"
+    );
+}
+
+#[test]
+fn filter_parent_scopes_to_one_cluster() {
+    // cluster <objective> mode: `--filter parent=<obj>` (reusing the
+    // shared filter grammar verbatim) scopes the listing to exactly that
+    // cluster.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(tmp.path(), "wal_protocol_correctness", "wal_find_frame_range_invariant");
+    seed_cluster(tmp.path(), "storage_compaction_correctness", "vacuum_atomic_under_crash");
+
+    // Unfiltered: both clusters.
+    aristo_in(tmp.path())
+        .args(["canon", "suggestions"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("2 cluster(s)"));
+
+    // Filtered: just the WAL cluster.
+    aristo_in(tmp.path())
+        .args(["canon", "suggestions", "--filter", "parent=wal_protocol_correctness"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("1 cluster(s)"))
+        .stdout(predicates::str::contains("wal_protocol_correctness"))
+        .stdout(predicates::str::contains("storage_compaction_correctness").not());
+}
+
+#[test]
+fn filter_parent_accepts_kanon_prefixed_objective() {
+    // The §6B `cluster <objective>` recipe is `--filter
+    // parent=kanon:<objective>`; the tier prefix is stripped so it
+    // matches the bare cluster key.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(tmp.path(), "wal_protocol_correctness", "wal_find_frame_range_invariant");
+
+    aristo_in(tmp.path())
+        .args([
+            "canon",
+            "suggestions",
+            "--filter",
+            "parent=kanon:wal_protocol_correctness",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("1 cluster(s)"))
+        .stdout(predicates::str::contains("wal_protocol_correctness"));
+}
+
+#[test]
+fn queue_status_counts_emit_no_session_no_writes() {
+    // status mode: `--counts` prints the counts table and exits — no
+    // session is opened, nothing is mutated.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(tmp.path(), "wal_protocol_correctness", "wal_find_frame_range_invariant");
+
+    let out = aristo_in(tmp.path())
+        .args(["canon", "suggestions", "--counts"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["suggestions"]["new"], 1, "got: {v}");
+
+    // No session was started.
+    assert!(
+        !tmp.path().join(".aristo/sessions/.active").exists(),
+        "status mode must not open a session"
+    );
+}
+
+#[test]
+fn matches_only_and_suggestions_only_each_skip_the_other_stage() {
+    // matches / suggestions stage selectors: `aristo canon list` reads
+    // only the primary-match cache; `aristo canon suggestions` reads only
+    // the suggestions queue. Each surfaces its own stage and not the
+    // other.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(tmp.path(), "wal_protocol_correctness", "wal_find_frame_range_invariant");
+
+    // suggestions-only: the queue, not the (empty) match cache.
+    aristo_in(tmp.path())
+        .args(["canon", "suggestions"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("proof-tree suggestions"));
+
+    // matches-only: the match cache, which has nothing — and critically
+    // does NOT surface the queued suggestion cluster.
+    aristo_in(tmp.path())
+        .args(["canon", "list"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("no canon matches"))
+        .stdout(predicates::str::contains("wal_protocol_correctness").not());
+}

--- a/crates/aristo-cli/tests/intent_review_session_kind.rs
+++ b/crates/aristo-cli/tests/intent_review_session_kind.rs
@@ -1,0 +1,332 @@
+//! §17 Slice 3 — end-to-end `intent-review` session kind.
+//!
+//! The session carries two item types: pending PRIMARY matches
+//! (`match:<id>#<canon-id>`) and SUGGESTION clusters (`cluster:<key>`)
+//! with their siblings (`sibling:<key>#<canon-id>`). Parent decided
+//! first (D6); reject-parent discards the cluster's DRAGGED-IN siblings
+//! only and KEEPS any member that independently matched on its own.
+//!
+//! Tests drive the real `aristo session {start,decide,exit}` CLI against
+//! a hand-seeded suggestions queue + cache, mirroring
+//! `critique_session_kind_integration.rs`.
+
+use assert_cmd::Command;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+/// Seed a queued cluster task (objective + the given siblings) directly
+/// into `.aristo/canon-suggestions-queue/pending/<key>.toml`. The on-disk
+/// shape matches what `runner.rs` writes after a stamp (verified against
+/// a real stamp run).
+fn seed_cluster(root: &Path, key: &str, siblings: &[&str]) {
+    let dir = root.join(".aristo/canon-suggestions-queue/pending");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut body = String::new();
+    body.push_str("for_canon_ids = [\"wal_commit_requires_fsync\"]\n");
+    body.push_str("discovered_at = \"2026-06-05T00:00:00Z\"\n\n");
+    body.push_str("[objective]\n");
+    body.push_str(&format!("canon_id = \"{key}\"\n"));
+    body.push_str("version = \"v0.1.0\"\n");
+    body.push_str("canonical_text = \"the WAL subsystem maintains correctness\"\n");
+    body.push_str("scope = \"turso\"\n");
+    body.push_str("prefix_tier = \"kanon:\"\n");
+    body.push_str("backed_by = \"\"\n");
+    body.push_str("disposition = \"open\"\n");
+    for s in siblings {
+        body.push_str("\n[[siblings]]\n");
+        body.push_str(&format!("canon_id = \"{s}\"\n"));
+        body.push_str("version = \"v0.1.0\"\n");
+        body.push_str(&format!("canonical_text = \"text for {s}\"\n"));
+        body.push_str("scope = \"turso\"\n");
+        body.push_str("prefix_tier = \"aristos:\"\n");
+        body.push_str("backed_by = \"golden model\"\n");
+        body.push_str("disposition = \"open\"\n");
+    }
+    std::fs::write(dir.join(format!("{key}.toml")), body).unwrap();
+}
+
+/// Add a pending PRIMARY match for `canon_id` to `canon-matches.toml`
+/// under a synthetic annotation. This is the "independently held"
+/// signal the D6 guard re-checks at discard time — a member that
+/// *became* a primary after the cluster was queued.
+fn seed_pending_match(root: &Path, annotation_id: &str, canon_id: &str) {
+    let path = root.join(".aristo/canon-matches.toml");
+    let existing = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+        "[__meta__]\nschema_version = 1\ncanon_version = \"v0.2.0\"\n\
+         last_fetched = \"2026-06-05T00:00:00Z\"\n"
+            .to_string()
+    });
+    let zero = format!("sha256:{}", "0".repeat(64));
+    let appended = format!(
+        "{existing}\n[{annotation_id}]\nlast_match_text_hash = \"{zero}\"\n\
+         canon_fetched_at = \"2026-06-05T00:00:00Z\"\n\n\
+         [[{annotation_id}.pending_matches]]\ncanon_id = \"{canon_id}\"\n\
+         version = \"v0.1.0\"\ncanonical_text = \"text for {canon_id}\"\n\
+         canon_version = \"v0.2.0\"\nconfidence = 0.9\nprefix_tier = \"aristos:\"\n\
+         backed_by = \"golden model\"\ndisposition = \"open\"\n\
+         found_at = \"2026-06-05T00:00:00Z\"\nfound_by = \"aristo stamp\"\n"
+    );
+    std::fs::write(&path, appended).unwrap();
+}
+
+fn read_queue_task(root: &Path, key: &str) -> Option<String> {
+    let p = root.join(format!(
+        ".aristo/canon-suggestions-queue/pending/{key}.toml"
+    ));
+    std::fs::read_to_string(p).ok()
+}
+
+#[test]
+fn intent_review_is_a_registered_session_kind() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("kind=intent-review"));
+}
+
+#[test]
+fn parent_first_then_accept_parent_opens_siblings() {
+    // Accept-parent is a validating no-op (adoption goes through
+    // stamp→accept per D4); the cluster stays queued so siblings can be
+    // decided individually afterward.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(
+        tmp.path(),
+        "wal_protocol_correctness",
+        &["wal_find_frame_range_invariant", "wal_checkpoint_error_no_db_leak"],
+    );
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success();
+
+    // Decide the PARENT first.
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "cluster:wal_protocol_correctness",
+            "--bucket",
+            "accepted",
+        ])
+        .assert()
+        .success();
+
+    // Siblings are still reviewable individually.
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "sibling:wal_protocol_correctness#wal_find_frame_range_invariant",
+            "--bucket",
+            "accepted",
+        ])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "sibling:wal_protocol_correctness#wal_checkpoint_error_no_db_leak",
+            "--bucket",
+            "rejected",
+        ])
+        .assert()
+        .success();
+
+    // The rejected sibling is fingerprinted by its bare canon_id.
+    let log = std::fs::read_to_string(tmp.path().join(".aristo/sessions/rejections.log")).unwrap();
+    assert!(
+        log.contains("\"fingerprint\":\"wal_checkpoint_error_no_db_leak\""),
+        "sibling reject must fingerprint its canon_id; log: {log}"
+    );
+}
+
+#[test]
+fn reject_parent_keeps_independent_match() {
+    // THE load-bearing D6 test. A cluster has two dragged-in siblings.
+    // One of them (`wal_checkpoint_error_no_db_leak`) independently
+    // matched on its own AFTER the cluster was queued — it has a pending
+    // primary match in the cache. Rejecting the parent must:
+    //   - DISCARD the purely-dragged-in sibling
+    //     (`wal_find_frame_range_invariant`) + fingerprint it, AND
+    //   - KEEP the independently-matched sibling in the queue (never
+    //     silently throw away an invariant the user is asserting).
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(
+        tmp.path(),
+        "wal_protocol_correctness",
+        &["wal_find_frame_range_invariant", "wal_checkpoint_error_no_db_leak"],
+    );
+    // The second sibling became a primary after merge.
+    seed_pending_match(
+        tmp.path(),
+        "some_other_annotation",
+        "wal_checkpoint_error_no_db_leak",
+    );
+
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "cluster:wal_protocol_correctness",
+            "--bucket",
+            "rejected",
+            "--note",
+            "not this contract",
+        ])
+        .assert()
+        .success();
+
+    // The task still exists (the independent member survives).
+    let task = read_queue_task(tmp.path(), "wal_protocol_correctness")
+        .expect("task must survive — it still holds an independently-matched member");
+    // The purely-dragged-in sibling is gone…
+    assert!(
+        !task.contains("wal_find_frame_range_invariant"),
+        "dragged-in-only sibling must be discarded; task: {task}"
+    );
+    // …the independently-matched member is KEPT…
+    assert!(
+        task.contains("wal_checkpoint_error_no_db_leak"),
+        "independently-matched member must be KEPT (D6); task: {task}"
+    );
+    // …and the objective is dropped (the parent was rejected).
+    assert!(
+        !task.contains("[objective]"),
+        "rejected parent's objective must be dropped; task: {task}"
+    );
+
+    // The discarded member is fingerprinted; the kept member is NOT
+    // (it keeps its own accept/reject flow).
+    let log = std::fs::read_to_string(tmp.path().join(".aristo/sessions/rejections.log")).unwrap();
+    assert!(
+        log.contains("\"fingerprint\":\"wal_find_frame_range_invariant\""),
+        "discarded sibling must be fingerprinted; log: {log}"
+    );
+    assert!(
+        !log.contains("\"item_ref\":\"wal_checkpoint_error_no_db_leak\""),
+        "the independently-matched member must NOT be discarded/fingerprinted; log: {log}"
+    );
+}
+
+#[test]
+fn reject_parent_with_no_independent_member_removes_the_whole_task() {
+    // When every sibling is purely dragged in, rejecting the parent
+    // removes the whole cluster task (nothing the user independently
+    // holds), fingerprinting each discarded member.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(
+        tmp.path(),
+        "wal_protocol_correctness",
+        &["wal_find_frame_range_invariant", "wal_checkpoint_error_no_db_leak"],
+    );
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "cluster:wal_protocol_correctness",
+            "--bucket",
+            "rejected",
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        read_queue_task(tmp.path(), "wal_protocol_correctness").is_none(),
+        "task with no independent member must be removed entirely"
+    );
+    let log = std::fs::read_to_string(tmp.path().join(".aristo/sessions/rejections.log")).unwrap();
+    assert!(log.contains("\"fingerprint\":\"wal_find_frame_range_invariant\""));
+    assert!(log.contains("\"fingerprint\":\"wal_checkpoint_error_no_db_leak\""));
+}
+
+#[test]
+fn exit_defer_undecided_parks_remaining_items() {
+    // `exit --defer-undecided` parks remaining open items in the per-kind
+    // backlog rather than erroring (strict exit would reject open items).
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    seed_cluster(
+        tmp.path(),
+        "wal_protocol_correctness",
+        &["wal_find_frame_range_invariant"],
+    );
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success();
+    // Defer one sibling; leave it parked.
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "sibling:wal_protocol_correctness#wal_find_frame_range_invariant",
+            "--bucket",
+            "pending",
+            "--note",
+            "later",
+        ])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args(["session", "exit", "--defer-undecided"])
+        .assert()
+        .success();
+
+    let backlog = std::fs::read_to_string(
+        tmp.path().join(".aristo/sessions/backlog/intent-review.toml"),
+    )
+    .unwrap();
+    assert!(
+        backlog.contains("wal_find_frame_range_invariant"),
+        "deferred sibling must be parked in the intent-review backlog; backlog: {backlog}"
+    );
+}
+
+#[test]
+fn bad_intent_ref_refused_with_actionable_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    aristo_in(tmp.path())
+        .args(["session", "start", "intent-review", "--subject", "x"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args([
+            "session",
+            "decide",
+            "--item",
+            "not_a_valid_intent_ref",
+            "--bucket",
+            "accepted",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("is not in"));
+}

--- a/crates/aristo-core/src/canon/http_client.rs
+++ b/crates/aristo-core/src/canon/http_client.rs
@@ -290,6 +290,7 @@ mod tests {
             effective_scopes: vec![":vanilla".into()],
             canon_version: "v0.2.0".into(),
             matched_at: "2026-06-15T09:14:22Z".into(),
+            suggestions: None,
         };
         serde_json::to_string(&resp).unwrap()
     }
@@ -557,6 +558,7 @@ mod tests {
                 applies_to: vec!["fn".into()],
             }],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         };
     }
 }

--- a/crates/aristo-core/src/canon/mock_client.rs
+++ b/crates/aristo-core/src/canon/mock_client.rs
@@ -160,6 +160,7 @@ results = [
                 applies_to: vec!["fn".into()],
             }],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         };
         let resp = client.match_annotations(&req).unwrap();
         assert_eq!(resp.results.len(), 1);
@@ -181,6 +182,7 @@ results = [
         let req = CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.5,
+            include_suggestions: false,
         };
         let err = client.match_annotations(&req).unwrap_err();
         assert!(matches!(err, CanonError::Fixture(_)));
@@ -197,6 +199,7 @@ results = [
         let req = CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.5,
+            include_suggestions: false,
         };
         let err = client.match_annotations(&req).unwrap_err();
         assert!(matches!(err, CanonError::Fixture(_)));
@@ -363,6 +366,7 @@ current_backing = "specialized neural checker"
             effective_scopes: vec![":vanilla".into()],
             canon_version: "v0.2.0".into(),
             matched_at: "2026-06-15T09:14:22Z".into(),
+            suggestions: None,
         };
         let tmp = TempDir::new().unwrap();
         let toml_text = toml::to_string(&resp).unwrap();
@@ -372,6 +376,7 @@ current_backing = "specialized neural checker"
         let req = CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.5,
+            include_suggestions: false,
         };
         let loaded = client.match_annotations(&req).unwrap();
         assert_eq!(loaded, resp);

--- a/crates/aristo-core/src/canon/mod.rs
+++ b/crates/aristo-core/src/canon/mod.rs
@@ -59,6 +59,6 @@ pub use noop_client::NoopCanonClient;
 pub use rewrite::{compute_rewrite, AcceptRewriteRequest, AttributeRewrite, RewriteError};
 pub use types::{
     synthesize_phase1_linked, AnnotationMatchInput, CanonEntry, CanonMatch, CanonMatchRequest,
-    CanonMatchResponse, PrefixTier, References, RequestVerifyBody, RequestVerifyResponse,
-    VerificationMetadata,
+    CanonMatchResponse, ClusterSuggestion, PrefixTier, References, Relationship, RequestVerifyBody,
+    RequestVerifyResponse, SuggestedEntry, VerificationMetadata,
 };

--- a/crates/aristo-core/src/canon/noop_client.rs
+++ b/crates/aristo-core/src/canon/noop_client.rs
@@ -62,6 +62,7 @@ mod tests {
                 applies_to: vec!["fn".into()],
             }],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         };
         let err = client.match_annotations(&req).unwrap_err();
         assert!(matches!(err, CanonError::NotEnabled));

--- a/crates/aristo-core/src/canon/types.rs
+++ b/crates/aristo-core/src/canon/types.rs
@@ -52,6 +52,14 @@ pub struct CanonMatchRequest {
     /// `stamp` sends `0.85`; `critique` sends `0.65`; tunable via
     /// `aristo.toml [canon] threshold_*`.
     pub confidence_threshold: f64,
+    /// Opt-in to the §17 proof-tree suggestions channel. When `true`,
+    /// the server expands each primary match into its proof-objective
+    /// cluster and attaches [`CanonMatchResponse::suggestions`].
+    /// Defaults to `false` so the existing match path stays
+    /// byte-identical on the wire (back-compat: old clients never send
+    /// the field; the server treats absence as `false`).
+    #[serde(default)]
+    pub include_suggestions: bool,
 }
 
 /// One annotation-shaped input to the batched match call.
@@ -86,6 +94,74 @@ pub struct CanonMatchResponse {
     pub canon_version: String,
     /// ISO-8601 timestamp of when the server computed this response.
     pub matched_at: String,
+    /// §17 proof-tree suggestions, aligned by annotation index to
+    /// [`results`](Self::results). One [`ClusterSuggestion`] per
+    /// requested annotation; entries are `None` where the annotation
+    /// had no cluster. The whole field is `None`/absent for clients
+    /// that did not set [`CanonMatchRequest::include_suggestions`]
+    /// (back-compat — old responses decode with `suggestions = None`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggestions: Option<Vec<Option<ClusterSuggestion>>>,
+}
+
+// ─── §17 proof-tree suggestions ────────────────────────────────────────────
+
+/// One proof-objective cluster pulled in for a primary match. Mirrors
+/// `ClusterSuggestion` in `contract/suggestions.schema.json`.
+///
+/// The cluster hangs off the primary `for_canon_id`; it carries the
+/// `objective` (the `kanon:` proof-objective parent — `None` until
+/// Slice 0b authors objective entries) and the `siblings` (co-member
+/// leaf entries, deduped, with the primary excluded by the server —
+/// "dedup ①").
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ClusterSuggestion {
+    /// The primary matched `canon_id` this cluster hangs off of.
+    pub for_canon_id: String,
+    /// The `kanon:` proof-objective (parent). `None` until Slice 0b
+    /// authors objective entries (siblings-only mode).
+    pub objective: Option<SuggestedEntry>,
+    /// Co-member leaf entries, deduped, with the primary excluded
+    /// (server "dedup ①"). May be empty.
+    pub siblings: Vec<SuggestedEntry>,
+}
+
+/// One suggested canon entry within a [`ClusterSuggestion`] — either
+/// the objective (parent) or a sibling leaf. Mirrors `SuggestedEntry`
+/// in `contract/suggestions.schema.json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SuggestedEntry {
+    pub canon_id: String,
+    pub version: String,
+    pub canonical_text: String,
+    pub scope: String,
+    pub prefix_tier: PrefixTier,
+    /// `Some(_)` for `aristos:` tier; `None` for `kanon:` tier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backed_by: Option<String>,
+    /// Scope-aware verification metadata. Informational in Phase 1
+    /// (same carve-out as [`CanonMatch::verification`]). Defaults to
+    /// the empty metadata when the server omits it.
+    #[serde(default)]
+    pub verification: VerificationMetadata,
+    /// Where this entry sits relative to the primary. v1 emits only
+    /// `parent` (the objective) + `sibling` (co-member leaves).
+    pub relationship: Relationship,
+}
+
+/// Where a [`SuggestedEntry`] sits relative to the primary match.
+/// Mirrors the `relationship` enum in
+/// `contract/suggestions.schema.json`. v1 emits only `Parent` +
+/// `Sibling`; `Child` is reserved for the future Lean-DAG layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Relationship {
+    /// The proof-objective node — the cluster's parent.
+    Parent,
+    /// A co-member leaf obligation under the same objective.
+    Sibling,
+    /// Reserved for the future Lean-DAG sub-obligation layer.
+    Child,
 }
 
 /// One match candidate for one annotation.
@@ -230,7 +306,7 @@ pub fn synthesize_phase1_linked(canon_id: &str, version: &str) -> crate::index::
 
 /// Scope-aware verification metadata surfaced by the match response.
 /// Mirrors the coverage.yaml routing manifest's per-entry fields.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct VerificationMetadata {
     /// `"tight"` | `"partial"` | `"informal"` | `"none"` per
     /// canon-strategy.md (the `relation` field on coverage entries).
@@ -424,6 +500,7 @@ mod tests {
                 applies_to: vec!["fn".into(), "method".into()],
             }],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: CanonMatchRequest = serde_json::from_str(&json).unwrap();
@@ -450,6 +527,7 @@ mod tests {
             effective_scopes: vec![":vanilla".into()],
             canon_version: "v0.2.0".into(),
             matched_at: "2026-06-15T09:14:22Z".into(),
+            suggestions: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         let back: CanonMatchResponse = serde_json::from_str(&json).unwrap();
@@ -708,6 +786,56 @@ mod tests {
     }
 
     #[test]
+    fn relationship_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_value(Relationship::Parent).unwrap(),
+            serde_json::json!("parent")
+        );
+        assert_eq!(
+            serde_json::to_value(Relationship::Sibling).unwrap(),
+            serde_json::json!("sibling")
+        );
+        assert_eq!(
+            serde_json::to_value(Relationship::Child).unwrap(),
+            serde_json::json!("child")
+        );
+        let back: Relationship = serde_json::from_str("\"parent\"").unwrap();
+        assert_eq!(back, Relationship::Parent);
+    }
+
+    #[test]
+    fn match_response_without_suggestions_omits_field() {
+        // include_suggestions defaults to false; the response carries
+        // no suggestions key — byte-identical to the pre-§17 wire shape.
+        let resp = CanonMatchResponse {
+            results: vec![],
+            effective_scopes: vec![":vanilla".into()],
+            canon_version: "v0.2.0".into(),
+            matched_at: "2026-06-15T09:14:22Z".into(),
+            suggestions: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !json.contains("suggestions"),
+            "expected suggestions to be omitted, got: {json}"
+        );
+    }
+
+    #[test]
+    fn old_response_decodes_with_suggestions_none() {
+        // Back-compat: a pre-§17 server response has no `suggestions`
+        // key. `#[serde(default)]` must decode it as `None`.
+        let raw = r#"{
+            "results": [],
+            "effective_scopes": [":vanilla"],
+            "canon_version": "v0.1.0",
+            "matched_at": "2026-05-22T18:04:51.080Z"
+        }"#;
+        let resp: CanonMatchResponse = serde_json::from_str(raw).unwrap();
+        assert!(resp.suggestions.is_none());
+    }
+
+    #[test]
     fn match_request_serializes_with_snake_case_keys() {
         // Important: server and SDK both expect snake_case wire form.
         // Field rename to camelCase here would break Slice 3.
@@ -717,6 +845,7 @@ mod tests {
                 applies_to: vec!["fn".into()],
             }],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("annotation_text"), "got: {json}");

--- a/crates/aristo-core/tests/canon_http_e2e.rs
+++ b/crates/aristo-core/tests/canon_http_e2e.rs
@@ -141,6 +141,7 @@ fn match_annotations_happy_path_round_trips() {
         effective_scopes: vec![":vanilla".into()],
         canon_version: "v0.2.0".into(),
         matched_at: "2026-06-15T09:14:22Z".into(),
+        suggestions: None,
     };
     let body = serde_json::to_string(&canned_response).unwrap();
     let (base, server) = spawn_mock(CannedResponse {
@@ -156,6 +157,7 @@ fn match_annotations_happy_path_round_trips() {
             applies_to: vec!["fn".into()],
         }],
         confidence_threshold: 0.85,
+        include_suggestions: false,
     };
     let resp = client
         .match_annotations(&req)
@@ -334,6 +336,7 @@ fn server_401_maps_to_auth_invalid() {
         .match_annotations(&CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.5,
+            include_suggestions: false,
         })
         .unwrap_err();
     assert!(
@@ -356,6 +359,7 @@ fn server_400_carries_message_body() {
         .match_annotations(&CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.3,
+            include_suggestions: false,
         })
         .unwrap_err();
     match err {
@@ -386,6 +390,7 @@ fn server_500_maps_to_server_error() {
         .match_annotations(&CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         })
         .unwrap_err();
     match err {
@@ -421,6 +426,7 @@ fn unreachable_server_maps_to_network_error() {
         .match_annotations(&CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         })
         .unwrap_err();
     assert!(
@@ -444,6 +450,7 @@ fn malformed_response_body_maps_to_decode_error() {
         .match_annotations(&CanonMatchRequest {
             annotations: vec![],
             confidence_threshold: 0.85,
+            include_suggestions: false,
         })
         .unwrap_err();
     assert!(matches!(err, CanonError::Decode(_)), "got {err:?}");

--- a/crates/aristo-core/tests/canon_suggestions_decode.rs
+++ b/crates/aristo-core/tests/canon_suggestions_decode.rs
@@ -1,0 +1,99 @@
+//! §17 proof-tree suggestions — cross-repo contract decode test.
+//!
+//! `fixtures/canon-match.suggestions.golden.json` is a byte-copy of the
+//! cross-repo contract at
+//! `docs/mockups/17-proof-tree-suggestions/contract/canon-match.suggestions.golden.json`
+//! (meta-workspace). toolsaurus (the producer) asserts it *emits* this
+//! exact JSON; aristo (the consumer) asserts it *decodes* it into the
+//! wire types with no loss. A field rename on either side breaks one of
+//! the two tests — that is the anti-drift point.
+//!
+//! Scenario: one annotation matched the leaf `wal_commit_requires_fsync`
+//! (P-014). The objective is populated here to exercise the full
+//! post-Slice-0b shape (objective MAY be null pre-0b).
+
+use aristo_core::canon::{
+    CanonMatchResponse, ClusterSuggestion, PrefixTier, Relationship, SuggestedEntry,
+};
+
+const GOLDEN: &str = include_str!("fixtures/canon-match.suggestions.golden.json");
+
+#[test]
+fn golden_decodes_into_one_cluster_with_parent_objective_and_five_siblings() {
+    let resp: CanonMatchResponse =
+        serde_json::from_str(GOLDEN).expect("golden suggestions response must decode");
+
+    // Primary results decode as before.
+    assert_eq!(resp.results.len(), 1);
+    assert_eq!(resp.results[0].len(), 1);
+    assert_eq!(resp.results[0][0].canon_id, "wal_commit_requires_fsync");
+
+    // Exactly one cluster, aligned by annotation index.
+    let suggestions = resp.suggestions.expect("golden carries a suggestions field");
+    assert_eq!(suggestions.len(), 1, "one cluster, aligned to results[]");
+    let cluster: &ClusterSuggestion = suggestions[0]
+        .as_ref()
+        .expect("annotation 0 has a non-null cluster");
+    assert_eq!(cluster.for_canon_id, "wal_commit_requires_fsync");
+
+    // Objective = the kanon: proof-objective parent (D2).
+    let objective: &SuggestedEntry = cluster
+        .objective
+        .as_ref()
+        .expect("golden populates the objective (post-0b shape)");
+    assert_eq!(objective.canon_id, "wal_protocol_correctness");
+    assert_eq!(objective.prefix_tier, PrefixTier::Kanon);
+    assert_eq!(objective.relationship, Relationship::Parent);
+    assert!(
+        objective.backed_by.is_none(),
+        "kanon: objective has no backing"
+    );
+
+    // Five siblings, all relationship=sibling, all aristos: tier.
+    assert_eq!(cluster.siblings.len(), 5, "five co-member siblings");
+    assert!(
+        cluster
+            .siblings
+            .iter()
+            .all(|s| s.relationship == Relationship::Sibling),
+        "every sibling carries relationship=sibling"
+    );
+    assert!(
+        cluster
+            .siblings
+            .iter()
+            .all(|s| s.prefix_tier == PrefixTier::Aristos),
+        "every sibling is aristos: tier"
+    );
+
+    // The primary is excluded from siblings (server dedup ①).
+    assert!(
+        !cluster
+            .siblings
+            .iter()
+            .any(|s| s.canon_id == "wal_commit_requires_fsync"),
+        "the matched primary must not appear among its own siblings"
+    );
+
+    // Spot-check one sibling's full shape (carried verbatim).
+    let s0 = &cluster.siblings[0];
+    assert_eq!(s0.canon_id, "wal_nbackfills_orders_with_recovery");
+    assert_eq!(s0.scope, "turso");
+    assert_eq!(s0.version, "v0.1.0");
+    assert_eq!(s0.verification.coverage_level, "partial");
+    assert_eq!(s0.verification.test_binaries, vec!["wal_conform"]);
+    assert_eq!(
+        s0.backed_by.as_deref(),
+        Some("golden model + proofs + differential testing")
+    );
+}
+
+#[test]
+fn golden_re_serializes_lossless_round_trip() {
+    // Decode → re-encode → decode and assert structural stability. Pins
+    // the field names + casing against silent drift.
+    let resp: CanonMatchResponse = serde_json::from_str(GOLDEN).unwrap();
+    let reencoded = serde_json::to_string(&resp).unwrap();
+    let back: CanonMatchResponse = serde_json::from_str(&reencoded).unwrap();
+    assert_eq!(resp, back);
+}

--- a/crates/aristo-core/tests/fixtures/canon-match.suggestions.golden.json
+++ b/crates/aristo-core/tests/fixtures/canon-match.suggestions.golden.json
@@ -1,0 +1,88 @@
+{
+  "_comment": "GOLDEN /canon/match response for §17. Scenario: one annotation matched the leaf wal_commit_requires_fsync (P-014). toolsaurus (producer) MUST emit a response that matches this shape; aristo (consumer) MUST decode it. Objective is populated here to exercise the full post-Slice-0b shape; it MAY be null (siblings-only) pre-0b. Siblings exclude the primary (server dedup ①).",
+  "results": [
+    [
+      {
+        "canon_id": "wal_commit_requires_fsync",
+        "version": "v0.1.0",
+        "canonical_text": "A commit frame must reach stable storage via fsync before the transaction is reported as durable",
+        "confidence": 0.91,
+        "scope": "turso",
+        "prefix_tier": "aristos:",
+        "backed_by": "golden model + proofs + differential testing",
+        "linked": "arta_5b1c9f2a7e3d4068",
+        "verification": { "coverage_level": "tight", "test_binaries": ["wal_conform"] }
+      }
+    ]
+  ],
+  "suggestions": [
+    {
+      "for_canon_id": "wal_commit_requires_fsync",
+      "objective": {
+        "canon_id": "wal_protocol_correctness",
+        "version": "v0.1.0",
+        "canonical_text": "the WAL subsystem maintains LSN monotonicity, frame commitment ordering, recovery idempotency, checkpoint safety, and group-commit atomicity",
+        "scope": "turso",
+        "prefix_tier": "kanon:",
+        "backed_by": null,
+        "verification": { "coverage_level": "none", "test_binaries": [] },
+        "relationship": "parent"
+      },
+      "siblings": [
+        {
+          "canon_id": "wal_nbackfills_orders_with_recovery",
+          "version": "v0.1.0",
+          "canonical_text": "The nbackfills counter advances after frames are durable, so recovery never replays already-checkpointed frames",
+          "scope": "turso",
+          "prefix_tier": "aristos:",
+          "backed_by": "golden model + proofs + differential testing",
+          "verification": { "coverage_level": "partial", "test_binaries": ["wal_conform"] },
+          "relationship": "sibling"
+        },
+        {
+          "canon_id": "wal_find_frame_range_invariant",
+          "version": "v0.1.0",
+          "canonical_text": "find_frame never reads outside the live frame range [nbackfills, max_frame]",
+          "scope": "turso",
+          "prefix_tier": "aristos:",
+          "backed_by": "golden model + proofs + differential testing",
+          "verification": { "coverage_level": "tight", "test_binaries": ["wal_conform"] },
+          "relationship": "sibling"
+        },
+        {
+          "canon_id": "wal_initialized_reflects_sync_outcome",
+          "version": "v0.1.0",
+          "canonical_text": "The WAL initialized flag is set true only after a successful sync of the wal-header",
+          "scope": "turso",
+          "prefix_tier": "aristos:",
+          "backed_by": "golden model + proofs + differential testing",
+          "verification": { "coverage_level": "tight", "test_binaries": ["wal_conform"] },
+          "relationship": "sibling"
+        },
+        {
+          "canon_id": "wal_checkpoint_error_no_db_leak",
+          "version": "v0.1.0",
+          "canonical_text": "A checkpoint failure must not leak frames into the main database file",
+          "scope": "turso",
+          "prefix_tier": "aristos:",
+          "backed_by": "golden model + proofs + differential testing",
+          "verification": { "coverage_level": "tight", "test_binaries": ["wal_conform"] },
+          "relationship": "sibling"
+        },
+        {
+          "canon_id": "wal_truncate_atomic_under_concurrent_writers",
+          "version": "v0.1.0",
+          "canonical_text": "WAL truncate is atomic: no committed frame can be observed lost across the truncate operation",
+          "scope": "turso",
+          "prefix_tier": "aristos:",
+          "backed_by": "golden model + proofs + differential testing",
+          "verification": { "coverage_level": "tight", "test_binaries": ["wal_conform"] },
+          "relationship": "sibling"
+        }
+      ]
+    }
+  ],
+  "effective_scopes": ["turso", ":vanilla"],
+  "canon_version": "v0.2.0",
+  "matched_at": "2026-06-05T00:00:00Z"
+}


### PR DESCRIPTION
## §17 proof-tree canon suggestions — aristo (client)

Part of the cross-repo §17 feature. When a canon match hits an entry that's part of a proof, the server also returns the rest of that **proof-objective cluster**; aristo surfaces these as adoptable **suggestions** parallel to the existing accept/reject.

### What's here
- **Wire types** — `CanonMatchResponse.suggestions` (+ `ClusterSuggestion`/`SuggestedEntry`/`Relationship`), `#[serde(default)]` so old responses still decode. Decodes the cross-repo golden fixture.
- **Suggestions queue** — `.aristo/canon-suggestions/` (one task = one cluster) with client-side de-dup (drop already-bound/pending/rejected; collapse clusters sharing an objective).
- **`aristo canon suggestions`** — list / show / `--counts`.
- **`intent-review` session kind** — surfaces pending primary matches + suggestion clusters; parent decided once per cluster; **reject-parent discards dragged-in suggestions only and keeps any member that independently matched** (load-bearing test `reject_parent_keeps_independent_match`).
- **Adaptive modes** — backlog / status / matches|suggestions / scope, composed from existing flags (`--skip-canon`, `--filter`, `--queue-status`); no new grammar.
- **`aristo-intent-suggestions` skill** — the menu-directed orchestrator (bundled).

### Tests
`cargo test -p aristo-core -p aristo-cli` green (new: `canon_suggestions_decode`, `canon_suggestions_command`, `intent_review_session_kind`, `intent_modes`, skill-bundled); clippy clean.

Design + cross-repo contract: aretta-context `docs/mockups/17-proof-tree-suggestions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
