### PR TITLE
feat(#10): wire canon_pending — surface pending canon matches/suggestions

### DIFF
--- a/.aristo/doc/canon_pending_counts_open_matches_plus_unclaimed_suggestions.md
+++ b/.aristo/doc/canon_pending_counts_open_matches_plus_unclaimed_suggestions.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `canon_pending_counts_open_matches_plus_unclaimed_suggestions`**
+
+`canon_pending` (#10) counts the canon work awaiting the user's review: open primary matches in the cache PLUS unclaimed suggestion tasks in the queue. Claimed tasks are excluded — they're already in flight, not waiting. It is tolerant: any read error yields 0, because it feeds a nudge and a nudge must never fail a workflow on missing or malformed cache state.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T19:37:39.27234Z"
+generated_at = "2026-06-07T19:53:07.500091Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -222,6 +222,17 @@ text_hash = "sha256:231001cb3b7f6d75fe746347c26fdb396c793ecc1fca2a72d1de808a97db
 body_hash = "sha256:8737e1f46bb364aa176f3711bef40e680ff511235c41ea3c0c6f46a31ccd5247"
 file = "crates/aristo-cli/src/commands/canon/runner.rs"
 site = "fn merge_response_into_cache (line 326)"
+covered_region = "function"
+
+[canon_pending_counts_open_matches_plus_unclaimed_suggestions]
+kind = "intent"
+text = "`canon_pending` (#10) counts the canon work awaiting the user's review: open primary matches in the cache PLUS unclaimed suggestion tasks in the queue. Claimed tasks are excluded — they're already in flight, not waiting. It is tolerant: any read error yields 0, because it feeds a nudge and a nudge must never fail a workflow on missing or malformed cache state."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:43f94d0f8c9f2b3306365e3904b8b9a8c3a880de3eefe080ca8051a10b0547ce"
+body_hash = "sha256:625904622666f4f2bbdab5c03358af336813fa0b704d18f8c2f39f3a35121afe"
+file = "crates/aristo-cli/src/commands/canon/suggestions.rs"
+site = "fn pending_total (line 491)"
 covered_region = "function"
 
 [clear_active_pointer_is_idempotent_and_load_bearing_for_exit]
@@ -648,7 +659,7 @@ text = "The union function is read-only and tolerant: it never mutates the works
 verify = "neural"
 status = "unknown"
 text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
-body_hash = "sha256:39a56812a96b7e6f06f91a89af81cfd931f94287273914f9ed088fda32b0581f"
+body_hash = "sha256:6a698b2b96c9ce048bdf33b04e70670dda917d265b5c7ced6b7872ff712e0f89"
 file = "crates/aristo-cli/src/commands/nudge.rs"
 site = "fn build_inputs (line 193)"
 covered_region = "function"

--- a/crates/aristo-cli/src/commands/canon/suggestions.rs
+++ b/crates/aristo-cli/src/commands/canon/suggestions.rs
@@ -463,25 +463,19 @@ fn run_show(ws: &Workspace, objective: &str) -> CliResult<()> {
     Ok(())
 }
 
-fn run_counts(ws: &Workspace) -> CliResult<()> {
-    let cache_path = ws.canon_matches_path();
-    let cache = CanonMatchesFile::read(&cache_path).map_err(CliError::Io)?;
+/// The two "awaiting review" canon numbers: open primary matches in the cache,
+/// and unclaimed suggestion tasks in the queue. Shared by the `--counts`
+/// readout and the nudge engine's `canon_pending` signal so both agree on what
+/// "pending" means. Claimed tasks are excluded — they're already in flight.
+fn pending_raw(ws: &Workspace) -> CliResult<(usize, usize)> {
+    let cache = CanonMatchesFile::read(&ws.canon_matches_path()).map_err(CliError::Io)?;
+    let match_pending = cache
+        .entries
+        .values()
+        .flat_map(|e| &e.pending_matches)
+        .filter(|m| matches!(m.disposition, Disposition::Open))
+        .count();
 
-    // Matches: pending = open primary matches in the cache. We don't
-    // distinguish new-vs-carried here (no prior snapshot to diff
-    // against in the read-only path), so everything open is "pending"
-    // and "new" is 0 — Slice 3's session seeding does the new/carried
-    // split. Reported here for the menu's at-a-glance count.
-    let mut match_pending = 0usize;
-    for entry in cache.entries.values() {
-        for m in &entry.pending_matches {
-            if matches!(m.disposition, Disposition::Open) {
-                match_pending += 1;
-            }
-        }
-    }
-
-    let tasks = read_all_tasks(ws)?;
     let qdir = QueueDir::for_pipeline(ws, PIPELINE);
     let pending_in_queue = if qdir.pending_dir().is_dir() {
         std::fs::read_dir(qdir.pending_dir())?
@@ -491,6 +485,31 @@ fn run_counts(ws: &Workspace) -> CliResult<()> {
     } else {
         0
     };
+    Ok((match_pending, pending_in_queue))
+}
+
+#[aristo::intent(
+    "`canon_pending` (#10) counts the canon work awaiting the user's review: \
+     open primary matches in the cache PLUS unclaimed suggestion tasks in the \
+     queue. Claimed tasks are excluded — they're already in flight, not \
+     waiting. It is tolerant: any read error yields 0, because it feeds a \
+     nudge and a nudge must never fail a workflow on missing or malformed \
+     cache state.",
+    verify = "test",
+    id = "canon_pending_counts_open_matches_plus_unclaimed_suggestions"
+)]
+/// Total canon work awaiting review (open matches + unclaimed suggestion
+/// tasks), for the nudge engine's `canon_pending` signal. Tolerant: any read
+/// error yields 0.
+pub(crate) fn pending_total(ws: &Workspace) -> usize {
+    pending_raw(ws).map(|(m, q)| m + q).unwrap_or(0)
+}
+
+fn run_counts(ws: &Workspace) -> CliResult<()> {
+    // `pending_raw` gives open matches + unclaimed queue tasks; the menu count
+    // also reports the in-flight (claimed) tasks, which it derives here.
+    let (match_pending, pending_in_queue) = pending_raw(ws)?;
+    let tasks = read_all_tasks(ws)?;
     let claimed_in_queue = tasks.len().saturating_sub(pending_in_queue);
 
     let counts = Counts {
@@ -588,6 +607,92 @@ mod tests {
             out.push(toml::from_str::<SuggestionTask>(&raw).unwrap());
         }
         out
+    }
+
+    #[test]
+    fn pending_total_is_zero_for_a_fresh_workspace() {
+        // No cache, no queue → tolerant 0 (a nudge must never fail on this).
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = Workspace {
+            root: tmp.path().to_path_buf(),
+        };
+        assert_eq!(pending_total(&ws), 0);
+    }
+
+    #[test]
+    fn pending_total_counts_open_matches_and_unclaimed_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = Workspace {
+            root: tmp.path().to_path_buf(),
+        };
+        std::fs::create_dir_all(ws.aristo_dir()).unwrap();
+        // One OPEN primary match in the cache.
+        std::fs::write(
+            ws.canon_matches_path(),
+            r#"
+[__meta__]
+schema_version = 1
+
+[foo]
+last_match_text_hash = "blake3:x"
+canon_fetched_at = "2026-06-15T09:14:22Z"
+
+[[foo.pending_matches]]
+canon_id = "x"
+version = "v0.1.0"
+canonical_text = "y"
+canon_version = "v0.2.0"
+confidence = 0.9
+prefix_tier = "aristos:"
+linked = "arta_x"
+disposition = "open"
+found_at = "2026-06-15T09:14:22Z"
+found_by = "aristo stamp"
+"#,
+        )
+        .unwrap();
+        // Two unclaimed suggestion tasks in the queue.
+        let qdir = QueueDir::for_pipeline(&ws, PIPELINE);
+        std::fs::create_dir_all(qdir.pending_dir()).unwrap();
+        std::fs::write(qdir.pending_dir().join("t1.toml"), "x").unwrap();
+        std::fs::write(qdir.pending_dir().join("t2.toml"), "x").unwrap();
+
+        assert_eq!(pending_total(&ws), 3, "1 open match + 2 unclaimed tasks");
+    }
+
+    #[test]
+    fn pending_total_excludes_non_open_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = Workspace {
+            root: tmp.path().to_path_buf(),
+        };
+        std::fs::create_dir_all(ws.aristo_dir()).unwrap();
+        // A skipped match does not count as pending review work.
+        std::fs::write(
+            ws.canon_matches_path(),
+            r#"
+[__meta__]
+schema_version = 1
+
+[foo]
+last_match_text_hash = "blake3:x"
+canon_fetched_at = "2026-06-15T09:14:22Z"
+
+[[foo.pending_matches]]
+canon_id = "x"
+version = "v0.1.0"
+canonical_text = "y"
+canon_version = "v0.2.0"
+confidence = 0.9
+prefix_tier = "aristos:"
+linked = "arta_x"
+disposition = "skipped"
+found_at = "2026-06-15T09:14:22Z"
+found_by = "aristo stamp"
+"#,
+        )
+        .unwrap();
+        assert_eq!(pending_total(&ws), 0);
     }
 
     #[test]

--- a/crates/aristo-cli/src/commands/nudge.rs
+++ b/crates/aristo-cli/src/commands/nudge.rs
@@ -243,15 +243,21 @@ pub(crate) fn build_inputs(
     // Local-only sign-in check (env var / config files; never network).
     let signed_in = aristo_core::auth::resolve_full().is_ok();
 
+    // Canon matching is paid (#10): only read the local cache + suggestions
+    // queue when signed in, so the canon signal does no work and stays silent
+    // otherwise (no upsell spam). The reader is tolerant — errors yield 0.
+    let canon_pending = if signed_in {
+        crate::commands::canon::suggestions::pending_total(ws)
+    } else {
+        0
+    };
+
     Ok(EngineInputs {
         metrics,
         edits_since_annotation: state.edits_since_annotation,
         unreviewed_intents,
         proofs_awaiting_review,
-        // TODO(S0d follow-up): read pending canon matches + suggestions from
-        // the local `.aristo/canon-matches.toml` + suggestions queue. Until
-        // then the (signed-in-gated) canon signal stays silent.
-        canon_pending: 0,
+        canon_pending,
         prior_score,
         tier_increased,
         signed_in,
@@ -371,6 +377,12 @@ fn backlog_summary(inputs: &EngineInputs) -> String {
         parts.push(format!(
             "{} intent(s) await review",
             inputs.unreviewed_intents
+        ));
+    }
+    if inputs.canon_pending > 0 {
+        parts.push(format!(
+            "{} canon match(es)/suggestion(s) pending",
+            inputs.canon_pending
         ));
     }
     if inputs.metrics.unverified > 0 {


### PR DESCRIPTION
**Phase 18 #10** — make the nudge engine's `canon_pending` signal real (it was stubbed to `0`). Stacked on #34 → #33; rebases onto `main` once the stack lands.

## What this adds
- **`canon::suggestions::pending_total(ws)`** — open primary matches in `.aristo/canon-matches.toml` + unclaimed suggestion-queue tasks (claimed = in-flight, excluded). **Tolerant**: any read error → `0`, so a nudge never fails on missing/malformed cache. Extracted `pending_raw`, shared with `aristo canon suggestions --counts` so both agree on "pending".
- **`build_inputs`**: `canon_pending = signed_in ? pending_total(ws) : 0` — does no work and stays silent when not signed in (canon is paid; no upsell spam, no network).
- **`backlog_summary`**: surfaces the pending canon count, in signal-priority order (review > canon > verify > proof-review).

The `canon_pending` SIGNALS entry + recommended-action routing (→ `aristo-intent-suggestions`) already existed; this wires the metric so the signal can actually fire. Completes #10's substrate. (`#4`/`#8` are likewise built as scorer signals; only the gated Stop-hook install remains for the proactive surface.)

## Tests / gate (all green locally)
- `pending_total`: fresh workspace → 0 (tolerant); open match + unclaimed tasks counted; non-open (skipped) matches excluded.
- `aristo canon suggestions --counts` behavior preserved (refactor is non-behavioral).
- `cargo fmt --check` · full test · `clippy -D warnings` · `rustdoc -D warnings` · `aristo stamp --check` (0 drift) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)