### PR TITLE
ci: notify aristo-docs to rebuild on docs changes

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,41 @@
+name: "notify aristo-docs on docs change"
+
+# Fires a repository_dispatch at the (private) aretta-ai/aristo-docs repo when the
+# OSS docs change, so the gated docs site (aristo.aretta.ai) rebuilds with fresh
+# prose without a push to that repo. aristo-docs' deploy.yml listens for the
+# `oss-docs-changed` event. See DP6 in the meta-workspace docs-platform.md.
+#
+# Secret required:
+#   ARISTO_DOCS_DISPATCH_TOKEN — fine-grained PAT scoped to aretta-ai/aristo-docs
+#                                with Repository permissions → Actions: Read and
+#                                write. Add under Settings → Secrets and variables
+#                                → Actions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: notify-aristo-docs
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch aristo-docs rebuild
+        env:
+          GH_TOKEN: ${{ secrets.ARISTO_DOCS_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api repos/aretta-ai/aristo-docs/dispatches \
+            -X POST \
+            -f event_type=oss-docs-changed \
+            -F client_payload[sha]="${{ github.sha }}" \
+            -F client_payload[ref]="${{ github.ref_name }}"

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -7,9 +7,12 @@ name: "notify aristo-docs on docs change"
 #
 # Secret required:
 #   ARISTO_DOCS_DISPATCH_TOKEN — fine-grained PAT scoped to aretta-ai/aristo-docs
-#                                with Repository permissions → Actions: Read and
-#                                write. Add under Settings → Secrets and variables
-#                                → Actions.
+#                                with Repository permissions → Contents: Read and
+#                                write (Metadata: Read is auto-included). This is
+#                                what the repository_dispatch API endpoint needs —
+#                                NOT Actions (that's for workflow_dispatch). Add it
+#                                under the aristo repo's Settings → Secrets and
+#                                variables → Actions.
 
 on:
   push:


### PR DESCRIPTION
Closes the docs auto-rebuild loop (DP6). On a push to `main` touching `docs/**`, this fires a `repository_dispatch` (`oss-docs-changed`) at the private `aretta-ai/aristo-docs` repo, whose `deploy.yml` already listens for it — so an OSS-prose edit here rebuilds and republishes the gated docs site without a manual push there.

Mirrors the existing `aretta-books → toolsaurus` dispatch pattern (`gh api .../dispatches`).

## One-time setup before merge

- [x] Add repo secret **`ARISTO_DOCS_DISPATCH_TOKEN`** — a fine-grained PAT, resource owner **`aretta-ai`**, scoped to **only** `aretta-ai/aristo-docs`, with **Repository permissions → Contents: Read and write** (Metadata: Read is auto-included). That's what the `repository_dispatch` endpoint requires — **not** Actions (that's for `workflow_dispatch`). Add it under this repo's Settings → Secrets and variables → Actions.

Until the secret exists the step fails closed (no dispatch); every `aristo-docs` push still rebuilds with fresh OSS prose regardless, so nothing breaks in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
