### PR TITLE
feat(#11,#12): aristo-status + aristo-help skills — complete the suite

### DIFF
--- a/crates/aristo-cli/src/skills/aristo-help.md
+++ b/crates/aristo-cli/src/skills/aristo-help.md
@@ -1,0 +1,46 @@
+---
+name: aristo-help
+description: Orientation for the Aristo skill suite. Summarizes each bundled skill (what it does + the benefit) and gives example end-to-end scenario flows — new-project setup, PR review, canon-bound deep verify, and failure → fix-or-waive. Start here if you're not sure which `/aristo-*` skill to reach for.
+sdk_version: {{SDK_VERSION}}
+---
+
+# Aristo skill suite — what's here and when to use it
+
+When the user invokes this skill (typically `/aristo-help`, or "what aristo skills are there?", "how do I use aristo?", "which skill do I run?"), give them this orientation. Aristo turns the *intent* behind code into checkable, verifiable claims; the skills below drive the loop. Each is a zero-argument slash command (NL/menu routing, not flags).
+
+## The skills
+
+- **`aristo-authoring`** — capture intent *as you code*. Annotate the non-obvious decisions (a chosen invariant, a refactor trap, a deliberate-not-incomplete choice) with `#[aristo::intent]` while the rationale is fresh. **Benefit:** the *why* is recorded at the load-bearing site, in the user's words, where it can be verified — not lost to a stale comment.
+
+- **`aristo-verify`** — verify intents and review the results. Opens a scope × mode menu (changed·neural by default, offline; full/both run server proofs in the background, sign-in gated), dispatches local one-shot workers and/or a server session, then walks the verdicts card by card (subject-only failure + success cards; fix-or-waive). **Benefit:** every claim is checked against the code, and nothing it concludes lands until the user accepts it.
+
+- **`aristo-critique`** — agentic prose-review of the annotations themselves (rephrasing, parent-shape, vocabulary, scope, clarity). Advisory only; never blocks, never edits source. **Benefit:** opinionated feedback that makes the claims sharper, opt-in.
+
+- **`aristo-intent-suggestions`** — review **canon matches**: the server's suggested canonical wording for your annotations, plus the sibling invariants of the same proof objective. **Benefit:** bind your claims to a shared catalog and adopt the related invariants you didn't think to write — high proof reuse.
+
+- **`aristo-authored-review`** — review the intents *you just authored* (distinct from canon matches): list what's unreviewed (new-this-session vs backlog), then either kick a background critique pass (Critique-first) or do a light per-intent pass (mark reviewed / edit / delete). **Benefit:** a natural-pause checkpoint so freshly-written claims actually get a second look.
+
+- **`aristo-status`** — a friendly, read-only project readout: tier + score, verification rate, counts, review backlog, pending canon, and the engine's recommended next action. **Benefit:** see where you stand at a glance, with one nudge toward the highest-value next step.
+
+- **`aristo-help`** — this overview.
+
+## Example scenario flows
+
+**New project → first verified claim.**
+`aristo init` → write code + `/aristo-authoring` (annotate the why) → `/aristo-verify` (changed·neural) → `/aristo-authored-review` (look over what you wrote) → commit (the git hook keeps the index honest) → `/aristo-status` to see the tier tick up.
+*Yields:* the intent behind the code is captured, checked, and reviewed before it ships.
+
+**PR review (CI).** On a pull request, an automated pass critiques the annotations added/modified and authors any missing intents on the changed code, then comments back — comment-only by default, no silent source mutation.
+*Yields:* intent coverage + prose quality enforced at review time, not after merge.
+
+**Canon-bound deep verify.** Sign in (`aristo auth login`) → `/aristo-verify` (full / both — server proofs in the background) → `/aristo-intent-suggestions` to adopt the matched canonical wording + sibling invariants.
+*Yields:* claims bound to the shared catalog with reusable, server-verified proofs.
+
+**Failure → fix-or-waive.** `/aristo-verify` surfaces a ✗ refuted card (the claim, the tested call-path, the violating path in *your* code) → **Fix in code** (edit + re-verify) or **Waive** (`aristo verify --accept <id> --because <reason>` — a tracked known-gap that the strict ratchet flips back to red if it ever starts passing).
+*Yields:* refutations are loud and actionable; accepted gaps are reasoned and can't silently rot.
+
+## Notes
+
+- Proactive nudges (annotate after N edits, review at a pause, verify backlog, score/tier changes) come from the unified nudge engine and are configurable via `[nudges] aggressiveness = off|low|medium|high` in `aristo.toml`.
+- Everything here is **subject-only**: the skills surface the user's own code and claims, never any internal verification model.
+- All skills are installed per-agent with `aristo install-skills`; check for updates with `aristo install-skills --check`.

--- a/crates/aristo-cli/src/skills/aristo-status.md
+++ b/crates/aristo-cli/src/skills/aristo-status.md
@@ -1,0 +1,64 @@
+---
+name: aristo-status
+description: Pretty-prints a friendly project verification readout. Runs the read-only commands — `aristo metrics --json` (counts, verification rate, tier, score), `aristo status` (full breakdown by kind / verify level / status, plus review backlog + canon/skill health), `aristo review --json` (intents awaiting review, new-this-session vs backlog), and `aristo nudge` (the engine's recommended next action) — and synthesizes them into one digest. Read-only; never mutates the workspace. Subject-only: it reports on the user's own annotations and code.
+sdk_version: {{SDK_VERSION}}
+---
+
+# Aristo status
+
+When the user invokes this skill (typically by typing `/aristo-status`, or asking "how's my coverage / tier?", "show my aristo status", "where do I stand?"), produce ONE friendly digest of the project's verification health. This skill is **read-only** — it runs reporting commands and pretty-prints. It never edits source, never stamps, never starts a session.
+
+**Subject-only:** everything you surface is about the user's own annotations, code, and progress — never any internal verification model.
+
+## Step 1 — gather (read-only commands)
+
+Run these and keep the output. None of them mutate anything:
+
+```bash
+aristo metrics --json     # machine-readable: intents, assumes, verifiable, verified_clean, unverified, verification_rate, tier, visible_score
+aristo status             # full human breakdown: by kind / verify level / status, tier + score, review backlog, canon health, skill health
+aristo review --json      # intents awaiting review: unreviewed_count, new_count, backlog_count, baseline_captured
+aristo nudge              # the nudge engine's "would-surface" readout — the recommended next action (do NOT invent a parallel one)
+```
+
+If `aristo metrics` reports there is no workspace (or the command errors with "no aristo workspace"), tell the user this directory isn't an Aristo project yet (suggest `aristo init`) and stop. Don't fabricate numbers.
+
+## Step 2 — synthesize ONE digest
+
+Pretty-print a single readout. Use the ACTUAL values from the commands — don't recompute or guess. Suggested shape:
+
+```
+Aristo status — <project dir>
+
+Tier:     <tier> · score <visible_score>      (ladder: Aspirant → Apprentice → Adept → Ascendent → ✦ Areté)
+Verified: <verified_clean>/<verifiable>  (<verification_rate as %>)   ·   <unverified> unverified
+Authored: <intents> intents · <assumes> assumes
+Review:   <unreviewed_count> awaiting   (<new_count> new this session · <backlog_count> backlog, when a baseline exists)
+```
+
+Then add, only when non-empty (pull from `aristo status`):
+- the **by-status** breakdown (verified / tested / neural / stale / counterexample / inconclusive / …) — surface any ⚠️ states (counterexample, forged, orphan) prominently;
+- the **review backlog** (deferred session items) and any **active review session**;
+- **canon health** + pending canon matches/suggestions (only when signed in);
+- **skill health** (installed / stale agent skills), if `aristo status` flags drift.
+
+Keep it tight and scannable. Don't dump raw JSON at the user.
+
+## Step 3 — recommend the next action (via the engine, not a parallel nudge)
+
+End with the single recommended next step. **Take it from `aristo nudge`'s readout** — that is the unified nudge/progress engine (#9), and routing through it keeps every surface consistent (don't hardcode a competing recommendation here). Phrase it as an offer, e.g.:
+
+- engine recommends review → "You have <N> intents awaiting review — want to run `/aristo-authored-review`?"
+- engine recommends verify → "<N> intents are unverified — want to run `/aristo-verify`?"
+- engine recommends canon → "There are pending canon matches — want `/aristo-intent-suggestions`?"
+- a win (tier/score up) → congratulate, briefly.
+- nothing fired / `aggressiveness = off` → just report; no nudge.
+
+If `aristo nudge` surfaced nothing, don't manufacture an action — a clean board is a good result; say so.
+
+## What this skill does NOT do
+
+- It does NOT mutate anything — no `stamp`, no `verify`, no `session start`, no source edits. It is a pure readout.
+- It does NOT recompute tier/score/rate itself — those come from `aristo metrics` / `aristo status` (one source of truth; no drift).
+- It does NOT invent next-step nudges — the recommendation comes from `aristo nudge` (the #9 engine), so it can never disagree with the proactive nudges.
+- It does NOT reference any internal verification model — subject-only.

--- a/crates/aristo-cli/src/skills/mod.rs
+++ b/crates/aristo-cli/src/skills/mod.rs
@@ -106,12 +106,24 @@ const AUTHORED_REVIEW: Skill = Skill {
     content: include_str!("aristo-authored-review.md"),
 };
 
+const STATUS: Skill = Skill {
+    name: "aristo-status",
+    content: include_str!("aristo-status.md"),
+};
+
+const HELP: Skill = Skill {
+    name: "aristo-help",
+    content: include_str!("aristo-help.md"),
+};
+
 const BUNDLED: &[Skill] = &[
     AUTHORING,
     VERIFY,
     CRITIQUE,
     INTENT_SUGGESTIONS,
     AUTHORED_REVIEW,
+    STATUS,
+    HELP,
 ];
 
 #[cfg(test)]
@@ -516,6 +528,73 @@ mod tests {
             body.contains("aristo session exit --defer-undecided"),
             "skill body must offer defer-undecided as the early-stop path \
              so un-decided proofs go to backlog, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn help_skill_is_bundled_and_covers_the_whole_suite() {
+        let s = find("aristo-help").expect("aristo-help must be bundled (Phase 18 #11)");
+        let body = s.resolved_content();
+        assert!(body.starts_with("---"), "skill must start with frontmatter");
+        assert!(
+            body.contains("name: aristo-help"),
+            "frontmatter must carry the skill name"
+        );
+        // Anti-drift: aristo-help must name EVERY bundled skill, so adding a
+        // skill without documenting it here fails this test (forces the sync).
+        for skill in bundled() {
+            assert!(
+                body.contains(skill.name),
+                "aristo-help must mention `{}` — a bundled skill is undocumented in the suite overview",
+                skill.name
+            );
+        }
+        // It must teach scenario flows, not just a skill list.
+        assert!(
+            body.contains("scenario flows") || body.contains("Example scenario"),
+            "aristo-help must give example end-to-end scenario flows"
+        );
+        assert!(
+            body.contains("fix-or-waive") || body.contains("fix or waive"),
+            "aristo-help must cover the failure → fix-or-waive flow"
+        );
+    }
+
+    #[test]
+    fn status_skill_is_bundled() {
+        let s = find("aristo-status").expect("aristo-status must be bundled (Phase 18 #12)");
+        let body = s.resolved_content();
+        assert!(body.starts_with("---"), "skill must start with frontmatter");
+        assert!(
+            body.contains("name: aristo-status"),
+            "frontmatter must carry the skill name"
+        );
+        // Reads the real reporting commands (one source of truth; no recompute).
+        assert!(
+            body.contains("aristo metrics --json"),
+            "skill must read metrics via `aristo metrics --json`"
+        );
+        assert!(
+            body.contains("aristo status"),
+            "skill must read the full breakdown via `aristo status`"
+        );
+        assert!(
+            body.contains("aristo review --json"),
+            "skill must surface the review backlog via `aristo review --json`"
+        );
+        // Next-action recommendation routes through the #9 engine, not a parallel nudge.
+        assert!(
+            body.contains("aristo nudge"),
+            "skill must take its recommended next action from `aristo nudge` (the #9 engine)"
+        );
+        // Read-only + subject-only discipline.
+        assert!(
+            body.contains("read-only") || body.contains("Read-only"),
+            "skill must declare it is read-only (no mutation)"
+        );
+        assert!(
+            body.contains("Subject-only") || body.contains("subject-only"),
+            "skill must encode the subject-only rule"
         );
     }
 


### PR DESCRIPTION
**Phase 18 #11 + #12** — the last two bundled skills, completing the suite. Stacked on #36 → … → #33; rebases onto `main` once the stack lands. (Sequenced after #1 so both reference the renamed `aristo-verify`.)

## #12 — `aristo-status` (read-only readout)
Runs the existing reporting commands — `aristo metrics --json`, `aristo status`, `aristo review --json` — and pretty-prints one digest: tier + score, verification rate, counts, review backlog, canon/skill health. **Recommended next action comes from `aristo nudge`** (the #9 engine), so it never disagrees with the proactive nudges and adds no parallel one. Never mutates; subject-only.

## #11 — `aristo-help` (suite orientation)
Summarizes every bundled skill (what + benefit) and gives end-to-end scenario flows: new-project setup, PR review, canon-bound deep verify, failure → fix-or-waive. **Anti-drift:** the contract test iterates `bundled()` and asserts the help body names *every* bundled skill — adding a skill without documenting it here fails CI.

## Notes
- Both registered in `BUNDLED` with contract tests. No new `#[aristo::intent]` annotations → the index/docs are untouched.
- The suite is now: `aristo-authoring`, `aristo-verify`, `aristo-critique`, `aristo-intent-suggestions`, `aristo-authored-review`, `aristo-status`, `aristo-help`.

## Gate (all green locally)
`cargo fmt --check` · full test (incl. `skills::status_skill_is_bundled`, `skills::help_skill_is_bundled_and_covers_the_whole_suite`) · `clippy -D warnings` · `rustdoc -D warnings` · `aristo stamp --check` (0 drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)