### PR TITLE
feat(#7): authored-intent review — `aristo review` + skill (engine's first consumer)

### DIFF
--- a/.aristo/doc/aggressiveness_off_is_hard_silence.md
+++ b/.aristo/doc/aggressiveness_off_is_hard_silence.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `aggressiveness_off_is_hard_silence`**
+
+Off MUST map to factor 0.0 — it is the global opt-out, and the scorer's fire test is `pressure * factor >= 1`, so only an exact 0.0 guarantees NOTHING ever fires regardless of how overdue a signal is. A non-zero `low` would let extreme pressure leak through a user who explicitly silenced nudges. The non-zero rungs are tunable defaults (D8); this table is the single place to retune global nudge sensitivity.
+
+<sub>Verify level: **neural**</sub>
+
+---

--- a/.aristo/doc/authored_intents_are_exactly_the_index_intents.md
+++ b/.aristo/doc/authored_intents_are_exactly_the_index_intents.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `authored_intents_are_exactly_the_index_intents`**
+
+Authored intents are exactly the `IndexEntry::Intent` entries — every one, including documentation-only `verify = false` intents (still claims the user authored and may want to review). Assumes are excluded: they state external invariants, not reviewable claims. This is the SAME set the engine's review_backlog metric counts, so `aristo review` and the nudge can never report a different backlog size for the same index.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/metrics_verifiable_excludes_assumes_and_doc_only_intents.md
+++ b/.aristo/doc/metrics_verifiable_excludes_assumes_and_doc_only_intents.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `metrics_verifiable_excludes_assumes_and_doc_only_intents`**
+
+The verifiable surface is intents with `verify != false` only — assumes are external invariants and never verified, and `verify = false` intents are documentation-only. `verified_clean` counts the verifiable intents in a terminal-clean status (the shared `Status::is_terminal_clean`), and `unverified` is exactly `verifiable - verified_clean`, so the three never disagree. The rate divides by `verifiable` (not by all intents), and is 0 when nothing is verifiable rather than a divide-by-zero.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/nudge_review_is_current_only_until_hash_drift.md
+++ b/.aristo/doc/nudge_review_is_current_only_until_hash_drift.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `nudge_review_is_current_only_until_hash_drift`**
+
+A review is current only while the annotation's text AND body hashes still match the snapshot taken when it was reviewed. Editing the claim or the covered code after review re-opens it (reads as unreviewed) — a reviewer approved a specific version, not the id forever. Without the hash check, a post-review edit would keep a stale 'reviewed' badge and the review backlog would under-count work that genuinely needs another look.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/nudge_scorer_off_silences_and_order_is_static_priority.md
+++ b/.aristo/doc/nudge_scorer_off_silences_and_order_is_static_priority.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `nudge_scorer_off_silences_and_order_is_static_priority`**
+
+Two invariants the scorer must preserve. First, `aggressiveness = off` is an absolute silence: its factor is 0.0 and the fire test is `pressure * factor >= 1`, so no signal fires at any pressure — even an infinite one (a tier-up). Second, the surfaced order is the static SIGNALS priority order, NOT the pressures: a count-pressure and a fraction-pressure are incommensurable, so sorting by pressure would let a noisy low-priority signal jump the queue ahead of a review the user actually needs to see first.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/nudge_union_is_read_only_and_tolerant.md
+++ b/.aristo/doc/nudge_union_is_read_only_and_tolerant.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `nudge_union_is_read_only_and_tolerant`**
+
+The union function is read-only and tolerant: it never mutates the workspace and never fails the caller on missing runtime state. Absent reviewed/proof-reviewed maps make everything read as unreviewed, an absent baseline disables the gain/slump signals, and an unreadable proofs dir contributes zero — degrade quietly. A nudge surface that errored or wrote files would turn an advisory into a workflow blocker, violating the engine's nudge-only posture (D3).
+
+<sub>Verify level: **neural**</sub>
+
+---

--- a/.aristo/doc/review_mark_validates_all_ids_before_writing.md
+++ b/.aristo/doc/review_mark_validates_all_ids_before_writing.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `review_mark_validates_all_ids_before_writing`**
+
+Marking validates EVERY requested id against the index before writing any review state: an unknown id (a typo, or an id that isn't an authored intent) marks nothing and errors. Partial marking on a bad batch would silently record some reviews and drop others, leaving the backlog disagreeing with what the user believes they reviewed.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/review_new_vs_backlog_needs_a_baseline.md
+++ b/.aristo/doc/review_new_vs_backlog_needs_a_baseline.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `review_new_vs_backlog_needs_a_baseline`**
+
+New vs backlog is computed against the SessionStart edit-window baseline: an unreviewed intent is 'new' only when a baseline WAS captured and its id is absent from it (authored this session). With no baseline the split is suppressed (new_count = 0) rather than guessed — calling everything 'new' on a fresh checkout would misreport a long-standing backlog as this-session's work.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/status_terminal_clean_is_verified_tested_neural.md
+++ b/.aristo/doc/status_terminal_clean_is_verified_tested_neural.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `status_terminal_clean_is_verified_tested_neural`**
+
+The terminal-clean states are exactly Verified, Tested, and Neural — an intent whose current code IS confirmed to hold under some verification method. Stale, Counterexample, Inconclusive, Unknown, and the B5b error states (Orphan / Forged / PendingDeepen) are NOT clean: each means the property is unproven, refuted, or untrusted for the current code. This is the single definition every surface — status counts, the badge rate, and the nudge engine's unverified backlog — shares, so they can never disagree on what 'verified' means.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T18:53:57.231596Z"
+generated_at = "2026-06-07T19:37:39.27234Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -101,6 +101,17 @@ text_hash = "sha256:bdb434ee177536ea137913a9c9ef700c2e326b2a07d2ad1942321b17e6eb
 body_hash = "sha256:bfc96b6fc698f698f92a72755df20ac53d9efed94db82d515643affe8cd3c0c5"
 file = "crates/aristo-cli/src/commands/index.rs"
 site = "fn atomic_write (line 326)"
+covered_region = "function"
+
+[authored_intents_are_exactly_the_index_intents]
+kind = "intent"
+text = "Authored intents are exactly the `IndexEntry::Intent` entries — every one, including documentation-only `verify = false` intents (still claims the user authored and may want to review). Assumes are excluded: they state external invariants, not reviewable claims. This is the SAME set the engine's review_backlog metric counts, so `aristo review` and the nudge can never report a different backlog size for the same index."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:9f309a1f2c52c2ed0340f99fd5f5ff771ffe47630fcf4c22f341f46de767323e"
+body_hash = "sha256:e8d1e8e1b02bfe7053a038d2395ee2824624653e171f26f66cbe4e8260cc7e17"
+file = "crates/aristo-cli/src/nudge/intents.rs"
+site = "fn authored_intents (line 25)"
 covered_region = "function"
 
 [backlog_append_is_read_modify_write_via_atomic]
@@ -617,7 +628,7 @@ status = "unknown"
 text_hash = "sha256:522b7b87d9e82c64526676a2c889c4c85ec5cd9f664097d84418db5ef2fcf44d"
 body_hash = "sha256:5836f8fa2b7ec5d6a9f37f643b76eda2e951f90c421496ffe875f770cc6e756f"
 file = "crates/aristo-cli/src/nudge/state.rs"
-site = "impl NudgeState::is_reviewed (line 109)"
+site = "impl NudgeState::is_reviewed (line 115)"
 covered_region = "function"
 
 [nudge_scorer_off_silences_and_order_is_static_priority]
@@ -628,7 +639,7 @@ status = "unknown"
 text_hash = "sha256:49a4a01352c3db6721786fcfa60d048158f7989ffe859083c1a460494d778faa"
 body_hash = "sha256:dbc43ab2643c2401bf194517b3674f181326662a79971676a39eeba0d4157597"
 file = "crates/aristo-cli/src/nudge/mod.rs"
-site = "fn score (line 227)"
+site = "fn score (line 228)"
 covered_region = "function"
 
 [nudge_union_is_read_only_and_tolerant]
@@ -637,9 +648,9 @@ text = "The union function is read-only and tolerant: it never mutates the works
 verify = "neural"
 status = "unknown"
 text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
-body_hash = "sha256:76dd420bf4ae25b8702ec4e2702fd8f923d2d7502ff933eb5b1a8b1bfe2d32b8"
+body_hash = "sha256:39a56812a96b7e6f06f91a89af81cfd931f94287273914f9ed088fda32b0581f"
 file = "crates/aristo-cli/src/commands/nudge.rs"
-site = "fn build_inputs (line 184)"
+site = "fn build_inputs (line 193)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]
@@ -803,6 +814,28 @@ text_hash = "sha256:89b3688be7f8cfc39cc31503feabc7ecc3043351f5d22af073672c2bb5c8
 body_hash = "sha256:9fb80092b5a1510522e1bfa26f5991ee2e282186e5ec5ba6100392a3e5d39876"
 file = "crates/aristo-cli/src/pipeline/queue.rs"
 site = "fn requeue (line 227)"
+covered_region = "function"
+
+[review_mark_validates_all_ids_before_writing]
+kind = "intent"
+text = "Marking validates EVERY requested id against the index before writing any review state: an unknown id (a typo, or an id that isn't an authored intent) marks nothing and errors. Partial marking on a bad batch would silently record some reviews and drop others, leaving the backlog disagreeing with what the user believes they reviewed."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:eab8b04c045da404119ce01ce1629d4b2fd25f1c188fdabd3e517ef063ebb442"
+body_hash = "sha256:2418cf7ea7bffbf6b0068430db350a8758e0810166895eaffd48f9522ea1712a"
+file = "crates/aristo-cli/src/commands/review.rs"
+site = "fn run_mark (line 67)"
+covered_region = "function"
+
+[review_new_vs_backlog_needs_a_baseline]
+kind = "intent"
+text = "New vs backlog is computed against the SessionStart edit-window baseline: an unreviewed intent is 'new' only when a baseline WAS captured and its id is absent from it (authored this session). With no baseline the split is suppressed (new_count = 0) rather than guessed — calling everything 'new' on a fresh checkout would misreport a long-standing backlog as this-session's work."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:1b7f1ceb706a487f4d943328c5566af04cbe753330a247505eaed4c35e91e3f0"
+body_hash = "sha256:cd1d109a548c30face26337cee6746fe02b8de911a7308c2b2e759ac9d32f32c"
+file = "crates/aristo-cli/src/commands/review.rs"
+site = "fn build_snapshot (line 166)"
 covered_region = "function"
 
 [rewrite_hashes_flag_is_migration_only_strict_default]

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T17:34:51.057594Z"
+generated_at = "2026-06-07T17:51:49.558495Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -56,7 +56,7 @@ status = "unknown"
 text_hash = "sha256:d5308f52c19b1bdbe2ad0c5ff247fd394ebd8a023ee16033a87c9762f345ab81"
 body_hash = "sha256:9e55ec61a23448589024b098299619a39b160be66699b59ea8e567f9d88723dc"
 file = "crates/aristo-core/src/config/mod.rs"
-site = "impl Aggressiveness::factor (line 472)"
+site = "impl Aggressiveness::factor (line 470)"
 covered_region = "function"
 
 [apply_findings_filters_open_by_default]
@@ -142,7 +142,7 @@ text = "`verification-rate` counts only intents (not assumes — assumes are ext
 verify = "neural"
 status = "unknown"
 text_hash = "sha256:d9acd5595fafabd8927cfbe243159010c610e72f84590d787f70163b4f6e5069"
-body_hash = "sha256:12c760ffa255c45f18973ecf9cbd3a62f69a883521dcf4126fc2fd7255d9c040"
+body_hash = "sha256:f27e81adecb0639c63aa72742e8b8fb754c03f4262deb0aaffc21b4651a2ab41"
 file = "crates/aristo-cli/src/commands/badge.rs"
 site = "fn is_verified_state (line 220)"
 covered_region = "function"
@@ -598,6 +598,17 @@ file = "crates/aristo-cli/src/commands/stamp.rs"
 site = "fn merge_status_from_prev (line 461)"
 covered_region = "function"
 
+[metrics_verifiable_excludes_assumes_and_doc_only_intents]
+kind = "intent"
+text = "The verifiable surface is intents with `verify != false` only — assumes are external invariants and never verified, and `verify = false` intents are documentation-only. `verified_clean` counts the verifiable intents in a terminal-clean status (the shared `Status::is_terminal_clean`), and `unverified` is exactly `verifiable - verified_clean`, so the three never disagree. The rate divides by `verifiable` (not by all intents), and is 0 when nothing is verifiable rather than a divide-by-zero."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:52b7fb9aaa1cdd9cf95be8e83b8af298a6746a8497f2d2119043f290b9b53b45"
+body_hash = "sha256:55e8c8089b540862a6aab7a1d7f9616868abc15e718d6b5e7995e20be7c5679a"
+file = "crates/aristo-core/src/metrics.rs"
+site = "impl Metrics (line 62)"
+covered_region = "impl_methods"
+
 [pending_and_claimed_share_parent_filesystem]
 kind = "assume"
 text = "The pending/ and claimed/ subdirectories share the same parent (the queue root under `.aristo/<pipeline>-queue/`), so cross-filesystem rename (EXDEV) is structurally impossible. A refactor that moved claimed/ to a different filesystem (e.g., tmpfs) would break the atomic claim by silently changing rename(2) semantics to copy+delete."
@@ -947,6 +958,17 @@ body_hash = "sha256:fc20c6867c9bd0ce7685f43a2af1f49fa1a59c9fc34863f9715a18f6a311
 file = "crates/aristo-cli/src/commands/status.rs"
 site = "fn print_canon_health (line 145)"
 covered_region = "function"
+
+[status_terminal_clean_is_verified_tested_neural]
+kind = "intent"
+text = "The terminal-clean states are exactly Verified, Tested, and Neural — an intent whose current code IS confirmed to hold under some verification method. Stale, Counterexample, Inconclusive, Unknown, and the B5b error states (Orphan / Forged / PendingDeepen) are NOT clean: each means the property is unproven, refuted, or untrusted for the current code. This is the single definition every surface — status counts, the badge rate, and the nudge engine's unverified backlog — shares, so they can never disagree on what 'verified' means."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:6a553ed4f85fd1a06c81879fbdea45f6149b5dd16269a458c52dedf0ce4b8394"
+body_hash = "sha256:314c776644f33a5e306ba65b4ec889557c417d54c937d31cabbf2543a3efaf9d"
+file = "crates/aristo-core/src/index/enums.rs"
+site = "impl Status (line 59)"
+covered_region = "impl_methods"
 
 [status_tier_call_matches_badge_command_call]
 kind = "intent"

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T18:42:28.282652Z"
+generated_at = "2026-06-07T18:53:57.231596Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -639,7 +639,7 @@ status = "unknown"
 text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
 body_hash = "sha256:76dd420bf4ae25b8702ec4e2702fd8f923d2d7502ff933eb5b1a8b1bfe2d32b8"
 file = "crates/aristo-cli/src/commands/nudge.rs"
-site = "fn build_inputs (line 182)"
+site = "fn build_inputs (line 184)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T18:10:15.04238Z"
+generated_at = "2026-06-07T18:27:12.282964Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -629,6 +629,17 @@ text_hash = "sha256:49a4a01352c3db6721786fcfa60d048158f7989ffe859083c1a460494d77
 body_hash = "sha256:2b5dd192c5067f7e75b0e215bd9a5f0243187f89b39818b216d48d99885d8e62"
 file = "crates/aristo-cli/src/nudge/mod.rs"
 site = "fn score (line 220)"
+covered_region = "function"
+
+[nudge_union_is_read_only_and_tolerant]
+kind = "intent"
+text = "The union function is read-only and tolerant: it never mutates the workspace and never fails the caller on missing runtime state. Absent reviewed/proof-reviewed maps make everything read as unreviewed, an absent baseline disables the gain/slump signals, and an unreadable proofs dir contributes zero — degrade quietly. A nudge surface that errored or wrote files would turn an advisory into a workflow blocker, violating the engine's nudge-only posture (D3)."
+verify = "neural"
+status = "unknown"
+text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
+body_hash = "sha256:76dd420bf4ae25b8702ec4e2702fd8f923d2d7502ff933eb5b1a8b1bfe2d32b8"
+file = "crates/aristo-cli/src/commands/nudge.rs"
+site = "fn build_inputs (line 34)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T17:23:02.857143Z"
+generated_at = "2026-06-07T17:34:51.057594Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -46,6 +46,17 @@ text_hash = "sha256:1033936bd224f14b75c286e4c8b2df9321719a0dfcd8de8ddf3d930d8a91
 body_hash = "sha256:9c756bf103f3f04ad0c2a049fc33cb586b5267b2fb3812ae4142d4331eafb564"
 file = "crates/aristo-cli/src/skills/install.rs"
 site = "fn agents_md_uninstall (line 206)"
+covered_region = "function"
+
+[aggressiveness_off_is_hard_silence]
+kind = "intent"
+text = "Off MUST map to factor 0.0 — it is the global opt-out, and the scorer's fire test is `pressure * factor >= 1`, so only an exact 0.0 guarantees NOTHING ever fires regardless of how overdue a signal is. A non-zero `low` would let extreme pressure leak through a user who explicitly silenced nudges. The non-zero rungs are tunable defaults (D8); this table is the single place to retune global nudge sensitivity."
+verify = "neural"
+status = "unknown"
+text_hash = "sha256:d5308f52c19b1bdbe2ad0c5ff247fd394ebd8a023ee16033a87c9762f345ab81"
+body_hash = "sha256:9e55ec61a23448589024b098299619a39b160be66699b59ea8e567f9d88723dc"
+file = "crates/aristo-core/src/config/mod.rs"
+site = "impl Aggressiveness::factor (line 472)"
 covered_region = "function"
 
 [apply_findings_filters_open_by_default]

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T18:07:08.516654Z"
+generated_at = "2026-06-07T18:10:15.04238Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -609,6 +609,17 @@ file = "crates/aristo-core/src/metrics.rs"
 site = "impl Metrics (line 62)"
 covered_region = "impl_methods"
 
+[nudge_review_is_current_only_until_hash_drift]
+kind = "intent"
+text = "A review is current only while the annotation's text AND body hashes still match the snapshot taken when it was reviewed. Editing the claim or the covered code after review re-opens it (reads as unreviewed) — a reviewer approved a specific version, not the id forever. Without the hash check, a post-review edit would keep a stale 'reviewed' badge and the review backlog would under-count work that genuinely needs another look."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:522b7b87d9e82c64526676a2c889c4c85ec5cd9f664097d84418db5ef2fcf44d"
+body_hash = "sha256:5836f8fa2b7ec5d6a9f37f643b76eda2e951f90c421496ffe875f770cc6e756f"
+file = "crates/aristo-cli/src/nudge/state.rs"
+site = "impl NudgeState::is_reviewed (line 109)"
+covered_region = "function"
+
 [nudge_scorer_off_silences_and_order_is_static_priority]
 kind = "intent"
 text = "Two invariants the scorer must preserve. First, `aggressiveness = off` is an absolute silence: its factor is 0.0 and the fire test is `pressure * factor >= 1`, so no signal fires at any pressure — even an infinite one (a tier-up). Second, the surfaced order is the static SIGNALS priority order, NOT the pressures: a count-pressure and a fraction-pressure are incommensurable, so sorting by pressure would let a noisy low-priority signal jump the queue ahead of a review the user actually needs to see first."
@@ -617,7 +628,7 @@ status = "unknown"
 text_hash = "sha256:49a4a01352c3db6721786fcfa60d048158f7989ffe859083c1a460494d778faa"
 body_hash = "sha256:2b5dd192c5067f7e75b0e215bd9a5f0243187f89b39818b216d48d99885d8e62"
 file = "crates/aristo-cli/src/nudge/mod.rs"
-site = "fn score (line 218)"
+site = "fn score (line 220)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T17:51:49.558495Z"
+generated_at = "2026-06-07T18:07:08.516654Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -608,6 +608,17 @@ body_hash = "sha256:55e8c8089b540862a6aab7a1d7f9616868abc15e718d6b5e7995e20be7c5
 file = "crates/aristo-core/src/metrics.rs"
 site = "impl Metrics (line 62)"
 covered_region = "impl_methods"
+
+[nudge_scorer_off_silences_and_order_is_static_priority]
+kind = "intent"
+text = "Two invariants the scorer must preserve. First, `aggressiveness = off` is an absolute silence: its factor is 0.0 and the fire test is `pressure * factor >= 1`, so no signal fires at any pressure — even an infinite one (a tier-up). Second, the surfaced order is the static SIGNALS priority order, NOT the pressures: a count-pressure and a fraction-pressure are incommensurable, so sorting by pressure would let a noisy low-priority signal jump the queue ahead of a review the user actually needs to see first."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:49a4a01352c3db6721786fcfa60d048158f7989ffe859083c1a460494d778faa"
+body_hash = "sha256:2b5dd192c5067f7e75b0e215bd9a5f0243187f89b39818b216d48d99885d8e62"
+file = "crates/aristo-cli/src/nudge/mod.rs"
+site = "fn score (line 218)"
+covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]
 kind = "assume"

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T18:27:12.282964Z"
+generated_at = "2026-06-07T18:42:28.282652Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -626,9 +626,9 @@ text = "Two invariants the scorer must preserve. First, `aggressiveness = off` i
 verify = "test"
 status = "unknown"
 text_hash = "sha256:49a4a01352c3db6721786fcfa60d048158f7989ffe859083c1a460494d778faa"
-body_hash = "sha256:2b5dd192c5067f7e75b0e215bd9a5f0243187f89b39818b216d48d99885d8e62"
+body_hash = "sha256:dbc43ab2643c2401bf194517b3674f181326662a79971676a39eeba0d4157597"
 file = "crates/aristo-cli/src/nudge/mod.rs"
-site = "fn score (line 220)"
+site = "fn score (line 227)"
 covered_region = "function"
 
 [nudge_union_is_read_only_and_tolerant]
@@ -639,7 +639,7 @@ status = "unknown"
 text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
 body_hash = "sha256:76dd420bf4ae25b8702ec4e2702fd8f923d2d7502ff933eb5b1a8b1bfe2d32b8"
 file = "crates/aristo-cli/src/commands/nudge.rs"
-site = "fn build_inputs (line 34)"
+site = "fn build_inputs (line 182)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,13 @@
 # structurally impossible.
 .aristo/sessions/
 
+# Nudge/progress engine state (Phase 18 #9): the reviewed map, edit-window
+# baseline, edit counter, and per-signal throttle. Per-user runtime — like
+# `.aristo/sessions/`, the *effects* of reviews reach git via normal commits;
+# this file is a personal audit trail. (Consumer-repo gitignore wiring is
+# deferred to #9 / audit A3; hand-maintained here for dogfooding.)
+.aristo/nudge-state.toml
+
 # Per-pipeline queue state — pending tasks, claimed-in-flight entries,
 # and the workers' atomic-rename machinery. Runtime only; a fresh clone
 # computes its own queue on the next `aristo verify` / `aristo critique`.

--- a/crates/aristo-cli/src/commands/badge.rs
+++ b/crates/aristo-cli/src/commands/badge.rs
@@ -229,7 +229,9 @@ impl Counters {
     id = "badge_verification_rate_counts_only_terminal_clean_intents"
 )]
 fn is_verified_state(status: Status) -> bool {
-    matches!(status, Status::Verified | Status::Tested | Status::Neural)
+    // Delegates to the single shared definition (A2) so the badge rate, the
+    // status counts, and the nudge engine can never disagree on "verified".
+    status.is_terminal_clean()
 }
 
 // ─── SVG rendering ────────────────────────────────────────────────────
@@ -491,6 +493,59 @@ mod tests {
         ]);
         let c = Counters::from(&index);
         assert_eq!(c.verification_rate_pct, 50);
+    }
+
+    #[test]
+    fn metrics_and_badge_agree_on_verified_clean_count() {
+        // A2 anti-drift: the badge's verification_rate_pct and the nudge
+        // engine's Metrics derive their "verified" numerator from ONE shared
+        // definition (Status::is_terminal_clean). This pins the two surfaces
+        // together so a future change to one can't silently diverge.
+        use aristo_core::metrics::Metrics;
+        let index = make_index(vec![
+            (
+                "a",
+                intent(
+                    VerifyLevel::Method(VerifyMethod::Neural),
+                    Status::Neural,
+                    false,
+                ),
+            ), // clean
+            (
+                "b",
+                intent(
+                    VerifyLevel::Method(VerifyMethod::Test),
+                    Status::Stale,
+                    false,
+                ),
+            ), // not clean
+            (
+                "c",
+                intent(
+                    VerifyLevel::Method(VerifyMethod::Full),
+                    Status::Verified,
+                    false,
+                ),
+            ), // clean
+            (
+                "d",
+                intent(VerifyLevel::Bool(false), Status::Unknown, false),
+            ), // doc-only
+            ("e", assume()), // assume
+        ]);
+        let counters = Counters::from(&index);
+        let metrics = Metrics::from_index(&index, &BTreeMap::new(), None);
+
+        assert_eq!(metrics.intents, 4, "4 intents (assume excluded)");
+        assert_eq!(metrics.verified_clean, 2, "a + c are terminal-clean");
+        // The badge's published rate (verified-clean / all-intents) must be
+        // reproducible from the same shared count the engine reports.
+        let expected_pct =
+            ((metrics.verified_clean as f64 / metrics.intents as f64) * 100.0).round() as u32;
+        assert_eq!(
+            counters.verification_rate_pct, expected_pct,
+            "badge rate must derive from the same verified-clean count the engine sees"
+        );
     }
 
     // ─── rendering via badge-maker (shields-parity output) ───────────

--- a/crates/aristo-cli/src/commands/metrics.rs
+++ b/crates/aristo-cli/src/commands/metrics.rs
@@ -1,0 +1,62 @@
+//! `aristo metrics` — the machine-readable project-metrics surface
+//! (Phase 18 #9). Emits the index-derived [`Metrics`] as JSON (`--json`) or a
+//! short human summary.
+//!
+//! The nudge/progress engine computes the same [`Metrics`] value internally;
+//! this command exposes it for tooling and the `aristo-status` skill (#12).
+//! It is read-only against the index (it walks source only for the coverage
+//! denominator the tier formula needs), so it never mutates the workspace.
+
+use aristo_core::metrics::Metrics;
+use aristo_core::walk::{count_fns_per_module_with, WalkOptions};
+
+use crate::commands::index::workspace_or_error;
+use crate::commands::show::read_index;
+use crate::preflight::{emit_advisory_if_stale, freshness_check};
+use crate::{CliError, CliResult};
+
+pub(crate) fn run(json: bool) -> CliResult<()> {
+    let ws = workspace_or_error()?;
+    emit_advisory_if_stale(&freshness_check(&ws));
+    let index = read_index(&ws.index_path())?;
+
+    // Walk source for the per-module fn surface the coverage score needs as
+    // its denominator — same conservative `WalkOptions::none()` the badge
+    // command uses (read-only, no config write path).
+    let fn_counts =
+        count_fns_per_module_with(&ws.root, &WalkOptions::none()).map_err(|e| CliError::Other {
+            message: format!("failed to walk source for metrics coverage: {e}"),
+            exit_code: 1,
+        })?;
+    let default_method = ws.load_config().verify.default_method;
+    let metrics = Metrics::from_index(&index, &fn_counts, default_method);
+
+    if json {
+        let out = serde_json::to_string_pretty(&metrics).map_err(|e| CliError::Other {
+            message: format!("serializing metrics: {e}"),
+            exit_code: 1,
+        })?;
+        println!("{out}");
+    } else {
+        print_human(&metrics);
+    }
+    Ok(())
+}
+
+fn print_human(m: &Metrics) {
+    let pct = (m.verification_rate * 100.0).round() as u32;
+    println!("Aristo metrics");
+    println!("  intents:     {}", m.intents);
+    println!("  assumes:     {}", m.assumes);
+    println!("  verifiable:  {}", m.verifiable);
+    println!(
+        "  verified:    {} / {} ({pct}%)",
+        m.verified_clean, m.verifiable
+    );
+    println!("  unverified:  {}", m.unverified);
+    println!(
+        "  tier:        {} (score {:.2})",
+        m.tier.label(),
+        m.visible_score
+    );
+}

--- a/crates/aristo-cli/src/commands/mod.rs
+++ b/crates/aristo-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod install_skills_hook;
 pub(crate) mod lang;
 pub(crate) mod lint;
 pub(crate) mod list;
+pub(crate) mod metrics;
 pub(crate) mod rename;
 pub(crate) mod session;
 pub(crate) mod show;

--- a/crates/aristo-cli/src/commands/mod.rs
+++ b/crates/aristo-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod lang;
 pub(crate) mod lint;
 pub(crate) mod list;
 pub(crate) mod metrics;
+pub(crate) mod nudge;
 pub(crate) mod rename;
 pub(crate) mod session;
 pub(crate) mod show;

--- a/crates/aristo-cli/src/commands/mod.rs
+++ b/crates/aristo-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod list;
 pub(crate) mod metrics;
 pub(crate) mod nudge;
 pub(crate) mod rename;
+pub(crate) mod review;
 pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod stamp;

--- a/crates/aristo-cli/src/commands/nudge.rs
+++ b/crates/aristo-cli/src/commands/nudge.rs
@@ -1,7 +1,9 @@
-//! `aristo nudge` — the nudge/progress engine's union function + (S0d) the
-//! introspection readout. The hook-driven emitter (`--event`) and throttle
-//! land in the next slice; this one wires the engine end-to-end and lets a
-//! human (or the #12 status skill) see what the engine *would* surface.
+//! `aristo nudge` — the nudge/progress engine's union function + surfaces
+//! (Phase 18 #9, S0d). With no `--event` it prints what the engine would
+//! surface (human introspection); with `--event <post-tool-use|stop|
+//! session-start>` it runs as a Claude Code hook emitter and ALWAYS exits 0
+//! (a nudge must never break the agent). The hook install + the live spike
+//! that validates the Stop-hook contract land in S0d.3.
 //!
 //! The union function [`build_inputs`] is the COMPUTE join the scorer reads:
 //! the index-derived [`Metrics`] plus the runtime facts only the cli can see
@@ -9,26 +11,174 @@
 //! read-only and never fails the caller on missing pieces — a nudge surface
 //! must degrade quietly, never break a workflow.
 
-use aristo_core::config::ConfigFile;
+use std::io::Read;
+
+use aristo_core::config::{Aggressiveness, ConfigFile};
 use aristo_core::index::IndexEntry;
 use aristo_core::metrics::Metrics;
 use aristo_core::walk::{count_fns_per_module_with, WalkOptions};
 
 use crate::commands::index::workspace_or_error;
 use crate::commands::show::read_index;
-use crate::nudge::state::{NudgeState, STATE_FILENAME};
-use crate::nudge::{score, Audience, EngineInputs};
+use crate::nudge::state::{Baseline, NudgeState, STATE_FILENAME};
+use crate::nudge::{score, throttle, Audience, Decision, EngineInputs};
 use crate::{CliError, CliResult, Workspace};
 
-pub(crate) fn run() -> CliResult<()> {
+/// Which Claude Code hook event this invocation is serving (or `None` for the
+/// human introspection readout).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HookEvent {
+    PostToolUse,
+    Stop,
+    SessionStart,
+}
+
+fn parse_event(raw: &str) -> Option<HookEvent> {
+    match raw {
+        "post-tool-use" | "PostToolUse" => Some(HookEvent::PostToolUse),
+        "stop" | "Stop" => Some(HookEvent::Stop),
+        "session-start" | "SessionStart" => Some(HookEvent::SessionStart),
+        _ => None,
+    }
+}
+
+pub(crate) fn run(event: Option<String>) -> CliResult<()> {
     let ws = workspace_or_error()?;
     let config = ws.load_config();
-    let state = NudgeState::load(&ws.aristo_dir().join(STATE_FILENAME));
-    let inputs = build_inputs(&ws, &config, &state)?;
     let aggressiveness = config.nudges.aggressiveness;
-    let decision = score(&inputs, aggressiveness);
-    print_readout(&inputs, aggressiveness, &decision);
+
+    // No --event → human introspection readout (the only mode that prints to
+    // a human and may surface an error).
+    let Some(raw) = event else {
+        let state = NudgeState::load(&ws.aristo_dir().join(STATE_FILENAME));
+        let inputs = build_inputs(&ws, &config, &state)?;
+        let decision = score(&inputs, aggressiveness);
+        print_readout(&inputs, aggressiveness, &decision);
+        return Ok(());
+    };
+
+    // Hook mode: a nudge hook must NEVER break the agent. Swallow every error
+    // and exit 0 — the worst case is "no nudge this turn".
+    let _ = emit_for_event(&ws, &config, aggressiveness, &raw);
     Ok(())
+}
+
+fn emit_for_event(
+    ws: &Workspace,
+    config: &ConfigFile,
+    aggressiveness: Aggressiveness,
+    raw_event: &str,
+) -> CliResult<()> {
+    let Some(event) = parse_event(raw_event) else {
+        return Ok(()); // unknown event → silent
+    };
+    let state_path = ws.aristo_dir().join(STATE_FILENAME);
+    let mut state = NudgeState::load(&state_path);
+    let now = now_epoch();
+
+    match event {
+        HookEvent::PostToolUse => {
+            // Count edit-like tool calls toward the authoring-debt signal.
+            if stdin_tool_is_edit() {
+                state.edits_since_annotation = state.edits_since_annotation.saturating_add(1);
+                let _ = state.save(&state_path);
+            }
+            if aggressiveness.is_off() {
+                return Ok(());
+            }
+            let inputs = build_inputs(ws, config, &state)?;
+            let decision = score(&inputs, aggressiveness);
+            // Agent surface (authoring_debt). Throttle it too so it doesn't
+            // nag on every edit once over threshold.
+            if let Some(f) = decision.agent.iter().find(|f| f.id == "authoring_debt") {
+                if throttle::may_surface(
+                    state.throttle.get(f.id),
+                    now,
+                    aggressiveness,
+                    f.metric,
+                    f.base,
+                ) {
+                    emit_agent_reminder(inputs.edits_since_annotation);
+                    state.throttle.insert(
+                        f.id.to_string(),
+                        throttle::record_after_surface(now, f.metric),
+                    );
+                    let _ = state.save(&state_path);
+                }
+            }
+        }
+        HookEvent::Stop => {
+            if aggressiveness.is_off() {
+                return Ok(());
+            }
+            let inputs = build_inputs(ws, config, &state)?;
+            let decision = score(&inputs, aggressiveness);
+            // Consolidated human nudge: surface if ANY fired human signal
+            // clears its throttle. Update records for the ones that did.
+            let cleared: Vec<crate::nudge::Fired> = decision
+                .human
+                .iter()
+                .filter(|f| {
+                    throttle::may_surface(
+                        state.throttle.get(f.id),
+                        now,
+                        aggressiveness,
+                        f.metric,
+                        f.base,
+                    )
+                })
+                .cloned()
+                .collect();
+            if !cleared.is_empty() {
+                emit_stop_reminder(&decision, &inputs);
+                for f in &cleared {
+                    state.throttle.insert(
+                        f.id.to_string(),
+                        throttle::record_after_surface(now, f.metric),
+                    );
+                }
+                let _ = state.save(&state_path);
+            }
+        }
+        HookEvent::SessionStart => {
+            // Capture the edit-window baseline + reset the edit counter, then
+            // re-surface any standing backlog as additionalContext.
+            let inputs = build_inputs(ws, config, &state)?;
+            state.baseline = Some(Baseline {
+                score: inputs.metrics.visible_score,
+                tier: inputs.metrics.tier.label().to_string(),
+            });
+            state.edits_since_annotation = 0;
+            let _ = state.save(&state_path);
+            if aggressiveness.is_off() {
+                return Ok(());
+            }
+            let decision = score(&inputs, aggressiveness);
+            if !decision.human.is_empty() {
+                emit_session_start_context(&decision, &inputs);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn now_epoch() -> u64 {
+    time::OffsetDateTime::now_utc().unix_timestamp().max(0) as u64
+}
+
+/// Read the PostToolUse hook payload from stdin and decide whether the tool
+/// was an edit-like (source-mutating) call. Tolerant: any parse failure or
+/// absent stdin counts as "not an edit" (don't bump on uncertainty).
+fn stdin_tool_is_edit() -> bool {
+    let mut buf = String::new();
+    if std::io::stdin().read_to_string(&mut buf).is_err() || buf.trim().is_empty() {
+        return false;
+    }
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&buf) else {
+        return false;
+    };
+    let tool = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+    matches!(tool, "Edit" | "Write" | "MultiEdit" | "NotebookEdit")
 }
 
 #[aristo::intent(
@@ -161,5 +311,102 @@ fn print_readout(
     for fired in &decision.agent {
         let _ = Audience::Agent; // audiences are surfaced on different channels
         println!("  · [agent] {} (pressure {:.2})", fired.id, fired.pressure);
+    }
+}
+
+// ─── hook emit (D10: the CLI nudges the AGENT; the agent talks to the human) ──
+
+/// PostToolUse agent reminder: prod the coding agent to capture intent.
+fn emit_agent_reminder(edits: usize) {
+    println!("<system-reminder>");
+    println!(
+        "Aristo: {edits} source edits since your last annotation. If any of \
+         them embodied a non-obvious decision (a chosen invariant, a \
+         refactor trap, an intentional-not-incomplete choice), capture it now \
+         with an `aristo::intent` while the rationale is fresh — see the \
+         aristo-authoring skill. Skip if the edits were purely mechanical."
+    );
+    println!("</system-reminder>");
+}
+
+/// Stop consolidated nudge: a hook can't pop an AskUserQuestion (D10), so it
+/// nudges the AGENT to offer the user the recommended review at a natural
+/// pause. Subject-only — about the user's own annotations/verification.
+fn emit_stop_reminder(decision: &Decision, inputs: &EngineInputs) {
+    println!("<system-reminder>");
+    println!("Aristo progress nudge — {}.", backlog_summary(inputs));
+    if let Some(rec) = decision.recommended() {
+        println!(
+            "At a natural pause, offer the user: {}. Don't interrupt mid-task.",
+            recommended_phrase(rec)
+        );
+    }
+    println!("</system-reminder>");
+}
+
+/// SessionStart additionalContext: re-surface standing backlog so the agent
+/// can offer a review early in the session. Same JSON shape the skills hook
+/// uses.
+fn emit_session_start_context(decision: &Decision, inputs: &EngineInputs) {
+    let mut context = format!("Aristo: {}.", backlog_summary(inputs));
+    if let Some(rec) = decision.recommended() {
+        context.push_str(&format!(
+            " When the user reaches a natural pause, offer: {}.",
+            recommended_phrase(rec)
+        ));
+    }
+    let json = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": context,
+        }
+    });
+    println!("{json}");
+}
+
+/// A subject-only one-line summary of the standing backlog.
+fn backlog_summary(inputs: &EngineInputs) -> String {
+    let mut parts = Vec::new();
+    if inputs.unreviewed_intents > 0 {
+        parts.push(format!(
+            "{} intent(s) await review",
+            inputs.unreviewed_intents
+        ));
+    }
+    if inputs.metrics.unverified > 0 {
+        parts.push(format!(
+            "{} of {} intents unverified",
+            inputs.metrics.unverified, inputs.metrics.verifiable
+        ));
+    }
+    if inputs.proofs_awaiting_review > 0 {
+        parts.push(format!(
+            "{} proof(s) await review",
+            inputs.proofs_awaiting_review
+        ));
+    }
+    if parts.is_empty() {
+        format!(
+            "tier {} (score {:.2})",
+            inputs.metrics.tier.label(),
+            inputs.metrics.visible_score
+        )
+    } else {
+        parts.join(" · ")
+    }
+}
+
+/// Map a signal id to the low-friction action the agent should offer.
+fn recommended_phrase(signal_id: &str) -> &'static str {
+    match signal_id {
+        "congrats" => "a quick note on the progress just made (tier/score went up)",
+        "review_backlog" => {
+            "an intent review — Critique-first runs in the background while you continue"
+        }
+        "canon_pending" => "a look at the pending canon matches (aristo-intent-suggestions)",
+        "verify_backlog" => "running `aristo verify` (can run in the background)",
+        "proof_review_backlog" => "a review of the freshly-verified proofs",
+        "score_slump" => "shoring up coverage — annotate or verify to recover the score",
+        _ => "a review of the outstanding aristo items",
     }
 }

--- a/crates/aristo-cli/src/commands/nudge.rs
+++ b/crates/aristo-cli/src/commands/nudge.rs
@@ -1,0 +1,165 @@
+//! `aristo nudge` — the nudge/progress engine's union function + (S0d) the
+//! introspection readout. The hook-driven emitter (`--event`) and throttle
+//! land in the next slice; this one wires the engine end-to-end and lets a
+//! human (or the #12 status skill) see what the engine *would* surface.
+//!
+//! The union function [`build_inputs`] is the COMPUTE join the scorer reads:
+//! the index-derived [`Metrics`] plus the runtime facts only the cli can see
+//! (reviewed map, proof-reviewed map, edit-window baseline, sign-in). It is
+//! read-only and never fails the caller on missing pieces — a nudge surface
+//! must degrade quietly, never break a workflow.
+
+use aristo_core::config::ConfigFile;
+use aristo_core::index::IndexEntry;
+use aristo_core::metrics::Metrics;
+use aristo_core::walk::{count_fns_per_module_with, WalkOptions};
+
+use crate::commands::index::workspace_or_error;
+use crate::commands::show::read_index;
+use crate::nudge::state::{NudgeState, STATE_FILENAME};
+use crate::nudge::{score, Audience, EngineInputs};
+use crate::{CliError, CliResult, Workspace};
+
+pub(crate) fn run() -> CliResult<()> {
+    let ws = workspace_or_error()?;
+    let config = ws.load_config();
+    let state = NudgeState::load(&ws.aristo_dir().join(STATE_FILENAME));
+    let inputs = build_inputs(&ws, &config, &state)?;
+    let aggressiveness = config.nudges.aggressiveness;
+    let decision = score(&inputs, aggressiveness);
+    print_readout(&inputs, aggressiveness, &decision);
+    Ok(())
+}
+
+#[aristo::intent(
+    "The union function is read-only and tolerant: it never mutates the \
+     workspace and never fails the caller on missing runtime state. Absent \
+     reviewed/proof-reviewed maps make everything read as unreviewed, an \
+     absent baseline disables the gain/slump signals, and an unreadable \
+     proofs dir contributes zero — degrade quietly. A nudge surface that \
+     errored or wrote files would turn an advisory into a workflow blocker, \
+     violating the engine's nudge-only posture (D3).",
+    verify = "neural",
+    id = "nudge_union_is_read_only_and_tolerant"
+)]
+/// Join the index-derived metrics with the cli-resident runtime signals into
+/// the [`EngineInputs`] the scorer consumes. Read-only; tolerant of missing
+/// state (the engine simply sees more as unreviewed / no baseline).
+pub(crate) fn build_inputs(
+    ws: &Workspace,
+    config: &ConfigFile,
+    state: &NudgeState,
+) -> CliResult<EngineInputs> {
+    let index = read_index(&ws.index_path())?;
+
+    // Coverage denominator for the tier formula (read-only walk, as in badge).
+    let fn_counts =
+        count_fns_per_module_with(&ws.root, &WalkOptions::none()).map_err(|e| CliError::Other {
+            message: format!("failed to walk source for metrics coverage: {e}"),
+            exit_code: 1,
+        })?;
+    let metrics = Metrics::from_index(&index, &fn_counts, config.verify.default_method);
+
+    // Unreviewed authored intents: every index intent the reviewed map doesn't
+    // currently vouch for (absent, unmarked, or hash-drifted).
+    let intent_keys: Vec<(String, String, String)> = index
+        .entries
+        .iter()
+        .filter_map(|(id, entry)| match entry {
+            IndexEntry::Intent(e) => Some((
+                id.as_str().to_string(),
+                e.text_hash.as_str().to_string(),
+                e.body_hash.as_str().to_string(),
+            )),
+            IndexEntry::Assume(_) => None,
+        })
+        .collect();
+    let unreviewed_intents = state.unreviewed_count(
+        intent_keys
+            .iter()
+            .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str())),
+    );
+
+    let proofs_awaiting_review = count_proofs_awaiting(ws, state);
+
+    let (prior_score, tier_increased) = match &state.baseline {
+        Some(b) => (
+            Some(b.score),
+            metrics.tier.label() != b.tier && metrics.visible_score > b.score,
+        ),
+        None => (None, false),
+    };
+
+    // Local-only sign-in check (env var / config files; never network).
+    let signed_in = aristo_core::auth::resolve_full().is_ok();
+
+    Ok(EngineInputs {
+        metrics,
+        edits_since_annotation: state.edits_since_annotation,
+        unreviewed_intents,
+        proofs_awaiting_review,
+        // TODO(S0d follow-up): read pending canon matches + suggestions from
+        // the local `.aristo/canon-matches.toml` + suggestions queue. Until
+        // then the (signed-in-gated) canon signal stays silent.
+        canon_pending: 0,
+        prior_score,
+        tier_increased,
+        signed_in,
+    })
+}
+
+/// Count `.aristo/proofs/<id>.proof` files whose verdict the proof-reviewed
+/// map doesn't yet vouch for. Absent dir → 0.
+fn count_proofs_awaiting(ws: &Workspace, state: &NudgeState) -> usize {
+    let dir = ws.aristo_dir().join("proofs");
+    let Ok(read) = std::fs::read_dir(&dir) else {
+        return 0;
+    };
+    let mut n = 0usize;
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("proof") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let id = stem.replace("__", ":");
+        if !state.proof_reviewed.get(&id).copied().unwrap_or(false) {
+            n += 1;
+        }
+    }
+    n
+}
+
+fn print_readout(
+    inputs: &EngineInputs,
+    aggressiveness: aristo_core::config::Aggressiveness,
+    decision: &crate::nudge::Decision,
+) {
+    println!("Aristo nudge engine — would-surface readout");
+    println!("  aggressiveness: {aggressiveness:?}");
+    println!(
+        "  inputs: {} unreviewed · {} unverified/{} verifiable · {} proofs awaiting · score {:.2} ({})",
+        inputs.unreviewed_intents,
+        inputs.metrics.unverified,
+        inputs.metrics.verifiable,
+        inputs.proofs_awaiting_review,
+        inputs.metrics.visible_score,
+        inputs.metrics.tier.label(),
+    );
+    if decision.is_silent() {
+        println!("  → nothing would fire.");
+        return;
+    }
+    if let Some(rec) = decision.recommended() {
+        println!("  → recommended: {rec}");
+    }
+    for fired in &decision.human {
+        println!("  · [human] {} (pressure {:.2})", fired.id, fired.pressure);
+    }
+    for fired in &decision.agent {
+        let _ = Audience::Agent; // audiences are surfaced on different channels
+        println!("  · [agent] {} (pressure {:.2})", fired.id, fired.pressure);
+    }
+}

--- a/crates/aristo-cli/src/commands/nudge.rs
+++ b/crates/aristo-cli/src/commands/nudge.rs
@@ -14,7 +14,6 @@
 use std::io::Read;
 
 use aristo_core::config::{Aggressiveness, ConfigFile};
-use aristo_core::index::IndexEntry;
 use aristo_core::metrics::Metrics;
 use aristo_core::walk::{count_fns_per_module_with, WalkOptions};
 
@@ -148,6 +147,16 @@ fn emit_for_event(
                 score: inputs.metrics.visible_score,
                 tier: inputs.metrics.tier.label().to_string(),
             });
+            // Snapshot the authored-intent id-set so #7 can split the review
+            // backlog into new-this-session vs carried-over. Best-effort: if
+            // the index can't be read, leave the window uncaptured (the split
+            // is then suppressed, not guessed).
+            state.window_intent_ids = read_index(&ws.index_path()).ok().map(|idx| {
+                crate::nudge::intents::authored_intents(&idx)
+                    .into_iter()
+                    .map(|i| i.id)
+                    .collect()
+            });
             state.edits_since_annotation = 0;
             let _ = state.save(&state_path);
             if aggressiveness.is_off() {
@@ -211,23 +220,14 @@ pub(crate) fn build_inputs(
     let metrics = Metrics::from_index(&index, &fn_counts, config.verify.default_method);
 
     // Unreviewed authored intents: every index intent the reviewed map doesn't
-    // currently vouch for (absent, unmarked, or hash-drifted).
-    let intent_keys: Vec<(String, String, String)> = index
-        .entries
-        .iter()
-        .filter_map(|(id, entry)| match entry {
-            IndexEntry::Intent(e) => Some((
-                id.as_str().to_string(),
-                e.text_hash.as_str().to_string(),
-                e.body_hash.as_str().to_string(),
-            )),
-            IndexEntry::Assume(_) => None,
-        })
-        .collect();
+    // currently vouch for (absent, unmarked, or hash-drifted). The same
+    // `authored_intents` enumeration `aristo review` reads, so the engine and
+    // the review surface can never report a different backlog.
+    let intents = crate::nudge::intents::authored_intents(&index);
     let unreviewed_intents = state.unreviewed_count(
-        intent_keys
+        intents
             .iter()
-            .map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str())),
+            .map(|i| (i.id.as_str(), i.text_hash.as_str(), i.body_hash.as_str())),
     );
 
     let proofs_awaiting_review = count_proofs_awaiting(ws, state);

--- a/crates/aristo-cli/src/commands/review.rs
+++ b/crates/aristo-cli/src/commands/review.rs
@@ -1,0 +1,380 @@
+//! `aristo review [--mark <id>]... [--json]` — review newly-authored intents
+//! (Phase 18 #7; the nudge engine's first consumer).
+//!
+//! The reviewed/unreviewed axis lives in the git-untracked
+//! `.aristo/nudge-state.toml` reviewed map (a text/body hash drift re-opens a
+//! reviewed intent — a reviewer approved a specific version, not the id
+//! forever). This command is the surface the `aristo-authored-review` skill
+//! drives:
+//!
+//! - **list** what awaits review, split into *new-this-session* vs *backlog*
+//!   when a SessionStart edit-window baseline exists;
+//! - **`--mark <id>`** records an intent as reviewed once the user has looked
+//!   at it.
+//!
+//! Editing or deleting an intent is a source operation the agent does
+//! directly (then `aristo stamp`); the re-stamp's hash drift naturally
+//! re-opens an edited intent. Subject-only: every line describes the user's
+//! own annotations.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::commands::index::workspace_or_error;
+use crate::commands::show::{read_index, status_label, verify_label};
+use crate::nudge::intents::{authored_intents, AuthoredIntent};
+use crate::nudge::state::{NudgeState, STATE_FILENAME};
+use crate::preflight::{emit_advisory_if_stale, freshness_check};
+use crate::{CliError, CliResult};
+
+/// Schema version of the `--json` snapshot (bump on a breaking shape change).
+const REVIEW_SCHEMA_VERSION: u32 = 1;
+
+pub(crate) fn run(json: bool, mark: Vec<String>) -> CliResult<()> {
+    let ws = workspace_or_error()?;
+    emit_advisory_if_stale(&freshness_check(&ws));
+    let index = read_index(&ws.index_path())?;
+    let authored = authored_intents(&index);
+    let state_path = ws.aristo_dir().join(STATE_FILENAME);
+    let mut state = NudgeState::load(&state_path);
+
+    let mark_ids = expand_ids(&mark);
+    if !mark_ids.is_empty() {
+        return run_mark(&state_path, &mut state, &authored, &mark_ids, json);
+    }
+
+    let snapshot = build_snapshot(&authored, &state);
+    if json {
+        emit_json(&snapshot)
+    } else {
+        print_human(&snapshot);
+        Ok(())
+    }
+}
+
+/// Split comma-joined ids and trim, so `--mark a,b` and `--mark a --mark b`
+/// are equivalent (mirrors `aristo critique --filter id=a,b`).
+fn expand_ids(raw: &[String]) -> Vec<String> {
+    raw.iter()
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+#[aristo::intent(
+    "Marking validates EVERY requested id against the index before writing any \
+     review state: an unknown id (a typo, or an id that isn't an authored \
+     intent) marks nothing and errors. Partial marking on a bad batch would \
+     silently record some reviews and drop others, leaving the backlog \
+     disagreeing with what the user believes they reviewed.",
+    verify = "test",
+    id = "review_mark_validates_all_ids_before_writing"
+)]
+fn run_mark(
+    state_path: &Path,
+    state: &mut NudgeState,
+    authored: &[AuthoredIntent],
+    ids: &[String],
+    json: bool,
+) -> CliResult<()> {
+    // Validate the WHOLE batch first (atomic): every id must be an authored
+    // intent before anything is written.
+    let mut resolved: Vec<&AuthoredIntent> = Vec::with_capacity(ids.len());
+    let mut unknown: Vec<&str> = Vec::new();
+    for id in ids {
+        match authored.iter().find(|i| &i.id == id) {
+            Some(i) => resolved.push(i),
+            None => unknown.push(id),
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(CliError::Other {
+            message: format!(
+                "not authored intent id(s) (nothing marked): {}. \
+                 Run `aristo review` to list reviewable ids.",
+                unknown.join(", ")
+            ),
+            exit_code: 2,
+        });
+    }
+
+    for i in &resolved {
+        state.mark_reviewed(&i.id, &i.text_hash, &i.body_hash);
+    }
+    state.save(state_path).map_err(|e| CliError::Other {
+        message: format!("failed to write nudge state: {e}"),
+        exit_code: 1,
+    })?;
+
+    let remaining = unreviewed(authored, state).len();
+    if json {
+        let out = serde_json::json!({
+            "marked": resolved.iter().map(|i| i.id.as_str()).collect::<Vec<_>>(),
+            "remaining_unreviewed": remaining,
+        });
+        let text = serde_json::to_string_pretty(&out).map_err(|e| CliError::Other {
+            message: format!("serializing review result: {e}"),
+            exit_code: 1,
+        })?;
+        println!("{text}");
+    } else {
+        println!(
+            "Marked {} intent(s) reviewed · {remaining} still await review.",
+            resolved.len()
+        );
+    }
+    Ok(())
+}
+
+/// The authored intents not currently vouched for by the reviewed map.
+fn unreviewed<'a>(authored: &'a [AuthoredIntent], state: &NudgeState) -> Vec<&'a AuthoredIntent> {
+    authored
+        .iter()
+        .filter(|i| !state.is_reviewed(&i.id, &i.text_hash, &i.body_hash))
+        .collect()
+}
+
+/// The machine-readable review snapshot (`--json`) and the basis for the human
+/// readout — one shape so the two outputs can never disagree.
+#[derive(Debug, Serialize)]
+struct ReviewSnapshot {
+    schema_version: u32,
+    unreviewed_count: usize,
+    new_count: usize,
+    backlog_count: usize,
+    /// Whether a SessionStart edit-window baseline was captured. Without one,
+    /// the new/backlog split is suppressed (`new_count = 0`, everything
+    /// reported under `unreviewed_count`).
+    baseline_captured: bool,
+    intents: Vec<ReviewIntentJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewIntentJson {
+    id: String,
+    text: String,
+    file: String,
+    site: String,
+    status: String,
+    verify: String,
+    is_new: bool,
+}
+
+#[aristo::intent(
+    "New vs backlog is computed against the SessionStart edit-window baseline: \
+     an unreviewed intent is 'new' only when a baseline WAS captured and its \
+     id is absent from it (authored this session). With no baseline the split \
+     is suppressed (new_count = 0) rather than guessed — calling everything \
+     'new' on a fresh checkout would misreport a long-standing backlog as \
+     this-session's work.",
+    verify = "test",
+    id = "review_new_vs_backlog_needs_a_baseline"
+)]
+fn build_snapshot(authored: &[AuthoredIntent], state: &NudgeState) -> ReviewSnapshot {
+    let unrev = unreviewed(authored, state);
+    let baseline = state.window_intent_ids.as_ref();
+    let baseline_captured = baseline.is_some();
+
+    let intents: Vec<ReviewIntentJson> = unrev
+        .iter()
+        .map(|i| ReviewIntentJson {
+            id: i.id.clone(),
+            text: i.text.clone(),
+            file: i.file.clone(),
+            site: i.site.clone(),
+            status: status_label(i.status).to_string(),
+            verify: verify_label(i.verify),
+            // "new" requires a baseline AND absence from it.
+            is_new: baseline.map(|set| !set.contains(&i.id)).unwrap_or(false),
+        })
+        .collect();
+
+    let unreviewed_count = intents.len();
+    let new_count = intents.iter().filter(|i| i.is_new).count();
+    let backlog_count = unreviewed_count - new_count;
+
+    ReviewSnapshot {
+        schema_version: REVIEW_SCHEMA_VERSION,
+        unreviewed_count,
+        new_count,
+        backlog_count,
+        baseline_captured,
+        intents,
+    }
+}
+
+fn emit_json(snapshot: &ReviewSnapshot) -> CliResult<()> {
+    let out = serde_json::to_string_pretty(snapshot).map_err(|e| CliError::Other {
+        message: format!("serializing review snapshot: {e}"),
+        exit_code: 1,
+    })?;
+    println!("{out}");
+    Ok(())
+}
+
+fn print_human(s: &ReviewSnapshot) {
+    println!("Aristo review");
+    if s.unreviewed_count == 0 {
+        println!("  All authored intents are reviewed. ✅");
+        return;
+    }
+    if s.baseline_captured {
+        println!(
+            "  {} await review — {} new this session · {} backlog.",
+            s.unreviewed_count, s.new_count, s.backlog_count
+        );
+    } else {
+        println!("  {} await review.", s.unreviewed_count);
+    }
+    println!();
+    for i in &s.intents {
+        if s.baseline_captured {
+            let tag = if i.is_new { "new" } else { "backlog" };
+            println!(
+                "  {} [{tag}] ({}, {}, {})",
+                i.id, i.site, i.verify, i.status
+            );
+        } else {
+            println!("  {} ({}, {}, {})", i.id, i.site, i.verify, i.status);
+        }
+        println!("    {}", i.text);
+    }
+    println!();
+    println!("Mark reviewed with: aristo review --mark <id>[,<id>...]");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::state::Baseline;
+    use aristo_core::index::{
+        AnnotationId, BindingState, CoveredRegion, IndexEntry, IndexFile, IntentEntry, Meta,
+        Sha256, Status, VerifyLevel, VerifyMethod,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn sha(c: char) -> Sha256 {
+        Sha256::parse(&format!("sha256:{}", c.to_string().repeat(64))).unwrap()
+    }
+
+    fn intent_entry(text: &str) -> IndexEntry {
+        IndexEntry::Intent(IntentEntry {
+            text: text.into(),
+            verify: VerifyLevel::Method(VerifyMethod::Test),
+            status: Status::Unknown,
+            text_hash: sha('a'),
+            body_hash: sha('b'),
+            file: "src/lib.rs".into(),
+            site: "fn foo".into(),
+            covered_region: CoveredRegion::Function,
+            binding: BindingState::Local,
+            parent: None,
+            last_critiqued_at_text_hash: None,
+            last_critique_finding_count: None,
+        })
+    }
+
+    fn index_with(ids: &[&str]) -> IndexFile {
+        let mut idx = IndexFile {
+            meta: Meta {
+                schema_version: 1,
+                generated_by: None,
+                generated_at: None,
+                source_root: None,
+            },
+            entries: BTreeMap::new(),
+        };
+        for id in ids {
+            idx.entries
+                .insert(AnnotationId::parse(id).unwrap(), intent_entry(id));
+        }
+        idx
+    }
+
+    #[test]
+    fn no_baseline_suppresses_the_split() {
+        let idx = index_with(&["i_one", "i_two"]);
+        let authored = authored_intents(&idx);
+        let state = NudgeState::default();
+        let snap = build_snapshot(&authored, &state);
+        assert_eq!(snap.unreviewed_count, 2);
+        assert!(!snap.baseline_captured);
+        assert_eq!(snap.new_count, 0, "no baseline ⇒ nothing claimed as new");
+        assert_eq!(snap.backlog_count, 2);
+    }
+
+    #[test]
+    fn baseline_splits_new_from_backlog() {
+        let idx = index_with(&["i_old", "i_new"]);
+        let authored = authored_intents(&idx);
+        let state = NudgeState {
+            baseline: Some(Baseline {
+                score: 0.0,
+                tier: "Aspirant".into(),
+            }),
+            // Only i_old existed when the window started; i_new is this session.
+            window_intent_ids: Some(BTreeSet::from(["i_old".to_string()])),
+            ..Default::default()
+        };
+        let snap = build_snapshot(&authored, &state);
+        assert!(snap.baseline_captured);
+        assert_eq!(snap.unreviewed_count, 2);
+        assert_eq!(snap.new_count, 1);
+        assert_eq!(snap.backlog_count, 1);
+        let new_ids: Vec<&str> = snap
+            .intents
+            .iter()
+            .filter(|i| i.is_new)
+            .map(|i| i.id.as_str())
+            .collect();
+        assert_eq!(new_ids, vec!["i_new"]);
+    }
+
+    #[test]
+    fn marking_drops_an_intent_from_the_backlog() {
+        let idx = index_with(&["i_one", "i_two"]);
+        let authored = authored_intents(&idx);
+        let mut state = NudgeState::default();
+        // Mark i_one against its current hashes.
+        state.mark_reviewed("i_one", sha('a').as_str(), sha('b').as_str());
+        let snap = build_snapshot(&authored, &state);
+        assert_eq!(snap.unreviewed_count, 1);
+        assert_eq!(snap.intents[0].id, "i_two");
+    }
+
+    #[test]
+    fn mark_rejects_unknown_id_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(STATE_FILENAME);
+        let idx = index_with(&["i_one"]);
+        let authored = authored_intents(&idx);
+        let mut state = NudgeState::default();
+        let err = run_mark(
+            &path,
+            &mut state,
+            &authored,
+            &["i_one".to_string(), "i_bogus".to_string()],
+            false,
+        )
+        .unwrap_err();
+        match err {
+            CliError::Other { exit_code, .. } => assert_eq!(exit_code, 2),
+            other => panic!("expected Other(exit 2), got {other:?}"),
+        }
+        // Atomic: the valid id was NOT marked because the batch had a bad id.
+        assert!(
+            !state.is_reviewed("i_one", sha('a').as_str(), sha('b').as_str()),
+            "a bad batch must mark nothing"
+        );
+        assert!(!path.exists(), "no state file written on a rejected batch");
+    }
+
+    #[test]
+    fn expand_ids_splits_commas_and_trims() {
+        let got = expand_ids(&["a, b".to_string(), "c".to_string(), "  ,".to_string()]);
+        assert_eq!(got, vec!["a", "b", "c"]);
+    }
+}

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -9,6 +9,10 @@
 mod commands;
 mod error;
 mod filter;
+/// The nudge/progress engine (Phase 18 #9). Public so the as-yet-unwired
+/// scorer is part of the lib API surface; the `aristo nudge` emitter (S0d)
+/// is its in-crate consumer.
+pub mod nudge;
 mod pipeline;
 mod preflight;
 mod session;

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -189,9 +189,15 @@ enum Commands {
         json: bool,
     },
 
-    /// Show what the nudge/progress engine would surface right now
-    /// (introspection; the hook-driven emitter lands next).
-    Nudge,
+    /// The nudge/progress engine. With no `--event`, prints what the engine
+    /// would surface right now (human introspection). With `--event`, runs as
+    /// a Claude Code hook emitter (`post-tool-use` / `stop` / `session-start`)
+    /// — always exits 0 so a nudge can never break the agent's workflow.
+    Nudge {
+        /// Hook event to serve (omit for the human readout).
+        #[arg(long)]
+        event: Option<String>,
+    },
 
     /// Check annotation prose for quality issues (rule-based; no LLM).
     Lint {
@@ -906,7 +912,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
         Commands::List { filters, json } => commands::list::run(&filters, json),
         Commands::Status => commands::status::run(),
         Commands::Metrics { json } => commands::metrics::run(json),
-        Commands::Nudge => commands::nudge::run(),
+        Commands::Nudge { event } => commands::nudge::run(event),
         Commands::Lint { check, fix, strict } => commands::lint::run(check, fix, strict),
         Commands::Verify {
             filters,

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -189,6 +189,10 @@ enum Commands {
         json: bool,
     },
 
+    /// Show what the nudge/progress engine would surface right now
+    /// (introspection; the hook-driven emitter lands next).
+    Nudge,
+
     /// Check annotation prose for quality issues (rule-based; no LLM).
     Lint {
         /// Read-only mode: exit non-zero on `error` findings (or
@@ -902,6 +906,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
         Commands::List { filters, json } => commands::list::run(&filters, json),
         Commands::Status => commands::status::run(),
         Commands::Metrics { json } => commands::metrics::run(json),
+        Commands::Nudge => commands::nudge::run(),
         Commands::Lint { check, fix, strict } => commands::lint::run(check, fix, strict),
         Commands::Verify {
             filters,

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -199,6 +199,20 @@ enum Commands {
         event: Option<String>,
     },
 
+    /// Review newly-authored intents (#7). With no flags, lists what awaits
+    /// review (split into new-this-session vs backlog when a baseline exists).
+    /// `--mark <id>` records intents as reviewed once you've looked at them.
+    Review {
+        /// Mark these authored intents reviewed (repeatable; comma-lists OK).
+        /// The whole batch is validated before anything is written.
+        #[arg(long = "mark", value_name = "ID")]
+        mark: Vec<String>,
+        /// Emit the review snapshot (or mark result) as JSON instead of a
+        /// human summary.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Check annotation prose for quality issues (rule-based; no LLM).
     Lint {
         /// Read-only mode: exit non-zero on `error` findings (or
@@ -913,6 +927,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
         Commands::Status => commands::status::run(),
         Commands::Metrics { json } => commands::metrics::run(json),
         Commands::Nudge { event } => commands::nudge::run(event),
+        Commands::Review { mark, json } => commands::review::run(json, mark),
         Commands::Lint { check, fix, strict } => commands::lint::run(check, fix, strict),
         Commands::Verify {
             filters,

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -177,6 +177,14 @@ enum Commands {
     /// Project-level summary (tier, counts, freshness).
     Status,
 
+    /// Machine-readable project metrics (counts, unverified backlog, tier).
+    /// The same `Metrics` value the nudge engine computes internally.
+    Metrics {
+        /// Emit the metrics as a JSON object instead of a human summary.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Check annotation prose for quality issues (rule-based; no LLM).
     Lint {
         /// Read-only mode: exit non-zero on `error` findings (or
@@ -889,6 +897,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
         } => commands::show::run(&selector, output_mode(json, toml_out)),
         Commands::List { filters, json } => commands::list::run(&filters, json),
         Commands::Status => commands::status::run(),
+        Commands::Metrics { json } => commands::metrics::run(json),
         Commands::Lint { check, fix, strict } => commands::lint::run(check, fix, strict),
         Commands::Verify {
             filters,

--- a/crates/aristo-cli/src/nudge/intents.rs
+++ b/crates/aristo-cli/src/nudge/intents.rs
@@ -1,0 +1,160 @@
+//! Enumerate authored intents for the reviewed/unreviewed axis (Phase 18 #7).
+//!
+//! One function, [`authored_intents`], is the single source of truth for
+//! "what is a reviewable authored intent" — both the engine's `review_backlog`
+//! signal (via the union function) and the `aristo review` surface read it, so
+//! they can never disagree on the backlog.
+
+use aristo_core::index::{IndexEntry, IndexFile, Status, VerifyLevel};
+
+/// One authored intent, carrying the fields the review surface and the
+/// reviewed map need. The hashes are stringified so they line up with the
+/// `NudgeState` reviewed map (`id → {text_hash, body_hash}`).
+#[derive(Debug, Clone)]
+pub struct AuthoredIntent {
+    pub id: String,
+    pub text: String,
+    pub file: String,
+    pub site: String,
+    pub status: Status,
+    pub verify: VerifyLevel,
+    pub text_hash: String,
+    pub body_hash: String,
+}
+
+#[aristo::intent(
+    "Authored intents are exactly the `IndexEntry::Intent` entries — every \
+     one, including documentation-only `verify = false` intents (still claims \
+     the user authored and may want to review). Assumes are excluded: they \
+     state external invariants, not reviewable claims. This is the SAME set \
+     the engine's review_backlog metric counts, so `aristo review` and the \
+     nudge can never report a different backlog size for the same index.",
+    verify = "test",
+    id = "authored_intents_are_exactly_the_index_intents"
+)]
+/// Every authored intent in the index, in id order (the `BTreeMap` iteration
+/// order — deterministic).
+pub fn authored_intents(index: &IndexFile) -> Vec<AuthoredIntent> {
+    index
+        .entries
+        .iter()
+        .filter_map(|(id, entry)| match entry {
+            IndexEntry::Intent(e) => Some(AuthoredIntent {
+                id: id.as_str().to_string(),
+                text: e.text.clone(),
+                file: e.file.clone(),
+                site: e.site.clone(),
+                status: e.status,
+                verify: e.verify,
+                text_hash: e.text_hash.as_str().to_string(),
+                body_hash: e.body_hash.as_str().to_string(),
+            }),
+            IndexEntry::Assume(_) => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aristo_core::index::{
+        AnnotationId, AnnotationKind, AssumeEntry, BindingState, CoveredRegion, IntentEntry, Meta,
+        Sha256, VerifyMethod,
+    };
+    use std::collections::BTreeMap;
+
+    fn sha(c: char) -> Sha256 {
+        Sha256::parse(&format!("sha256:{}", c.to_string().repeat(64))).unwrap()
+    }
+
+    fn intent(text: &str) -> IndexEntry {
+        IndexEntry::Intent(IntentEntry {
+            text: text.into(),
+            verify: VerifyLevel::Method(VerifyMethod::Test),
+            status: Status::Tested,
+            text_hash: sha('a'),
+            body_hash: sha('b'),
+            file: "src/lib.rs".into(),
+            site: "fn foo".into(),
+            covered_region: CoveredRegion::Function,
+            binding: BindingState::Local,
+            parent: None,
+            last_critiqued_at_text_hash: None,
+            last_critique_finding_count: None,
+        })
+    }
+
+    fn assume(text: &str) -> IndexEntry {
+        IndexEntry::Assume(AssumeEntry {
+            text: text.into(),
+            status: Status::Unknown,
+            text_hash: sha('a'),
+            body_hash: sha('b'),
+            file: "src/lib.rs".into(),
+            site: "fn foo".into(),
+            covered_region: CoveredRegion::Function,
+            linked: None,
+            parent: None,
+        })
+    }
+
+    fn index_with(entries: Vec<(&str, IndexEntry)>) -> IndexFile {
+        let mut idx = IndexFile {
+            meta: Meta {
+                schema_version: 1,
+                generated_by: None,
+                generated_at: None,
+                source_root: None,
+            },
+            entries: BTreeMap::new(),
+        };
+        for (id, e) in entries {
+            idx.entries.insert(AnnotationId::parse(id).unwrap(), e);
+        }
+        idx
+    }
+
+    #[test]
+    fn enumerates_intents_excludes_assumes() {
+        let idx = index_with(vec![
+            ("i_one", intent("first claim")),
+            ("a_one", assume("an external invariant")),
+            ("i_two", intent("second claim")),
+        ]);
+        let got = authored_intents(&idx);
+        let ids: Vec<&str> = got.iter().map(|i| i.id.as_str()).collect();
+        // Sorted by id (BTreeMap order); the assume is dropped.
+        assert_eq!(ids, vec!["i_one", "i_two"]);
+    }
+
+    #[test]
+    fn carries_text_site_and_hashes() {
+        let idx = index_with(vec![("i_one", intent("first claim"))]);
+        let got = authored_intents(&idx);
+        let one = &got[0];
+        assert_eq!(one.text, "first claim");
+        assert_eq!(one.site, "fn foo");
+        assert_eq!(one.text_hash, sha('a').as_str());
+        assert_eq!(one.body_hash, sha('b').as_str());
+        assert_eq!(one.status, Status::Tested);
+    }
+
+    #[test]
+    fn includes_documentation_only_intents() {
+        // verify = false (doc-only) intents are still authored claims; they
+        // must appear so the review backlog matches the engine's count.
+        let mut e = intent("doc only");
+        if let IndexEntry::Intent(ref mut ie) = e {
+            ie.verify = VerifyLevel::Bool(false);
+        }
+        let idx = index_with(vec![("i_doc", e)]);
+        assert_eq!(authored_intents(&idx).len(), 1);
+    }
+
+    // Touch AnnotationKind so the import documents intent-vs-assume scope even
+    // though enumeration matches on IndexEntry directly.
+    #[test]
+    fn annotation_kind_is_intent_or_assume() {
+        assert_ne!(AnnotationKind::Intent, AnnotationKind::Assume);
+    }
+}

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -1,0 +1,418 @@
+//! The nudge/progress engine's DECIDE leg (Phase 18 #9, S0c).
+//!
+//! A plug-and-play scorer over a registry of [`Signal`]s. Each signal turns
+//! some engine input into a raw "pressure" `m`; the scorer normalizes it by
+//! the signal's base `b` and scales by the configured aggressiveness factor
+//! `f`, firing iff `pressure * f >= 1`. Adding a nudge is one [`SIGNALS`]
+//! entry — the scorer, ordering, and (later) throttle/render are generic.
+//!
+//! Two design invariants this module enforces:
+//!
+//! - **`aggressiveness = off` is a hard silence.** `factor()` is `0.0`, so
+//!   `pressure * 0.0 >= 1` is false for every signal at every pressure —
+//!   nothing can fire (cf. the `aggressiveness_off_is_hard_silence` intent
+//!   in `aristo-core::config`).
+//! - **Ordering is fixed priority, not pressure.** Pressures of counts and
+//!   fractions are incommensurable, so the surfaced order is the static
+//!   [`SIGNALS`] order (congrats banner, then review > canon > verify >
+//!   proof-review > slump); the Agent-audience signal is a separate surface.
+
+use aristo_core::config::Aggressiveness;
+use aristo_core::metrics::Metrics;
+
+/// Who a fired signal is addressed to. The two are surfaced through
+/// different channels (D4/D10): the agent gets an inline `<system-reminder>`;
+/// the human gets the consolidated review prompt the agent pops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Audience {
+    /// Nudge the coding agent directly (e.g. "you haven't annotated lately").
+    Agent,
+    /// Surface to the human via the agent-run review prompt.
+    Human,
+}
+
+/// Everything the signal metrics read. The cli's union function (S0c+)
+/// populates the runtime fields it can't see from the index alone (reviewed
+/// map, queue/canon counts, the edit-window baseline); the index-derived
+/// part is [`Metrics`].
+#[derive(Debug, Clone)]
+pub struct EngineInputs {
+    /// Index-derived metrics (counts, backlog, tier, score).
+    pub metrics: Metrics,
+    /// Source edits since the last annotation was added (PostToolUse counter).
+    pub edits_since_annotation: usize,
+    /// Authored intents not yet marked reviewed (new + backlog).
+    pub unreviewed_intents: usize,
+    /// Proofs carrying a verdict not yet in the proof-reviewed map.
+    pub proofs_awaiting_review: usize,
+    /// Pending canon matches + suggestions (only meaningful when signed in).
+    pub canon_pending: usize,
+    /// The visible score at the edit-window baseline, if one was captured.
+    pub prior_score: Option<f64>,
+    /// Whether the tier rose since the edit-window baseline (instant win).
+    pub tier_increased: bool,
+    /// Whether a repo-scoped token is present (gates the paid canon signal).
+    pub signed_in: bool,
+}
+
+/// A registered nudge. `metric` extracts the raw pressure numerator `m` from
+/// the inputs; `base` is the denominator `b`; the signal fires when
+/// `(m / b) * factor >= 1`.
+pub struct Signal {
+    /// Stable identifier (also the throttle-map key).
+    pub id: &'static str,
+    /// Who the nudge is for.
+    pub audience: Audience,
+    /// The pressure denominator `b` (> 0).
+    pub base: f64,
+    /// Extract the raw pressure numerator `m` from the inputs.
+    pub metric: fn(&EngineInputs) -> f64,
+}
+
+impl Signal {
+    /// Normalized pressure `m / b` (independent of aggressiveness).
+    pub fn pressure(&self, inputs: &EngineInputs) -> f64 {
+        (self.metric)(inputs) / self.base
+    }
+}
+
+/// A signal that fired, with the pressure that fired it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Fired {
+    pub id: &'static str,
+    pub audience: Audience,
+    pub pressure: f64,
+}
+
+/// The registry. Order IS priority for the human surface: the congrats
+/// banner leads, then review > canon > verify > proof-review > slump. The
+/// Agent-audience `authoring_debt` sits last (separate channel, order among
+/// human signals irrelevant to it).
+pub static SIGNALS: &[Signal] = &[
+    Signal {
+        id: "congrats",
+        audience: Audience::Human,
+        base: 0.05,
+        metric: metric_congrats,
+    },
+    Signal {
+        id: "review_backlog",
+        audience: Audience::Human,
+        base: 3.0,
+        metric: metric_review_backlog,
+    },
+    Signal {
+        id: "canon_pending",
+        audience: Audience::Human,
+        base: 3.0,
+        metric: metric_canon_pending,
+    },
+    Signal {
+        id: "verify_backlog",
+        audience: Audience::Human,
+        base: 0.25,
+        metric: metric_verify_backlog,
+    },
+    Signal {
+        id: "proof_review_backlog",
+        audience: Audience::Human,
+        base: 3.0,
+        metric: metric_proof_review_backlog,
+    },
+    Signal {
+        id: "score_slump",
+        audience: Audience::Human,
+        base: 0.05,
+        metric: metric_score_slump,
+    },
+    Signal {
+        id: "authoring_debt",
+        audience: Audience::Agent,
+        base: 3.0,
+        metric: metric_authoring_debt,
+    },
+];
+
+fn metric_authoring_debt(i: &EngineInputs) -> f64 {
+    i.edits_since_annotation as f64
+}
+
+fn metric_review_backlog(i: &EngineInputs) -> f64 {
+    i.unreviewed_intents as f64
+}
+
+fn metric_proof_review_backlog(i: &EngineInputs) -> f64 {
+    i.proofs_awaiting_review as f64
+}
+
+fn metric_canon_pending(i: &EngineInputs) -> f64 {
+    // Paid signal: silent unless signed in (no upsell spam).
+    if i.signed_in {
+        i.canon_pending as f64
+    } else {
+        0.0
+    }
+}
+
+fn metric_verify_backlog(i: &EngineInputs) -> f64 {
+    // Fraction of the verifiable surface still unverified.
+    if i.metrics.verifiable == 0 {
+        0.0
+    } else {
+        i.metrics.unverified as f64 / i.metrics.verifiable as f64
+    }
+}
+
+fn metric_score_slump(i: &EngineInputs) -> f64 {
+    // Relative drop from the edit-window baseline; 0 if no baseline or no drop.
+    match i.prior_score {
+        Some(prior) if prior > 0.0 => {
+            let drop = prior - i.metrics.visible_score;
+            if drop > 0.0 {
+                drop / prior
+            } else {
+                0.0
+            }
+        }
+        _ => 0.0,
+    }
+}
+
+fn metric_congrats(i: &EngineInputs) -> f64 {
+    // A tier-up is an instant win — always congratulate (when nudges are on);
+    // INFINITY pressure clears any non-zero factor's threshold but is still
+    // silenced by factor 0.0 (off). Otherwise congratulate on a score gain.
+    if i.tier_increased {
+        return f64::INFINITY;
+    }
+    match i.prior_score {
+        Some(prior) => (i.metrics.visible_score - prior).max(0.0),
+        None => 0.0,
+    }
+}
+
+/// The scorer's verdict: the fired signals in priority order, split by
+/// audience, plus the recommended lead (the highest-priority fired human
+/// signal — the engine kicks its low-friction/background action).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Decision {
+    /// Fired Human-audience signals, highest priority first.
+    pub human: Vec<Fired>,
+    /// Fired Agent-audience signals.
+    pub agent: Vec<Fired>,
+}
+
+impl Decision {
+    /// The recommended lead signal id — the top fired human signal, or `None`
+    /// when nothing human-facing fired.
+    pub fn recommended(&self) -> Option<&'static str> {
+        self.human.first().map(|f| f.id)
+    }
+
+    /// True when nothing fired for either audience.
+    pub fn is_silent(&self) -> bool {
+        self.human.is_empty() && self.agent.is_empty()
+    }
+}
+
+#[aristo::intent(
+    "Two invariants the scorer must preserve. First, `aggressiveness = off` \
+     is an absolute silence: its factor is 0.0 and the fire test is \
+     `pressure * factor >= 1`, so no signal fires at any pressure — even an \
+     infinite one (a tier-up). Second, the surfaced order is the static \
+     SIGNALS priority order, NOT the pressures: a count-pressure and a \
+     fraction-pressure are incommensurable, so sorting by pressure would let \
+     a noisy low-priority signal jump the queue ahead of a review the user \
+     actually needs to see first.",
+    verify = "test",
+    id = "nudge_scorer_off_silences_and_order_is_static_priority"
+)]
+pub fn score(inputs: &EngineInputs, aggressiveness: Aggressiveness) -> Decision {
+    let factor = aggressiveness.factor();
+    let mut decision = Decision::default();
+    for signal in SIGNALS {
+        let pressure = signal.pressure(inputs);
+        if pressure * factor >= 1.0 {
+            let fired = Fired {
+                id: signal.id,
+                audience: signal.audience,
+                pressure,
+            };
+            match signal.audience {
+                Audience::Human => decision.human.push(fired),
+                Audience::Agent => decision.agent.push(fired),
+            }
+        }
+    }
+    decision
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aristo_core::badge::Tier;
+    use aristo_core::metrics::{Metrics, METRICS_SCHEMA_VERSION};
+
+    fn metrics(verifiable: usize, unverified: usize, score: f64, tier: Tier) -> Metrics {
+        Metrics {
+            schema_version: METRICS_SCHEMA_VERSION,
+            intents: verifiable,
+            assumes: 0,
+            verifiable,
+            verified_clean: verifiable - unverified,
+            unverified,
+            verification_rate: if verifiable == 0 {
+                0.0
+            } else {
+                (verifiable - unverified) as f64 / verifiable as f64
+            },
+            tier,
+            visible_score: score,
+        }
+    }
+
+    fn inputs() -> EngineInputs {
+        EngineInputs {
+            metrics: metrics(0, 0, 0.0, Tier::Aspirant),
+            edits_since_annotation: 0,
+            unreviewed_intents: 0,
+            proofs_awaiting_review: 0,
+            canon_pending: 0,
+            prior_score: None,
+            tier_increased: false,
+            signed_in: false,
+        }
+    }
+
+    #[test]
+    fn off_is_a_hard_silence_even_under_extreme_pressure() {
+        let mut i = inputs();
+        i.unreviewed_intents = 1000;
+        i.edits_since_annotation = 1000;
+        i.tier_increased = true;
+        let d = score(&i, Aggressiveness::Off);
+        assert!(d.is_silent(), "off must silence everything: {d:?}");
+    }
+
+    #[test]
+    fn nothing_fires_at_zero_pressure() {
+        let d = score(&inputs(), Aggressiveness::High);
+        assert!(d.is_silent());
+    }
+
+    #[test]
+    fn review_backlog_fires_at_base_under_medium() {
+        let mut i = inputs();
+        i.unreviewed_intents = 3; // pressure 3/3 = 1.0; *1.0 medium = 1.0 >= 1
+        let d = score(&i, Aggressiveness::Medium);
+        assert!(d.human.iter().any(|f| f.id == "review_backlog"));
+    }
+
+    #[test]
+    fn low_aggressiveness_needs_more_pressure_than_medium() {
+        let mut i = inputs();
+        i.unreviewed_intents = 3; // 1.0 pressure
+                                  // low factor 0.6 → 0.6 < 1 → does not fire
+        assert!(score(&i, Aggressiveness::Low)
+            .human
+            .iter()
+            .all(|f| f.id != "review_backlog"));
+        // medium factor 1.0 → fires
+        assert!(score(&i, Aggressiveness::Medium)
+            .human
+            .iter()
+            .any(|f| f.id == "review_backlog"));
+    }
+
+    #[test]
+    fn canon_pending_is_silent_until_signed_in() {
+        let mut i = inputs();
+        i.canon_pending = 10;
+        assert!(score(&i, Aggressiveness::High)
+            .human
+            .iter()
+            .all(|f| f.id != "canon_pending"));
+        i.signed_in = true;
+        assert!(score(&i, Aggressiveness::High)
+            .human
+            .iter()
+            .any(|f| f.id == "canon_pending"));
+    }
+
+    #[test]
+    fn tier_up_always_congratulates_when_on() {
+        let mut i = inputs();
+        i.tier_increased = true;
+        let d = score(&i, Aggressiveness::Low);
+        assert_eq!(
+            d.recommended(),
+            Some("congrats"),
+            "tier-up leads as the banner"
+        );
+    }
+
+    #[test]
+    fn verify_backlog_uses_unverified_fraction() {
+        let mut i = inputs();
+        // 1 of 1 unverified → fraction 1.0; /0.25 = 4.0 pressure → fires easily.
+        i.metrics = metrics(1, 1, 0.0, Tier::Aspirant);
+        assert!(score(&i, Aggressiveness::Low)
+            .human
+            .iter()
+            .any(|f| f.id == "verify_backlog"));
+        // 0 unverified → no pressure.
+        i.metrics = metrics(4, 0, 0.5, Tier::Adept);
+        assert!(score(&i, Aggressiveness::High)
+            .human
+            .iter()
+            .all(|f| f.id != "verify_backlog"));
+    }
+
+    #[test]
+    fn score_slump_fires_on_a_relative_drop_from_baseline() {
+        let mut i = inputs();
+        i.prior_score = Some(0.50);
+        i.metrics = metrics(0, 0, 0.40, Tier::Adept); // drop 0.10 / 0.50 = 0.20
+                                                      // 0.20 / 0.05 = 4.0 pressure → fires.
+        assert!(score(&i, Aggressiveness::Low)
+            .human
+            .iter()
+            .any(|f| f.id == "score_slump"));
+        // No drop → silent.
+        i.metrics = metrics(0, 0, 0.60, Tier::Adept);
+        assert!(score(&i, Aggressiveness::High)
+            .human
+            .iter()
+            .all(|f| f.id != "score_slump"));
+    }
+
+    #[test]
+    fn authoring_debt_is_agent_audience() {
+        let mut i = inputs();
+        i.edits_since_annotation = 3;
+        let d = score(&i, Aggressiveness::Medium);
+        assert!(d.agent.iter().any(|f| f.id == "authoring_debt"));
+        assert!(d.human.iter().all(|f| f.id != "authoring_debt"));
+    }
+
+    #[test]
+    fn human_signals_keep_static_priority_order() {
+        // Fire review, canon, and verify together; the surfaced order must be
+        // review > canon > verify regardless of their pressures.
+        let mut i = inputs();
+        i.signed_in = true;
+        i.unreviewed_intents = 100; // huge
+        i.canon_pending = 3; // exactly base
+        i.metrics = metrics(1, 1, 0.0, Tier::Aspirant); // verify fraction 1.0
+        let d = score(&i, Aggressiveness::Medium);
+        let order: Vec<&str> = d.human.iter().map(|f| f.id).collect();
+        let review = order.iter().position(|x| *x == "review_backlog").unwrap();
+        let canon = order.iter().position(|x| *x == "canon_pending").unwrap();
+        let verify = order.iter().position(|x| *x == "verify_backlog").unwrap();
+        assert!(
+            review < canon && canon < verify,
+            "priority order: {order:?}"
+        );
+        assert_eq!(d.recommended(), Some("review_backlog"));
+    }
+}

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -20,6 +20,8 @@
 use aristo_core::config::Aggressiveness;
 use aristo_core::metrics::Metrics;
 
+pub mod state;
+
 /// Who a fired signal is addressed to. The two are surfaced through
 /// different channels (D4/D10): the agent gets an inline `<system-reminder>`;
 /// the human gets the consolidated review prompt the agent pops.

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -20,6 +20,7 @@
 use aristo_core::config::Aggressiveness;
 use aristo_core::metrics::Metrics;
 
+pub mod intents;
 pub mod state;
 pub mod throttle;
 

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -1,9 +1,9 @@
 //! The nudge/progress engine's DECIDE leg (Phase 18 #9, S0c).
 //!
-//! A plug-and-play scorer over a registry of [`Signal`]s. Each signal turns
+//! A plug-and-play scorer over a registry of `Signal`s. Each signal turns
 //! some engine input into a raw "pressure" `m`; the scorer normalizes it by
 //! the signal's base `b` and scales by the configured aggressiveness factor
-//! `f`, firing iff `pressure * f >= 1`. Adding a nudge is one [`SIGNALS`]
+//! `f`, firing iff `pressure * f >= 1`. Adding a nudge is one `SIGNALS`
 //! entry — the scorer, ordering, and (later) throttle/render are generic.
 //!
 //! Two design invariants this module enforces:
@@ -14,7 +14,7 @@
 //!   in `aristo-core::config`).
 //! - **Ordering is fixed priority, not pressure.** Pressures of counts and
 //!   fractions are incommensurable, so the surfaced order is the static
-//!   [`SIGNALS`] order (congrats banner, then review > canon > verify >
+//!   `SIGNALS` order (congrats banner, then review > canon > verify >
 //!   proof-review > slump); the Agent-audience signal is a separate surface.
 
 use aristo_core::config::Aggressiveness;

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -21,6 +21,7 @@ use aristo_core::config::Aggressiveness;
 use aristo_core::metrics::Metrics;
 
 pub mod state;
+pub mod throttle;
 
 /// Who a fired signal is addressed to. The two are surfaced through
 /// different channels (D4/D10): the agent gets an inline `<system-reminder>`;

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -79,12 +79,18 @@ impl Signal {
     }
 }
 
-/// A signal that fired, with the pressure that fired it.
+/// A signal that fired, with the pressure that fired it and the raw
+/// `metric`/`base` (so the throttle can apply a material-increase re-arm
+/// against the same numbers).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Fired {
     pub id: &'static str,
     pub audience: Audience,
     pub pressure: f64,
+    /// The raw pressure numerator `m` (`pressure == metric / base`).
+    pub metric: f64,
+    /// The signal's pressure denominator `b`.
+    pub base: f64,
 }
 
 /// The registry. Order IS priority for the human surface: the congrats
@@ -234,12 +240,15 @@ pub fn score(inputs: &EngineInputs, aggressiveness: Aggressiveness) -> Decision 
     let factor = aggressiveness.factor();
     let mut decision = Decision::default();
     for signal in SIGNALS {
-        let pressure = signal.pressure(inputs);
+        let metric = (signal.metric)(inputs);
+        let pressure = metric / signal.base;
         if pressure * factor >= 1.0 {
             let fired = Fired {
                 id: signal.id,
                 audience: signal.audience,
                 pressure,
+                metric,
+                base: signal.base,
             };
             match signal.audience {
                 Audience::Human => decision.human.push(fired),

--- a/crates/aristo-cli/src/nudge/state.rs
+++ b/crates/aristo-cli/src/nudge/state.rs
@@ -15,7 +15,7 @@
 //! bad state). The file is git-untracked: it is per-user runtime, like
 //! `.aristo/sessions/`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -60,6 +60,12 @@ pub struct NudgeState {
     pub edits_since_annotation: usize,
     /// The edit-window baseline, if captured.
     pub baseline: Option<Baseline>,
+    /// The set of authored-intent ids present when the current edit window
+    /// began (captured at SessionStart). Powers #7's new-vs-backlog split: an
+    /// unreviewed intent is "new this session" when its id is absent from this
+    /// set, else "backlog". `None` means no window was captured (no hooks /
+    /// fresh checkout) — the split is then suppressed rather than guessed.
+    pub window_intent_ids: Option<BTreeSet<String>>,
     /// annotation id → review record.
     pub reviewed: BTreeMap<String, ReviewRecord>,
     /// proof id → reviewed.
@@ -178,6 +184,7 @@ mod tests {
                 score: 0.42,
                 tier: "Adept".into(),
             }),
+            window_intent_ids: Some(BTreeSet::from(["aret_a".to_string(), "aret_b".to_string()])),
             ..Default::default()
         };
         s.mark_reviewed("aret_abc12345", "sha256:t", "sha256:b");

--- a/crates/aristo-cli/src/nudge/state.rs
+++ b/crates/aristo-cli/src/nudge/state.rs
@@ -1,0 +1,232 @@
+//! Persistent, git-untracked engine state: `.aristo/nudge-state.toml`
+//! (Phase 18 #9, S0c). Holds the runtime facts the index can't carry:
+//!
+//! - the **reviewed map** (`annotation id → {text_hash, body_hash, reviewed}`)
+//!   — the reviewed/unreviewed axis #7 drives; a hash drift re-flips an entry
+//!   to unreviewed (D6/Q3);
+//! - the **proof-reviewed map** (`proof id → reviewed`);
+//! - the **edit-window baseline** (score + tier captured at SessionStart) for
+//!   the congrats / slump signals;
+//! - the per-window **edit counter** for the authoring-debt signal;
+//! - per-signal **throttle** records (last fired + last surfaced metric).
+//!
+//! Writes are atomic (tempfile + rename), tolerant on read (a missing or
+//! corrupt file degrades to default state — the engine never fails a hook on
+//! bad state). The file is git-untracked: it is per-user runtime, like
+//! `.aristo/sessions/`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Basename under `.aristo/`.
+pub const STATE_FILENAME: &str = "nudge-state.toml";
+
+/// One annotation's review record. `reviewed` is re-flipped to the
+/// unreviewed view whenever the live text/body hashes drift from these.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewRecord {
+    pub text_hash: String,
+    pub body_hash: String,
+    pub reviewed: bool,
+}
+
+/// The score/tier snapshot captured at the start of an edit window, against
+/// which congrats (gain) and slump (drop) are measured.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Baseline {
+    pub score: f64,
+    /// The tier label at baseline (compared by string; the engine only needs
+    /// "did it change", not ordering).
+    pub tier: String,
+}
+
+/// Per-signal throttle bookkeeping.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThrottleRecord {
+    /// Unix epoch seconds the signal last surfaced (0 if never).
+    pub last_fired_epoch: u64,
+    /// The metric value at the last surfacing (for material-change re-arm).
+    pub last_surfaced_metric: f64,
+}
+
+/// The whole engine state file. Every field defaults, so older / partial
+/// files deserialize cleanly.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NudgeState {
+    /// Source edits since the last annotation was added (authoring-debt).
+    pub edits_since_annotation: usize,
+    /// The edit-window baseline, if captured.
+    pub baseline: Option<Baseline>,
+    /// annotation id → review record.
+    pub reviewed: BTreeMap<String, ReviewRecord>,
+    /// proof id → reviewed.
+    pub proof_reviewed: BTreeMap<String, bool>,
+    /// signal id → throttle record.
+    pub throttle: BTreeMap<String, ThrottleRecord>,
+}
+
+impl NudgeState {
+    /// Read the state file, tolerating absence and corruption (either yields
+    /// default state). A nudge hook must never fail on bad state.
+    pub fn load(path: &Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(text) => toml::from_str(&text).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Atomically write the state file (tempfile in the same dir + rename).
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let text = toml::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let tmp = path.with_extension("toml.tmp");
+        std::fs::write(&tmp, text)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Count intents the user has not (currently) reviewed. An intent is
+    /// unreviewed when it has no record, its record is `reviewed = false`, or
+    /// its live hashes have drifted from the reviewed snapshot (a post-review
+    /// edit re-opens it). `current` is `(id, text_hash, body_hash)` for every
+    /// authored intent in the index.
+    pub fn unreviewed_count<'a>(
+        &self,
+        current: impl IntoIterator<Item = (&'a str, &'a str, &'a str)>,
+    ) -> usize {
+        current
+            .into_iter()
+            .filter(|(id, text_hash, body_hash)| !self.is_reviewed(id, text_hash, body_hash))
+            .count()
+    }
+
+    #[aristo::intent(
+        "A review is current only while the annotation's text AND body hashes \
+         still match the snapshot taken when it was reviewed. Editing the \
+         claim or the covered code after review re-opens it (reads as \
+         unreviewed) — a reviewer approved a specific version, not the id \
+         forever. Without the hash check, a post-review edit would keep a \
+         stale 'reviewed' badge and the review backlog would under-count work \
+         that genuinely needs another look.",
+        verify = "test",
+        id = "nudge_review_is_current_only_until_hash_drift"
+    )]
+    /// True iff this annotation is currently reviewed (record present,
+    /// `reviewed = true`, and both hashes still match — no drift).
+    pub fn is_reviewed(&self, id: &str, text_hash: &str, body_hash: &str) -> bool {
+        match self.reviewed.get(id) {
+            Some(r) => r.reviewed && r.text_hash == text_hash && r.body_hash == body_hash,
+            None => false,
+        }
+    }
+
+    /// Mark an annotation reviewed against its current hashes (clears any
+    /// prior drift).
+    pub fn mark_reviewed(&mut self, id: &str, text_hash: &str, body_hash: &str) {
+        self.reviewed.insert(
+            id.to_string(),
+            ReviewRecord {
+                text_hash: text_hash.to_string(),
+                body_hash: body_hash.to_string(),
+                reviewed: true,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(text: &str, body: &str, reviewed: bool) -> ReviewRecord {
+        ReviewRecord {
+            text_hash: text.into(),
+            body_hash: body.into(),
+            reviewed,
+        }
+    }
+
+    #[test]
+    fn missing_file_loads_default_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = NudgeState::load(&dir.path().join("nope.toml"));
+        assert_eq!(s, NudgeState::default());
+    }
+
+    #[test]
+    fn corrupt_file_loads_default_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(STATE_FILENAME);
+        std::fs::write(&p, "this is { not valid toml ][").unwrap();
+        // Must not panic / error — a hook can't fail on bad state.
+        assert_eq!(NudgeState::load(&p), NudgeState::default());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(STATE_FILENAME);
+        let mut s = NudgeState {
+            edits_since_annotation: 4,
+            baseline: Some(Baseline {
+                score: 0.42,
+                tier: "Adept".into(),
+            }),
+            ..Default::default()
+        };
+        s.mark_reviewed("aret_abc12345", "sha256:t", "sha256:b");
+        s.proof_reviewed.insert("aret_abc12345".into(), true);
+        s.throttle.insert(
+            "review_backlog".into(),
+            ThrottleRecord {
+                last_fired_epoch: 1_700_000_000,
+                last_surfaced_metric: 3.0,
+            },
+        );
+        s.save(&p).unwrap();
+        assert_eq!(NudgeState::load(&p), s);
+    }
+
+    #[test]
+    fn unreviewed_counts_absent_unmarked_and_drifted() {
+        let mut s = NudgeState::default();
+        s.reviewed.insert("reviewed".into(), rec("t1", "b1", true));
+        s.reviewed.insert("unmarked".into(), rec("t2", "b2", false));
+        s.reviewed.insert("drifted".into(), rec("t3", "b3", true));
+
+        let current = vec![
+            ("reviewed", "t1", "b1"),  // reviewed, hashes match → reviewed
+            ("unmarked", "t2", "b2"),  // record says reviewed=false → unreviewed
+            ("drifted", "tX", "b3"),   // text drifted → unreviewed
+            ("brand_new", "t4", "b4"), // no record → unreviewed
+        ];
+        assert_eq!(s.unreviewed_count(current), 3);
+    }
+
+    #[test]
+    fn body_drift_after_review_reopens_the_intent() {
+        let mut s = NudgeState::default();
+        s.mark_reviewed("x", "sha256:t", "sha256:b");
+        assert!(
+            s.is_reviewed("x", "sha256:t", "sha256:b"),
+            "fresh review holds"
+        );
+        assert!(
+            !s.is_reviewed("x", "sha256:t", "sha256:b2"),
+            "a body edit after review re-opens it"
+        );
+    }
+
+    #[test]
+    fn empty_reviewed_map_means_everything_unreviewed() {
+        let s = NudgeState::default();
+        let current = vec![("a", "t", "b"), ("c", "t", "b")];
+        assert_eq!(s.unreviewed_count(current), 2);
+    }
+}

--- a/crates/aristo-cli/src/nudge/throttle.rs
+++ b/crates/aristo-cli/src/nudge/throttle.rs
@@ -1,0 +1,171 @@
+//! Anti-nag throttle for the human-facing nudge surface (Phase 18 #9, S0d).
+//!
+//! A fired signal still has to clear the throttle before it actually
+//! surfaces, so the engine doesn't repeat the same nudge every turn. Two
+//! ways to clear it (D8 / SPINE-PLAN "throttle"):
+//!
+//! 1. **Cooldown elapsed** — at least `cooldown_secs(level)` since this
+//!    signal last surfaced. Higher aggressiveness = shorter cooldown; `off`
+//!    never surfaces (it is already silenced upstream, but the cooldown is
+//!    `None` here too as a belt-and-braces guard).
+//! 2. **Material increase** — even inside the cooldown, a signal whose metric
+//!    has grown by at least `step(level, base)` since it last surfaced
+//!    re-arms (a genuinely worse backlog shouldn't wait out the timer).
+//!
+//! Cadence is wall-clock here (the SPINE-PLAN's "edit-window" notion is
+//! approximated by minutes — simpler and robust against missing SessionStart
+//! events; the per-signal record carries the last-fired epoch + last metric).
+//! The Agent-audience surface (authoring debt) is NOT throttled here — it is
+//! same-turn only and cheap; this module governs the consolidated human nudge.
+
+use aristo_core::config::Aggressiveness;
+
+use super::state::ThrottleRecord;
+
+/// Seconds a human signal must wait between surfacings, by aggressiveness.
+/// `None` = never surface (`off`).
+pub fn cooldown_secs(level: Aggressiveness) -> Option<u64> {
+    match level {
+        Aggressiveness::Off => None,
+        Aggressiveness::Low => Some(30 * 60),
+        Aggressiveness::Medium => Some(10 * 60),
+        Aggressiveness::High => Some(3 * 60),
+    }
+}
+
+/// The metric increase that re-arms a signal inside its cooldown. Scales with
+/// the signal's base (so a count-signal needs ~a few more, a fraction-signal a
+/// bit more fraction) and shrinks at higher aggressiveness (re-arms sooner).
+/// Floored at 1.0 so a count signal always needs at least one more.
+pub fn rearm_step(level: Aggressiveness, base: f64) -> f64 {
+    let k = match level {
+        Aggressiveness::Off => return f64::INFINITY, // never re-arms
+        Aggressiveness::Low => 1.0,
+        Aggressiveness::Medium => 0.66,
+        Aggressiveness::High => 0.33,
+    };
+    (base * k).max(1.0)
+}
+
+/// Whether a fired signal may surface now: cooldown elapsed OR a material
+/// increase since it last surfaced. A signal that never surfaced always may.
+pub fn may_surface(
+    record: Option<&ThrottleRecord>,
+    now_epoch: u64,
+    level: Aggressiveness,
+    current_metric: f64,
+    base: f64,
+) -> bool {
+    let Some(cooldown) = cooldown_secs(level) else {
+        return false; // off → never
+    };
+    let Some(record) = record else {
+        return true; // never surfaced → surface
+    };
+    let elapsed = now_epoch.saturating_sub(record.last_fired_epoch);
+    if elapsed >= cooldown {
+        return true;
+    }
+    // Inside the cooldown: re-arm only on a material increase.
+    current_metric >= record.last_surfaced_metric + rearm_step(level, base)
+}
+
+/// The record to store after a signal surfaces.
+pub fn record_after_surface(now_epoch: u64, current_metric: f64) -> ThrottleRecord {
+    ThrottleRecord {
+        last_fired_epoch: now_epoch,
+        last_surfaced_metric: current_metric,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOUR: u64 = 3600;
+
+    #[test]
+    fn off_never_surfaces() {
+        assert!(!may_surface(None, HOUR, Aggressiveness::Off, 100.0, 3.0));
+    }
+
+    #[test]
+    fn never_surfaced_always_may() {
+        assert!(may_surface(None, 0, Aggressiveness::Low, 1.0, 3.0));
+    }
+
+    #[test]
+    fn waits_out_the_cooldown() {
+        let rec = ThrottleRecord {
+            last_fired_epoch: HOUR,
+            last_surfaced_metric: 3.0,
+        };
+        // 1 minute later under medium (10m cooldown), same metric → blocked.
+        assert!(!may_surface(
+            Some(&rec),
+            HOUR + 60,
+            Aggressiveness::Medium,
+            3.0,
+            3.0
+        ));
+        // 11 minutes later → cooldown elapsed → may.
+        assert!(may_surface(
+            Some(&rec),
+            HOUR + 11 * 60,
+            Aggressiveness::Medium,
+            3.0,
+            3.0
+        ));
+    }
+
+    #[test]
+    fn material_increase_rearms_inside_cooldown() {
+        let rec = ThrottleRecord {
+            last_fired_epoch: HOUR,
+            last_surfaced_metric: 3.0,
+        };
+        // Still inside cooldown (1 min later). base 3.0, medium k=0.66 →
+        // step = max(1.98, 1.0) = 1.98. 3.0 + 1.98 = 4.98.
+        assert!(
+            !may_surface(Some(&rec), HOUR + 60, Aggressiveness::Medium, 4.0, 3.0),
+            "metric 4.0 is below the re-arm threshold 4.98 → still throttled"
+        );
+        assert!(
+            may_surface(Some(&rec), HOUR + 60, Aggressiveness::Medium, 5.0, 3.0),
+            "metric 5.0 clears the 4.98 re-arm threshold"
+        );
+    }
+
+    #[test]
+    fn higher_aggressiveness_rearms_on_smaller_increase() {
+        let rec = ThrottleRecord {
+            last_fired_epoch: HOUR,
+            last_surfaced_metric: 3.0,
+        };
+        // base 3.0: high k=0.33 → step max(0.99,1.0)=1.0 → threshold 4.0;
+        // low k=1.0 → step 3.0 → threshold 6.0. metric 4.5 inside cooldown:
+        assert!(may_surface(
+            Some(&rec),
+            HOUR + 60,
+            Aggressiveness::High,
+            4.5,
+            3.0
+        ));
+        assert!(!may_surface(
+            Some(&rec),
+            HOUR + 60,
+            Aggressiveness::Low,
+            4.5,
+            3.0
+        ));
+    }
+
+    #[test]
+    fn cooldown_shrinks_with_aggressiveness() {
+        assert_eq!(cooldown_secs(Aggressiveness::Off), None);
+        let low = cooldown_secs(Aggressiveness::Low).unwrap();
+        let med = cooldown_secs(Aggressiveness::Medium).unwrap();
+        let high = cooldown_secs(Aggressiveness::High).unwrap();
+        assert!(low > med && med > high, "{low} > {med} > {high}");
+    }
+}

--- a/crates/aristo-cli/src/skills/aristo-authored-review.md
+++ b/crates/aristo-cli/src/skills/aristo-authored-review.md
@@ -1,0 +1,102 @@
+---
+name: aristo-authored-review
+description: Review the intents you (or the agent) just authored. Lists unreviewed `#[aristo::intent]` annotations via `aristo review --json` — split into new-this-session vs backlog — then drives an `AskUserQuestion` flow to either kick a background critique pass (Critique-first) or do a light per-intent pass (Review now). Marks reviewed via `aristo review --mark <id>`; the reviewed state lives in `.aristo/nudge-state.toml` and a later edit re-opens an intent. Subject-only: every prompt is about the user's own annotations.
+sdk_version: {{SDK_VERSION}}
+---
+
+# Aristo authored-intent review
+
+When the user invokes this skill (typically by typing `/aristo-authored-review`, asking to
+"review the intents we just wrote" / "review my annotations", or after the aristo nudge
+engine surfaced a review backlog at a natural pause), follow this orchestration exactly.
+
+This is the consume side of authoring: you wrote intents; now you decide which are *good*.
+It is distinct from `aristo-intent-suggestions` (which reviews **canon matches** — the
+server's suggested wording) — this skill reviews the **authored** intents themselves, before
+or independent of any canon match. The reviewed/unreviewed axis is local: it lives in the
+git-untracked `.aristo/nudge-state.toml` reviewed map. Marking an intent reviewed records
+the version you approved; **editing the claim or its covered code later re-opens it** (the
+approval was for a specific version, not the id forever).
+
+**Subject-only rule (load-bearing):** every line you surface is about the *user's own*
+annotations and code. Never reference the verification model, internal proof objects, or
+anything the user can't see in their own source.
+
+## Step 0 — check for an active review session (FIRST, BEFORE ANY WORK)
+
+Run `aristo session active`. Three cases:
+
+- **Empty stdout** → no active session; proceed.
+- **A session whose `kind` is a review kind you opened earlier** (e.g. `critique-review`
+  from a Critique-first pass that didn't reach exit) → resume that flow (jump to the
+  critique skill's review step); do NOT start a fresh pass.
+- **A session of a different kind** → REFUSE. Print: "an aristo `<kind>` session is active
+  (id=<id>, subject=<subject>). Exit it first with `aristo session exit` (or
+  `aristo session exit --defer-undecided` to park open items), then re-invoke
+  `/aristo-authored-review`." Stop here.
+
+This is Layer 3 of the three-layer session guard (Layer 1 = the SDK refusing mutating
+commands while a session is active; Layer 2 = the per-turn hook reminder).
+
+## Step 1 — list what awaits review
+
+```bash
+aristo review --json
+```
+
+The snapshot has `unreviewed_count`, `new_count`, `backlog_count`, `baseline_captured`, and
+an `intents` array (each: `id`, `text`, `file`, `site`, `status`, `verify`, `is_new`).
+
+- **`unreviewed_count == 0`** → tell the user everything authored is reviewed, and stop.
+- Otherwise lead with the count, using the split when `baseline_captured` is true:
+  *"X new this session · Y backlog await review."* When `baseline_captured` is false, just
+  say *"X intents await review"* (no SessionStart baseline was captured, so the
+  new-vs-backlog split is not claimed).
+
+## Step 2 — offer the approach (one `AskUserQuestion`)
+
+Pop a single `AskUserQuestion` with the high-level choice. Lead with the **recommended**
+option:
+
+- **Critique-first (recommended)** — kick a background `aristo critique` pass over the
+  unreviewed intents, keep working, then review its prose findings. Best when there are
+  several intents or you want a quality second opinion.
+- **Review now** — a light, per-intent pass right here: mark reviewed / edit / delete.
+- **Not now** — defer; the backlog persists and the nudge will resurface it later.
+
+### Critique-first (background)
+
+**Guard ordering (D11):** kick the critique pass **BEFORE** opening any review session — the
+session guard blocks `aristo critique` (and `aristo stamp`) while a session is active.
+
+```bash
+aristo critique --filter id=<comma,separated,unreviewed,ids>
+```
+
+Then hand off to the **aristo-critique** skill to run the worker loop and review findings in
+its `critique-review` session. Marking an intent reviewed here is implied by acting on (or
+dismissing) its critique findings — once you've addressed an intent's findings, run
+`aristo review --mark <id>` for it.
+
+### Review now (light, per-intent)
+
+Present the unreviewed intents as an `AskUserQuestion` batch. The picker shows **at most
+4 questions per page**, so paginate larger sets (one page of ≤4, decide, then the next).
+For each intent, put its `text` + `site` in the option preview so the user reads the actual
+claim. Per intent, offer:
+
+- **Looks good → mark reviewed** → `aristo review --mark <id>`
+- **Edit the wording** → edit the `#[aristo::intent("…")]` text in source, then
+  `aristo stamp` (the re-stamp's hash drift re-opens it; mark it reviewed again once happy).
+- **Delete it** → remove the annotation from source, then `aristo stamp`.
+- **Skip** → leave it unreviewed (it stays in the backlog).
+
+You can mark several at once: `aristo review --mark id1,id2,id3`. The whole batch is
+validated before anything is written — a wrong id marks nothing and errors, so re-check the
+id and retry.
+
+## Step 3 — confirm and close
+
+After the pass, run `aristo review` once more to show the remaining backlog (or "all
+reviewed ✅"). Never edit `.aristo/` state files directly — `aristo review --mark` is the
+only write path for the reviewed axis; source edits go through `aristo stamp`.

--- a/crates/aristo-cli/src/skills/mod.rs
+++ b/crates/aristo-cli/src/skills/mod.rs
@@ -101,7 +101,18 @@ const INTENT_SUGGESTIONS: Skill = Skill {
     content: include_str!("aristo-intent-suggestions.md"),
 };
 
-const BUNDLED: &[Skill] = &[AUTHORING, NEURAL_VERIFY, CRITIQUE, INTENT_SUGGESTIONS];
+const AUTHORED_REVIEW: Skill = Skill {
+    name: "aristo-authored-review",
+    content: include_str!("aristo-authored-review.md"),
+};
+
+const BUNDLED: &[Skill] = &[
+    AUTHORING,
+    NEURAL_VERIFY,
+    CRITIQUE,
+    INTENT_SUGGESTIONS,
+    AUTHORED_REVIEW,
+];
 
 #[cfg(test)]
 mod tests {
@@ -219,6 +230,70 @@ mod tests {
         assert!(
             body.contains("name: aristo-intent-suggestions"),
             "frontmatter must include the skill name"
+        );
+    }
+
+    #[test]
+    fn authored_review_skill_is_bundled() {
+        let s = find("aristo-authored-review")
+            .expect("aristo-authored-review must be bundled (Phase 18 #7)");
+        let body = s.resolved_content();
+        // Frontmatter sanity.
+        assert!(
+            body.starts_with("---"),
+            "skill must start with YAML frontmatter"
+        );
+        assert!(
+            body.contains("name: aristo-authored-review"),
+            "frontmatter must include the skill name"
+        );
+        // The two CLI surfaces this skill drives.
+        assert!(
+            body.contains("aristo review --json"),
+            "skill body must teach listing the backlog via `aristo review --json`"
+        );
+        assert!(
+            body.contains("aristo review --mark"),
+            "skill body must teach marking reviewed via `aristo review --mark`"
+        );
+        // D9: the two review paths.
+        assert!(
+            body.contains("Critique-first") && body.contains("Review now"),
+            "skill body must offer both the Critique-first and Review-now paths (D9)"
+        );
+        // Critique-first reuses the existing critique command + skill.
+        assert!(
+            body.contains("aristo critique --filter id="),
+            "Critique-first must kick `aristo critique --filter id=` over the new intents"
+        );
+        // D11 guard ordering: kick critique BEFORE opening a session.
+        assert!(
+            body.contains("BEFORE") && body.contains("Guard ordering"),
+            "skill body must encode the D11 guard ordering (kick critique before a session)"
+        );
+        // Layer-3 session-guard discipline (mirrors the other review skills).
+        assert!(
+            body.contains("aristo session active"),
+            "skill body's step 0 must check for an active review session (Layer 3)"
+        );
+        // Menu-driven, paginated.
+        assert!(
+            body.contains("AskUserQuestion"),
+            "skill body must drive the review via AskUserQuestion menus"
+        );
+        assert!(
+            body.contains("4 questions per page") || body.contains("4/page"),
+            "skill body must call out the ≤4-questions-per-page cap (paginate larger sets)"
+        );
+        // Subject-only rule (never reference the model).
+        assert!(
+            body.contains("Subject-only") || body.contains("subject-only"),
+            "skill body must encode the subject-only rule"
+        );
+        // Source edits funnel through stamp (no direct .aristo/ state writes).
+        assert!(
+            body.contains("aristo stamp"),
+            "skill body must funnel source edits through `aristo stamp`"
         );
     }
 

--- a/crates/aristo-cli/tests/metrics_command.rs
+++ b/crates/aristo-cli/tests/metrics_command.rs
@@ -1,0 +1,72 @@
+//! `aristo metrics` — JSON contract + human-summary integration tests.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write_lib(root: &Path, content: &str) {
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), content).unwrap();
+}
+
+#[test]
+fn metrics_json_emits_a_parseable_metrics_payload() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"
+            #[aristo::intent("one", verify = "test", id = "a")] fn a() {}
+            #[aristo::intent("two", verify = "neural", id = "b")] fn b() {}
+            #[aristo::intent("doc only", verify = false, id = "c")] fn c() {}
+            #[aristo::assume("external invariant", id = "d")] fn d() {}
+        "#,
+    );
+    aristo_in(tmp.path()).arg("stamp").assert().success();
+
+    let out = aristo_in(tmp.path())
+        .args(["metrics", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "metrics --json must exit 0");
+    let json = String::from_utf8(out.stdout).unwrap();
+
+    // The frozen contract: stdout parses straight into the core Metrics type.
+    let m: aristo_core::metrics::Metrics =
+        serde_json::from_str(&json).expect("metrics --json must parse into aristo_core Metrics");
+    assert_eq!(m.intents, 3, "3 intents (the assume is excluded)");
+    assert_eq!(m.assumes, 1);
+    assert_eq!(m.verifiable, 2, "verify=false is not verifiable");
+    assert_eq!(m.verified_clean, 0, "nothing verified just after stamp");
+    assert_eq!(m.unverified, 2);
+    assert_eq!(
+        m.schema_version,
+        aristo_core::metrics::METRICS_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn metrics_human_summary_lists_counts_and_tier() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("one", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path()).arg("stamp").assert().success();
+    aristo_in(tmp.path())
+        .arg("metrics")
+        .assert()
+        .success()
+        .stdout(contains("Aristo metrics"))
+        .stdout(contains("intents:"))
+        .stdout(contains("unverified:"))
+        .stdout(contains("tier:"));
+}

--- a/crates/aristo-cli/tests/nudge_command.rs
+++ b/crates/aristo-cli/tests/nudge_command.rs
@@ -70,3 +70,88 @@ fn nudge_is_silent_when_aggressiveness_off() {
         .success()
         .stdout(contains("nothing would fire"));
 }
+
+#[test]
+fn nudge_stop_event_emits_consolidated_agent_reminder() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "stop"])
+        .assert()
+        .success()
+        .stdout(contains("<system-reminder>"))
+        .stdout(contains("offer the user"));
+}
+
+#[test]
+fn nudge_session_start_captures_baseline_in_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "session-start"])
+        .assert()
+        .success();
+
+    let state = fs::read_to_string(tmp.path().join(".aristo/nudge-state.toml")).unwrap();
+    assert!(
+        state.contains("[baseline]"),
+        "session-start must persist a baseline: {state}"
+    );
+}
+
+#[test]
+fn nudge_hook_event_is_silent_when_off() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    let cfg = tmp.path().join("aristo.toml");
+    let contents = fs::read_to_string(&cfg).unwrap();
+    fs::write(
+        &cfg,
+        contents.replace("aggressiveness = \"medium\"", "aggressiveness = \"off\""),
+    )
+    .unwrap();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    // off → the Stop hook emits nothing at all.
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "stop"])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn nudge_unknown_event_is_silent() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "bogus-event"])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}

--- a/crates/aristo-cli/tests/nudge_command.rs
+++ b/crates/aristo-cli/tests/nudge_command.rs
@@ -1,0 +1,72 @@
+//! `aristo nudge` — engine readout integration tests (S0d.1).
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write_lib(root: &Path, content: &str) {
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), content).unwrap();
+}
+
+#[test]
+fn nudge_surfaces_verify_backlog_for_an_unverified_intent() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    // Default aggressiveness (medium): a fully-unverified surface fires
+    // verify_backlog (fraction 1.0 / base 0.25 = pressure 4.0).
+    aristo_in(tmp.path())
+        .arg("nudge")
+        .assert()
+        .success()
+        .stdout(contains("nudge engine"))
+        .stdout(contains("verify_backlog"));
+}
+
+#[test]
+fn nudge_is_silent_when_aggressiveness_off() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    // Opt out via config — the hard global silence. `aristo init` already
+    // writes `[nudges] aggressiveness = "medium"`, so flip that value rather
+    // than appending a second (duplicate) table.
+    let cfg = tmp.path().join("aristo.toml");
+    let contents = fs::read_to_string(&cfg).unwrap();
+    let flipped = contents.replace("aggressiveness = \"medium\"", "aggressiveness = \"off\"");
+    assert_ne!(
+        contents, flipped,
+        "expected the default medium value to flip"
+    );
+    fs::write(&cfg, flipped).unwrap();
+
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .arg("nudge")
+        .assert()
+        .success()
+        .stdout(contains("nothing would fire"));
+}

--- a/crates/aristo-cli/tests/review_command.rs
+++ b/crates/aristo-cli/tests/review_command.rs
@@ -1,0 +1,143 @@
+//! `aristo review` — authored-intent review surface integration tests
+//! (Phase 18 #7).
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write_lib(root: &Path, content: &str) {
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), content).unwrap();
+}
+
+/// init → one intent → stamp → review.
+fn repo_with_one_intent() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+    tmp
+}
+
+#[test]
+fn review_lists_an_unreviewed_authored_intent() {
+    let tmp = repo_with_one_intent();
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 1"))
+        .stdout(contains("\"id\": \"a\""))
+        .stdout(contains("does a thing"));
+}
+
+#[test]
+fn review_human_readout_prompts_to_mark() {
+    let tmp = repo_with_one_intent();
+    aristo_in(tmp.path())
+        .arg("review")
+        .assert()
+        .success()
+        .stdout(contains("await review"))
+        .stdout(contains("aristo review --mark"));
+}
+
+#[test]
+fn marking_an_intent_clears_it_from_the_backlog() {
+    let tmp = repo_with_one_intent();
+    aristo_in(tmp.path())
+        .args(["review", "--mark", "a"])
+        .assert()
+        .success()
+        .stdout(contains("Marked 1 intent(s) reviewed"));
+
+    // Now the backlog is empty.
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 0"));
+
+    aristo_in(tmp.path())
+        .arg("review")
+        .assert()
+        .success()
+        .stdout(contains("All authored intents are reviewed"));
+}
+
+#[test]
+fn marking_an_unknown_id_errors_and_writes_nothing() {
+    let tmp = repo_with_one_intent();
+    // A batch with a bad id marks nothing (atomic) and exits non-zero.
+    aristo_in(tmp.path())
+        .args(["review", "--mark", "a,bogus"])
+        .assert()
+        .failure()
+        .stderr(contains("bogus"));
+
+    // The valid id in the bad batch was NOT marked.
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 1"));
+}
+
+#[test]
+fn editing_an_intent_after_review_reopens_it() {
+    let tmp = repo_with_one_intent();
+    aristo_in(tmp.path())
+        .args(["review", "--mark", "a"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 0"));
+
+    // Reword the claim (same id) and re-stamp → the reviewed snapshot drifts,
+    // so the intent re-opens as unreviewed.
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a DIFFERENT thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 1"));
+}
+
+#[test]
+fn review_is_empty_with_no_authored_intents() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(tmp.path(), "pub fn a() {}\n");
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+    aristo_in(tmp.path())
+        .args(["review", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"unreviewed_count\": 0"));
+}

--- a/crates/aristo-core/src/badge.rs
+++ b/crates/aristo-core/src/badge.rs
@@ -38,6 +38,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::index::{IdNamespace, IndexEntry, IndexFile, Status, VerifyLevel, VerifyMethod};
@@ -63,7 +64,7 @@ const ASCENDENT_CUTOFF: f64 = 0.65;
 /// Visible-only projects (free-tier or paid-but-not-yet-server-bound)
 /// saturate at [`Tier::Ascendent`] regardless of how high the
 /// numeric score climbs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Tier {
     /// Seeking the path; has annotations, minimal verification.

--- a/crates/aristo-core/src/config/mod.rs
+++ b/crates/aristo-core/src/config/mod.rs
@@ -62,6 +62,8 @@ pub struct ConfigFile {
     pub index: IndexConfig,
     #[serde(default)]
     pub canon: CanonConfig,
+    #[serde(default)]
+    pub nudges: NudgesConfig,
 }
 
 // ─── [verify] ──────────────────────────────────────────────────────────────
@@ -430,6 +432,67 @@ fn default_threshold_critique() -> f64 {
     0.65
 }
 
+// ─── [nudges] ─────────────────────────────────────────────────────────────
+
+/// `[nudges]` — the proactive nudge/progress engine (Phase 18). A single
+/// `aggressiveness` knob scales every nudge's fire threshold (and the
+/// human-prompt cooldown); `off` silences the engine entirely — the global
+/// opt-out, mirroring `[canon] enabled = false`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct NudgesConfig {
+    /// How eagerly the engine surfaces nudges. Higher lowers every
+    /// signal's fire threshold and shortens the human cooldown; `off`
+    /// disables all nudges. Default `medium`.
+    #[serde(default)]
+    pub aggressiveness: Aggressiveness,
+}
+
+/// Nudge aggressiveness ladder. Maps to a numeric factor `f` the scorer
+/// multiplies into each signal's normalized pressure: a signal fires when
+/// `pressure * f >= 1`, so higher `f` fires sooner. `Off` yields `f = 0`,
+/// the structural global opt-out (nothing can fire).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Aggressiveness {
+    /// No nudges at all (global opt-out).
+    Off,
+    /// Quietest: only large backlogs / strong signals surface.
+    Low,
+    /// Balanced default.
+    #[default]
+    Medium,
+    /// Eager: surfaces sooner and re-arms faster.
+    High,
+}
+
+impl Aggressiveness {
+    #[aristo::intent(
+        "Off MUST map to factor 0.0 — it is the global opt-out, and the \
+         scorer's fire test is `pressure * factor >= 1`, so only an exact \
+         0.0 guarantees NOTHING ever fires regardless of how overdue a \
+         signal is. A non-zero `low` would let extreme pressure leak \
+         through a user who explicitly silenced nudges. The non-zero rungs \
+         are tunable defaults (D8); this table is the single place to \
+         retune global nudge sensitivity.",
+        verify = "neural",
+        id = "aggressiveness_off_is_hard_silence"
+    )]
+    pub fn factor(self) -> f64 {
+        match self {
+            Aggressiveness::Off => 0.0,
+            Aggressiveness::Low => 0.6,
+            Aggressiveness::Medium => 1.0,
+            Aggressiveness::High => 1.6,
+        }
+    }
+
+    /// True when nudges are entirely disabled (`aggressiveness = "off"`).
+    pub fn is_off(self) -> bool {
+        matches!(self, Aggressiveness::Off)
+    }
+}
+
 // ─── helpers ──────────────────────────────────────────────────────────────
 
 fn default_true() -> bool {
@@ -466,6 +529,7 @@ mod tests {
         assert!(config.canon.enabled);
         assert!((config.canon.threshold_stamp - 0.85).abs() < f64::EPSILON);
         assert!((config.canon.threshold_critique - 0.65).abs() < f64::EPSILON);
+        assert_eq!(config.nudges.aggressiveness, Aggressiveness::Medium);
     }
 
     #[test]

--- a/crates/aristo-core/src/index/enums.rs
+++ b/crates/aristo-core/src/index/enums.rs
@@ -56,6 +56,25 @@ pub enum Status {
     Inconclusive,
 }
 
+#[aristo::intent(
+    "The terminal-clean states are exactly Verified, Tested, and Neural — \
+     an intent whose current code IS confirmed to hold under some \
+     verification method. Stale, Counterexample, Inconclusive, Unknown, \
+     and the B5b error states (Orphan / Forged / PendingDeepen) are NOT \
+     clean: each means the property is unproven, refuted, or untrusted for \
+     the current code. This is the single definition every surface — \
+     status counts, the badge rate, and the nudge engine's unverified \
+     backlog — shares, so they can never disagree on what 'verified' means.",
+    verify = "test",
+    id = "status_terminal_clean_is_verified_tested_neural"
+)]
+impl Status {
+    /// True iff this status is a terminal-clean (confirmed-verified) state.
+    pub fn is_terminal_clean(self) -> bool {
+        matches!(self, Status::Verified | Status::Tested | Status::Neural)
+    }
+}
+
 /// `verify` field value. Mixed-type per design (G1):
 ///
 /// - `false` (TOML bool): documentation only; no check ever runs.
@@ -153,5 +172,23 @@ mod tests {
     fn unknown_status_value_is_rejected() {
         let result: Result<Status, _> = serde_json::from_value(serde_json::json!("partial"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn terminal_clean_is_exactly_verified_tested_neural() {
+        for s in [Status::Verified, Status::Tested, Status::Neural] {
+            assert!(s.is_terminal_clean(), "{s:?} should be terminal-clean");
+        }
+        for s in [
+            Status::Stale,
+            Status::Orphan,
+            Status::Forged,
+            Status::Unknown,
+            Status::PendingDeepen,
+            Status::Counterexample,
+            Status::Inconclusive,
+        ] {
+            assert!(!s.is_terminal_clean(), "{s:?} must NOT be terminal-clean");
+        }
     }
 }

--- a/crates/aristo-core/src/lib.rs
+++ b/crates/aristo-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod git;
 pub mod hash;
 pub mod id;
 pub mod index;
+pub mod metrics;
 pub mod proof;
 pub mod spec;
 pub mod update_check;

--- a/crates/aristo-core/src/metrics.rs
+++ b/crates/aristo-core/src/metrics.rs
@@ -1,0 +1,276 @@
+//! `aristo-core::metrics` — the canonical, index-derived metrics surface
+//! (Phase 18 #9, the nudge/progress engine's COMPUTE leg).
+//!
+//! [`Metrics`] is the single source of truth for the annotation counts that
+//! `aristo status`, `aristo badge`, `aristo metrics`, and the nudge engine
+//! all report. Producing them from ONE counting pass ([`Metrics::from_index`]
+//! plus the shared [`compute_tier`] formula) is what keeps those surfaces
+//! from drifting on the same underlying numbers (audit A2: converge the
+//! *counting pass*, not the published scalar — each surface still derives
+//! its own headline number from these shared counts).
+//!
+//! This core type holds only what is derivable from the index alone. The
+//! cli layers the runtime signals it can't see from here — queue depth,
+//! canon-match counts, the reviewed/proof-reviewed maps, the edit-window
+//! baseline, the prior-score snapshot — in its union function (S0c+).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::badge::{compute_tier, Tier};
+use crate::index::{IndexEntry, IndexFile, VerifyLevel, VerifyMethod};
+
+/// Schema version for the `aristo metrics --json` payload. Bump on any
+/// breaking change to [`Metrics`]'s shape so consumers can gate.
+pub const METRICS_SCHEMA_VERSION: u32 = 1;
+
+/// Index-derived project metrics — counts, the unverified backlog, and the
+/// tier/score. Serializes to the `aristo metrics --json` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Metrics {
+    /// Payload schema version (see [`METRICS_SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// Total `intent` annotations (every `verify` level, including `false`).
+    pub intents: usize,
+    /// Total `assume` annotations — external invariants, never verified.
+    pub assumes: usize,
+    /// Intents with `verify != false`: the verifiable surface (the
+    /// denominator of [`Metrics::verification_rate`] and the unverified
+    /// backlog).
+    pub verifiable: usize,
+    /// Verifiable intents currently in a terminal-clean status
+    /// (`Status::is_terminal_clean`: Verified / Tested / Neural).
+    pub verified_clean: usize,
+    /// `verifiable - verified_clean`: the unverified backlog the
+    /// `verify_backlog` nudge signal watches.
+    pub unverified: usize,
+    /// `verified_clean / verifiable`, or `0.0` when nothing is verifiable.
+    /// This is the engine's own rate; it is intentionally NOT the badge's
+    /// `verification_rate_pct` (which divides by ALL intents) — both derive
+    /// from the same shared counts (A2).
+    pub verification_rate: f64,
+    /// The project tier (Aspirant … ✦ Areté), via the depth-weighted badge
+    /// formula.
+    pub tier: Tier,
+    /// The `[0, 1]` visible score backing the tier.
+    pub visible_score: f64,
+}
+
+#[aristo::intent(
+    "The verifiable surface is intents with `verify != false` only — assumes \
+     are external invariants and never verified, and `verify = false` intents \
+     are documentation-only. `verified_clean` counts the verifiable intents in \
+     a terminal-clean status (the shared `Status::is_terminal_clean`), and \
+     `unverified` is exactly `verifiable - verified_clean`, so the three never \
+     disagree. The rate divides by `verifiable` (not by all intents), and is \
+     0 when nothing is verifiable rather than a divide-by-zero.",
+    verify = "test",
+    id = "metrics_verifiable_excludes_assumes_and_doc_only_intents"
+)]
+impl Metrics {
+    /// Compute every index-derived metric in one pass. `fn_counts` is the
+    /// per-module function surface the coverage score needs (the cli walks
+    /// source for it); `default_method` resolves `verify = true` for the
+    /// tier formula (from `[verify] default_method`).
+    pub fn from_index(
+        index: &IndexFile,
+        fn_counts: &BTreeMap<PathBuf, u32>,
+        default_method: Option<VerifyMethod>,
+    ) -> Self {
+        let mut intents = 0usize;
+        let mut assumes = 0usize;
+        let mut verifiable = 0usize;
+        let mut verified_clean = 0usize;
+
+        for entry in index.entries.values() {
+            match entry {
+                IndexEntry::Intent(e) => {
+                    intents += 1;
+                    // verify=false intents are documentation-only: never
+                    // verifiable, so excluded from the backlog and rate.
+                    if !matches!(e.verify, VerifyLevel::Bool(false)) {
+                        verifiable += 1;
+                        if e.status.is_terminal_clean() {
+                            verified_clean += 1;
+                        }
+                    }
+                }
+                IndexEntry::Assume(_) => assumes += 1,
+            }
+        }
+
+        let unverified = verifiable - verified_clean;
+        let verification_rate = if verifiable == 0 {
+            0.0
+        } else {
+            verified_clean as f64 / verifiable as f64
+        };
+
+        let computation = compute_tier(index, fn_counts, default_method);
+
+        Metrics {
+            schema_version: METRICS_SCHEMA_VERSION,
+            intents,
+            assumes,
+            verifiable,
+            verified_clean,
+            unverified,
+            verification_rate,
+            tier: computation.tier,
+            visible_score: computation.visible_score,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{
+        AnnotationId, AssumeEntry, BindingState, CoveredRegion, IndexEntry, IndexFile, IntentEntry,
+        Meta, Sha256, Status, VerifyLevel, VerifyMethod,
+    };
+
+    fn sha(c: char) -> Sha256 {
+        Sha256::parse(&format!("sha256:{}", c.to_string().repeat(64))).unwrap()
+    }
+
+    fn intent(verify: VerifyLevel, status: Status) -> IndexEntry {
+        IndexEntry::Intent(IntentEntry {
+            text: "x".into(),
+            verify,
+            status,
+            text_hash: sha('a'),
+            body_hash: sha('b'),
+            file: "src/lib.rs".into(),
+            site: "fn f".into(),
+            covered_region: CoveredRegion::Function,
+            binding: BindingState::Local,
+            parent: None,
+            last_critiqued_at_text_hash: None,
+            last_critique_finding_count: None,
+        })
+    }
+
+    fn assume() -> IndexEntry {
+        IndexEntry::Assume(AssumeEntry {
+            text: "y".into(),
+            status: Status::Unknown,
+            text_hash: sha('a'),
+            body_hash: sha('b'),
+            file: "src/lib.rs".into(),
+            site: "fn g".into(),
+            covered_region: CoveredRegion::Function,
+            linked: None,
+            parent: None,
+        })
+    }
+
+    fn index_of(entries: Vec<IndexEntry>) -> IndexFile {
+        let mut map = std::collections::BTreeMap::new();
+        for (i, e) in entries.into_iter().enumerate() {
+            map.insert(AnnotationId::parse(&format!("id_{i}")).unwrap(), e);
+        }
+        IndexFile {
+            meta: Meta {
+                schema_version: 1,
+                generated_by: None,
+                generated_at: None,
+                source_root: None,
+            },
+            entries: map,
+        }
+    }
+
+    fn metrics_of(entries: Vec<IndexEntry>) -> Metrics {
+        Metrics::from_index(&index_of(entries), &BTreeMap::new(), None)
+    }
+
+    #[test]
+    fn empty_index_is_all_zero_aspirant() {
+        let m = metrics_of(vec![]);
+        assert_eq!(m.intents, 0);
+        assert_eq!(m.assumes, 0);
+        assert_eq!(m.verifiable, 0);
+        assert_eq!(m.verified_clean, 0);
+        assert_eq!(m.unverified, 0);
+        assert_eq!(m.verification_rate, 0.0);
+        assert_eq!(m.tier, Tier::Aspirant);
+        assert_eq!(m.visible_score, 0.0);
+        assert_eq!(m.schema_version, METRICS_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn assumes_are_counted_separately_and_never_verifiable() {
+        let m = metrics_of(vec![assume(), assume()]);
+        assert_eq!(m.assumes, 2);
+        assert_eq!(m.intents, 0);
+        assert_eq!(m.verifiable, 0);
+    }
+
+    #[test]
+    fn verify_false_intents_are_not_verifiable() {
+        let m = metrics_of(vec![
+            intent(VerifyLevel::Bool(false), Status::Unknown),
+            intent(VerifyLevel::Method(VerifyMethod::Test), Status::Unknown),
+        ]);
+        assert_eq!(m.intents, 2, "both are intents");
+        assert_eq!(m.verifiable, 1, "only the non-false one is verifiable");
+    }
+
+    #[test]
+    fn verified_clean_counts_only_terminal_clean_verifiable_intents() {
+        let m = metrics_of(vec![
+            intent(VerifyLevel::Method(VerifyMethod::Neural), Status::Neural), // clean
+            intent(VerifyLevel::Method(VerifyMethod::Test), Status::Tested),   // clean
+            intent(VerifyLevel::Method(VerifyMethod::Full), Status::Verified), // clean
+            intent(VerifyLevel::Method(VerifyMethod::Neural), Status::Stale),  // not clean
+            intent(VerifyLevel::Method(VerifyMethod::Test), Status::Unknown),  // not clean
+            intent(VerifyLevel::Bool(false), Status::Verified), // not verifiable (excluded)
+        ]);
+        assert_eq!(m.intents, 6);
+        assert_eq!(m.verifiable, 5);
+        assert_eq!(m.verified_clean, 3);
+        assert_eq!(m.unverified, 2);
+        assert!((m.verification_rate - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn unverified_plus_verified_clean_equals_verifiable() {
+        let m = metrics_of(vec![
+            intent(VerifyLevel::Method(VerifyMethod::Neural), Status::Neural),
+            intent(
+                VerifyLevel::Method(VerifyMethod::Test),
+                Status::Counterexample,
+            ),
+            intent(VerifyLevel::Bool(true), Status::Unknown),
+        ]);
+        assert_eq!(m.verified_clean + m.unverified, m.verifiable);
+    }
+
+    #[test]
+    fn metrics_json_round_trips() {
+        let m = metrics_of(vec![intent(
+            VerifyLevel::Method(VerifyMethod::Neural),
+            Status::Neural,
+        )]);
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Metrics = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn metrics_schema_generates() {
+        // The JsonSchema derive must produce a schema (gates the
+        // `aristo metrics --json` contract test in the cli).
+        let schema = schemars::schema_for!(Metrics);
+        let json = serde_json::to_string(&schema).unwrap();
+        assert!(
+            json.contains("verification_rate"),
+            "schema names the fields"
+        );
+        assert!(json.contains("verified_clean"));
+    }
+}

--- a/schemas/aristo-config.schema.json
+++ b/schemas/aristo-config.schema.json
@@ -56,6 +56,16 @@
         }
       ]
     },
+    "nudges": {
+      "default": {
+        "aggressiveness": "medium"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NudgesConfig"
+        }
+      ]
+    },
     "stamp": {
       "default": {
         "hash_crate_root": false,
@@ -93,6 +103,39 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "Aggressiveness": {
+      "description": "Nudge aggressiveness ladder. Maps to a numeric factor `f` the scorer multiplies into each signal's normalized pressure: a signal fires when `pressure * f >= 1`, so higher `f` fires sooner. `Off` yields `f = 0`, the structural global opt-out (nothing can fire).",
+      "oneOf": [
+        {
+          "description": "No nudges at all (global opt-out).",
+          "type": "string",
+          "enum": [
+            "off"
+          ]
+        },
+        {
+          "description": "Quietest: only large backlogs / strong signals surface.",
+          "type": "string",
+          "enum": [
+            "low"
+          ]
+        },
+        {
+          "description": "Balanced default.",
+          "type": "string",
+          "enum": [
+            "medium"
+          ]
+        },
+        {
+          "description": "Eager: surfaces sooner and re-arms faster.",
+          "type": "string",
+          "enum": [
+            "high"
+          ]
+        }
+      ]
+    },
     "CacheStrategy": {
       "oneOf": [
         {
@@ -287,6 +330,22 @@
           ],
           "format": "uint32",
           "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "NudgesConfig": {
+      "description": "`[nudges]` — the proactive nudge/progress engine (Phase 18). A single `aggressiveness` knob scales every nudge's fire threshold (and the human-prompt cooldown); `off` silences the engine entirely — the global opt-out, mirroring `[canon] enabled = false`.",
+      "type": "object",
+      "properties": {
+        "aggressiveness": {
+          "description": "How eagerly the engine surfaces nudges. Higher lowers every signal's fire threshold and shortens the human cooldown; `off` disables all nudges. Default `medium`.",
+          "default": "medium",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Aggressiveness"
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
**Phase 18 #7** — end-of-session authored-intent review, the nudge engine's **first consumer** (D2). Stacked on #33 (`feat/phase18-nudge-engine`); rebases onto `main` once #32 → #33 land.

## What this adds
- **`aristo review`** — lists authored intents awaiting review, split into *new-this-session* vs *backlog* (when a SessionStart baseline exists), human or `--json`.
- **`aristo review --mark <id>[,<id>…]`** — records intents reviewed. The whole batch is validated before any write (atomic): a bad id marks nothing and errors.
- **`aristo-authored-review` skill** — the agent-facing orchestrator: list → `AskUserQuestion` → **Critique-first** (background `aristo critique --filter id=…`, reusing the critique skill) or **Review-now** (light per-intent: mark / edit / delete).

## Design adherence
- **D6/Q3 identity:** review state keys on the (now-deterministic, #13) `aret_*` id; a text/body **hash drift re-opens** a reviewed intent — a reviewer approved a *version*, not the id forever.
- **Single source of truth:** `nudge::intents::authored_intents` is the one enumeration both the engine's `review_backlog` metric and `aristo review` read — they can never report a different backlog.
- **D9 two paths** (Critique-first recommended / Review-now light); **D11 guard ordering** (kick critique + stamp *before* opening a session); **Layer-3** session-guard check in the skill.
- **Subject-only** (never references the model); source edits funnel through `aristo stamp`.

## Deferred (gated)
The **Stop-hook auto-trigger** (S0d.3) stays deferred until the S0a live-hook spike validates the contract. This surface is usable now via the skill or directly.

## Tests / gate (all green locally)
- Unit: `authored_intents` enumeration, new-vs-backlog split, atomic mark-validation, comma-expansion.
- Integration (`tests/review_command.rs`): list → mark → backlog clears → reword re-opens → empty repo.
- Skill contract test pins the load-bearing lines; drift-safe via the shared enumeration.
- `cargo fmt --check` · full test suite · `clippy -D warnings` · `rustdoc -D warnings` · `aristo stamp --check` (0 drift) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)