### PR TITLE
feat(#9): nudge surface v2 — additionalContext channel + auto-install (S0d.3)

### DIFF
--- a/.aristo/doc/nudge_reaches_agent_only_via_additional_context.md
+++ b/.aristo/doc/nudge_reaches_agent_only_via_additional_context.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `nudge_reaches_agent_only_via_additional_context`**
+
+A hook reaches the agent's context ONLY through `hookSpecificOutput.additionalContext`; a plain string (even a literal `<system-reminder>`) printed to a hook's stdout lands in the transcript but never in the model's context (the S0a spike: the old Stop/PostToolUse stdout reminders never reached the agent, the SessionStart additionalContext did). Every agent-facing nudge MUST use this JSON envelope — emitting bare text would be a silently-dead nudge.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/score_authoring_debt_needs_no_index_walk.md
+++ b/.aristo/doc/score_authoring_debt_needs_no_index_walk.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `score_authoring_debt_needs_no_index_walk`**
+
+Scoring the authoring-debt (agent) signal needs ONLY the edit counter — never the index-derived Metrics. The PostToolUse hook that drives it fires on every edit, so it must not walk the source tree per edit; this scores the one signal straight from the counter, reusing the registry's base and the identical `pressure * factor >= 1` fire rule so it can't drift from `score`.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/statusline_install_never_clobbers_user_config.md
+++ b/.aristo/doc/statusline_install_never_clobbers_user_config.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `statusline_install_never_clobbers_user_config`**
+
+Installing the statusLine NEVER clobbers an existing one: settings.json's `statusLine` is a single value (not an append-safe array), so a user who already configured a status line keeps it — aristo only sets it when the field is absent. Uninstall removes it only when it is aristo's own (its command mentions the aristo statusline marker).
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/doc/statusline_is_read_only_and_tolerant.md
+++ b/.aristo/doc/statusline_is_read_only_and_tolerant.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `statusline_is_read_only_and_tolerant`**
+
+The statusline is read-only and TOLERANT: on any failure — no workspace, an unreadable index, or nudges globally off — it prints nothing and exits 0. The status bar re-renders on every turn, so a statusline that errored or wrote files would corrupt the bar or thrash the workspace on every keystroke. Silence is the correct degraded state.
+
+<sub>Verify level: **test**</sub>
+
+---

--- a/.aristo/index.toml
+++ b/.aristo/index.toml
@@ -1,7 +1,7 @@
 [__meta__]
 schema_version = 1
 generated_by = "aristo stamp 0.2.2"
-generated_at = "2026-06-07T19:53:07.500091Z"
+generated_at = "2026-06-08T02:46:09.139374Z"
 source_root = "."
 
 [abort_requires_explicit_confirmation]
@@ -551,7 +551,7 @@ status = "unknown"
 text_hash = "sha256:9cb4356aacef3066c29135e3eb68ee56bd482752df4eab394a26687bb4fee8e8"
 body_hash = "sha256:c42c6102bd77459be15f1ed1515943e4ad2fdc34c4beb3d4646df01775e925e9"
 file = "crates/aristo-cli/src/commands/install_skills_hook.rs"
-site = "fn install_hook_into (line 82)"
+site = "fn install_hook_into (line 107)"
 covered_region = "function"
 
 [install_skills_scope_symmetry]
@@ -631,6 +631,17 @@ file = "crates/aristo-core/src/metrics.rs"
 site = "impl Metrics (line 62)"
 covered_region = "impl_methods"
 
+[nudge_reaches_agent_only_via_additional_context]
+kind = "intent"
+text = "A hook reaches the agent's context ONLY through `hookSpecificOutput.additionalContext`; a plain string (even a literal `<system-reminder>`) printed to a hook's stdout lands in the transcript but never in the model's context (the S0a spike: the old Stop/PostToolUse stdout reminders never reached the agent, the SessionStart additionalContext did). Every agent-facing nudge MUST use this JSON envelope — emitting bare text would be a silently-dead nudge."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:ac76ddc9d55031dee1c281e8d229ff7ad11e1528f15504df49289da9226780aa"
+body_hash = "sha256:77493839fc119526bcab1e0d8f62c3185dfda1fc4da08353cd1955296adbb5a7"
+file = "crates/aristo-cli/src/commands/nudge.rs"
+site = "fn additional_context_json (line 346)"
+covered_region = "function"
+
 [nudge_review_is_current_only_until_hash_drift]
 kind = "intent"
 text = "A review is current only while the annotation's text AND body hashes still match the snapshot taken when it was reviewed. Editing the claim or the covered code after review re-opens it (reads as unreviewed) — a reviewer approved a specific version, not the id forever. Without the hash check, a post-review edit would keep a stale 'reviewed' badge and the review backlog would under-count work that genuinely needs another look."
@@ -661,7 +672,7 @@ status = "unknown"
 text_hash = "sha256:17427cceab6bab02b06161b728889eda24186d92dd43739f16b9d1802d71ebed"
 body_hash = "sha256:6a698b2b96c9ce048bdf33b04e70670dda917d265b5c7ced6b7872ff712e0f89"
 file = "crates/aristo-cli/src/commands/nudge.rs"
-site = "fn build_inputs (line 193)"
+site = "fn build_inputs (line 210)"
 covered_region = "function"
 
 [pending_and_claimed_share_parent_filesystem]
@@ -871,6 +882,17 @@ file = "crates/aristo-core/src/walk/scan_ids.rs"
 site = "fn scan_id_occurrences (line 67)"
 covered_region = "function"
 
+[score_authoring_debt_needs_no_index_walk]
+kind = "intent"
+text = "Scoring the authoring-debt (agent) signal needs ONLY the edit counter — never the index-derived Metrics. The PostToolUse hook that drives it fires on every edit, so it must not walk the source tree per edit; this scores the one signal straight from the counter, reusing the registry's base and the identical `pressure * factor >= 1` fire rule so it can't drift from `score`."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:cc3ffc853d038a1fdd06b82d8236e74b37da4065de6e71a2cfdd770f17781bec"
+body_hash = "sha256:e3ce1842067ab47993b57f53d0c3672c2027a7de0b52c33ced0a0590a44d850f"
+file = "crates/aristo-cli/src/nudge/mod.rs"
+site = "fn score_authoring_debt (line 263)"
+covered_region = "function"
+
 [session_active_is_noop_outside_workspace]
 kind = "intent"
 text = "`aristo session active` is wired into Claude Code's UserPromptSubmit hook (Layer 2). The hook fires on EVERY prompt across EVERY project, not only aristo workspaces. So `active` must exit 0 with empty stdout when run outside an aristo workspace — a hard error would block every prompt in any non-aristo project the user opens. The interactive form (no `--hook-format`) follows the same rule for symmetry: an active session can only exist within a workspace anyway, so no-workspace and no-session are observationally identical at the CLI surface."
@@ -1058,6 +1080,28 @@ file = "crates/aristo-cli/src/commands/status.rs"
 site = "fn compute_project_tier (line 268)"
 covered_region = "function"
 
+[statusline_install_never_clobbers_user_config]
+kind = "intent"
+text = "Installing the statusLine NEVER clobbers an existing one: settings.json's `statusLine` is a single value (not an append-safe array), so a user who already configured a status line keeps it — aristo only sets it when the field is absent. Uninstall removes it only when it is aristo's own (its command mentions the aristo statusline marker)."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:5cf9b9994c71bbc597356a1fcdbc24f12f44b145e667d61e7a4c2c4c04816552"
+body_hash = "sha256:7cda889306436c16c4b2ea2f4afc2498ac1b10bf2fe4d365fce597e81f0ea471"
+file = "crates/aristo-cli/src/commands/install_skills_hook.rs"
+site = "fn install_statusline (line 250)"
+covered_region = "function"
+
+[statusline_is_read_only_and_tolerant]
+kind = "intent"
+text = "The statusline is read-only and TOLERANT: on any failure — no workspace, an unreadable index, or nudges globally off — it prints nothing and exits 0. The status bar re-renders on every turn, so a statusline that errored or wrote files would corrupt the bar or thrash the workspace on every keystroke. Silence is the correct degraded state."
+verify = "test"
+status = "unknown"
+text_hash = "sha256:005c9fef461bbb6cecf519d93cc85f2f6cc1fd1987aff92cfb6542c341192ff0"
+body_hash = "sha256:e7f6c869aca7f761afdefb5bf1d67e8f34b1abf01138013e7f8ef603e50c59d0"
+file = "crates/aristo-cli/src/commands/statusline.rs"
+site = "fn run (line 22)"
+covered_region = "function"
+
 [stmt_form_intents_use_open_visit_descent_not_whitelist]
 kind = "intent"
 text = "stmt-form intents are discovered via syn::Visit's full descent (visit_block + default traversal of every Expr variant), NOT a hand-rolled whitelist of expression kinds. A whitelist silently drops macros nested inside any unenumerated context — match arms, closures, unsafe blocks, async blocks, try blocks, let initializers — and the failure mode is invisible (the intent doesn't appear in `aristo list`, can't be cited as a ground in a proof, and skips the freshness check). The Visit-based descent is open by default; new syn::Expr variants get visited automatically."
@@ -1143,7 +1187,7 @@ status = "unknown"
 text_hash = "sha256:7c052ede0fce6c52efca830d4b479d0bca75033b0b6ac0bf111827fbdffdbf65"
 body_hash = "sha256:63f64377ee2cc32be1f03ea4cb56c9badc88ea481cee9df2bbf5fe1fb8672108"
 file = "crates/aristo-cli/src/commands/install_skills_hook.rs"
-site = "fn uninstall_hook_from (line 129)"
+site = "fn uninstall_hook_from (line 154)"
 covered_region = "function"
 
 [uninstall_skills_reverses_install]
@@ -1165,7 +1209,7 @@ status = "unknown"
 text_hash = "sha256:2912a7446cba9fa220b88cb66a2bf4be70a186d1f32800ac3cbc1b511fc65c46"
 body_hash = "sha256:a98870f81df795fee8469f0a01e968aaded6d266ea2fd5b4b9de6f0ce31fef22"
 file = "crates/aristo-cli/src/commands/install_skills.rs"
-site = "fn update_scopes (line 626)"
+site = "fn update_scopes (line 633)"
 covered_region = "function"
 
 [validator_collects_all_failures_not_short_circuit]

--- a/crates/aristo-cli/src/commands/install_skills.rs
+++ b/crates/aristo-cli/src/commands/install_skills.rs
@@ -240,6 +240,11 @@ fn install_file_copy_agent(agent: Agent, root: &std::path::Path) -> CliResult<()
         } else {
             println!("  • Skill-staleness SessionStart hook already present: {settings_display}");
         }
+        // Nudge-engine surface (Phase 18 #9): PostToolUse + UserPromptSubmit +
+        // SessionStart hooks + the ambient statusLine. Idempotent; gated at
+        // runtime by `[nudges] aggressiveness` (off → silent).
+        super::install_skills_hook::install_nudge_surface(root)?;
+        println!("  • Wrote nudge-engine hooks + statusLine to: {settings_display}");
     }
     Ok(())
 }
@@ -280,6 +285,8 @@ fn uninstall_file_copy_agent(agent: Agent, root: &std::path::Path) -> CliResult<
             println!("  • Removed skill-staleness SessionStart hook from: {settings_display}");
             removed += 1;
         }
+        // Nudge-engine surface (hooks + our statusLine, never a user's).
+        super::install_skills_hook::uninstall_nudge_surface(root)?;
     }
     Ok(removed)
 }

--- a/crates/aristo-cli/src/commands/install_skills_hook.rs
+++ b/crates/aristo-cli/src/commands/install_skills_hook.rs
@@ -47,6 +47,31 @@ const SESSION_START_COMMAND: &str = "aristo install-skills --hook-format 2>/dev/
 /// Marker substring identifying the SessionStart staleness hook.
 const SESSION_START_MARKER: &str = "aristo install-skills --hook-format";
 
+// ─── nudge surface v2 (Phase 18 #9): the engine's hook surfaces ──────────────
+// All emit via `hookSpecificOutput.additionalContext` (the only channel that
+// reaches the agent — the S0a spike). Same tolerant `2>/dev/null || true`
+// fallback so a stale on-PATH aristo never breaks a session. Behaviour is
+// gated at runtime by `[nudges] aggressiveness` (off → silent), so these
+// install unconditionally for Claude Code.
+
+/// PostToolUse: the authoring-debt nudge (edit counter → "annotate" reminder).
+const POST_TOOL_USE_COMMAND: &str = "aristo nudge --event post-tool-use 2>/dev/null || true";
+const POST_TOOL_USE_MARKER: &str = "aristo nudge --event post-tool-use";
+
+/// UserPromptSubmit: the consolidated per-turn review/verify/score nudge (the
+/// Stop replacement — Stop's output never reached the agent).
+const USER_PROMPT_NUDGE_COMMAND: &str =
+    "aristo nudge --event user-prompt-submit 2>/dev/null || true";
+const USER_PROMPT_NUDGE_MARKER: &str = "aristo nudge --event user-prompt-submit";
+
+/// SessionStart: compute-only baseline capture (surfaces nothing itself).
+const SESSION_START_NUDGE_COMMAND: &str = "aristo nudge --event session-start 2>/dev/null || true";
+const SESSION_START_NUDGE_MARKER: &str = "aristo nudge --event session-start";
+
+/// statusLine: the ambient user-facing status segment.
+const STATUSLINE_COMMAND: &str = "aristo statusline 2>/dev/null || true";
+const STATUSLINE_MARKER: &str = "aristo statusline";
+
 /// Settings file path under `<root>/.claude/`.
 fn settings_path(root: &Path) -> std::path::PathBuf {
     root.join(".claude").join("settings.json")
@@ -183,6 +208,110 @@ pub fn uninstall_claude_hook(root: &Path) -> CliResult<bool> {
 /// Remove the `SessionStart` skill-staleness hook.
 pub fn uninstall_session_start_hook(root: &Path) -> CliResult<bool> {
     uninstall_hook_from(root, "SessionStart", SESSION_START_MARKER)
+}
+
+// ─── nudge surface v2 install/uninstall ─────────────────────────────────────
+
+/// Install all nudge-engine surfaces for Claude Code: the PostToolUse,
+/// UserPromptSubmit, and SessionStart hooks plus the statusLine. Idempotent.
+pub fn install_nudge_surface(root: &Path) -> CliResult<()> {
+    install_hook_into(
+        root,
+        "PostToolUse",
+        POST_TOOL_USE_MARKER,
+        post_tool_use_entry(),
+    )?;
+    install_hook_into(
+        root,
+        "UserPromptSubmit",
+        USER_PROMPT_NUDGE_MARKER,
+        user_prompt_nudge_entry(),
+    )?;
+    install_hook_into(
+        root,
+        "SessionStart",
+        SESSION_START_NUDGE_MARKER,
+        session_start_nudge_entry(),
+    )?;
+    install_statusline(root)?;
+    Ok(())
+}
+
+/// Remove all nudge-engine surfaces. Each removal preserves any non-aristo
+/// hooks and only touches a statusLine that is ours.
+pub fn uninstall_nudge_surface(root: &Path) -> CliResult<()> {
+    uninstall_hook_from(root, "PostToolUse", POST_TOOL_USE_MARKER)?;
+    uninstall_hook_from(root, "UserPromptSubmit", USER_PROMPT_NUDGE_MARKER)?;
+    uninstall_hook_from(root, "SessionStart", SESSION_START_NUDGE_MARKER)?;
+    uninstall_statusline(root)?;
+    Ok(())
+}
+
+#[aristo::intent(
+    "Installing the statusLine NEVER clobbers an existing one: settings.json's \
+     `statusLine` is a single value (not an append-safe array), so a user who \
+     already configured a status line keeps it — aristo only sets it when the \
+     field is absent. Uninstall removes it only when it is aristo's own \
+     (its command mentions the aristo statusline marker).",
+    verify = "test",
+    id = "statusline_install_never_clobbers_user_config"
+)]
+fn install_statusline(root: &Path) -> CliResult<bool> {
+    let path = settings_path(root);
+    let mut value = read_settings(&path)?;
+    let obj = ensure_object(&mut value);
+    if obj.contains_key("statusLine") {
+        return Ok(false); // respect the user's existing statusLine
+    }
+    obj.insert(
+        "statusLine".to_string(),
+        serde_json::json!({ "type": "command", "command": STATUSLINE_COMMAND }),
+    );
+    write_settings(&path, &value)?;
+    Ok(true)
+}
+
+fn uninstall_statusline(root: &Path) -> CliResult<bool> {
+    let path = settings_path(root);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut value = read_settings(&path)?;
+    let Some(obj) = value.as_object_mut() else {
+        return Ok(false);
+    };
+    let is_ours = obj
+        .get("statusLine")
+        .map(|v| entry_mentions_hook(v, STATUSLINE_MARKER))
+        .unwrap_or(false);
+    if is_ours {
+        obj.remove("statusLine");
+        write_settings(&path, &value)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// `PostToolUse` entry: matched to the edit-like tools (the nudge emitter
+/// also re-checks the tool name from stdin).
+fn post_tool_use_entry() -> Value {
+    serde_json::json!({
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [ { "type": "command", "command": POST_TOOL_USE_COMMAND } ]
+    })
+}
+
+fn user_prompt_nudge_entry() -> Value {
+    serde_json::json!({
+        "matcher": ".*",
+        "hooks": [ { "type": "command", "command": USER_PROMPT_NUDGE_COMMAND } ]
+    })
+}
+
+fn session_start_nudge_entry() -> Value {
+    serde_json::json!({
+        "hooks": [ { "type": "command", "command": SESSION_START_NUDGE_COMMAND } ]
+    })
 }
 
 fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
@@ -346,5 +475,79 @@ mod tests {
         install_claude_hook(tmp.path()).unwrap();
         assert!(uninstall_claude_hook(tmp.path()).unwrap());
         assert!(!uninstall_claude_hook(tmp.path()).unwrap());
+    }
+
+    #[test]
+    fn nudge_surface_installs_all_three_hooks_plus_statusline() {
+        let tmp = TempDir::new().unwrap();
+        install_nudge_surface(tmp.path()).unwrap();
+        let body = std::fs::read_to_string(settings_path(tmp.path())).unwrap();
+        assert!(body.contains(POST_TOOL_USE_MARKER));
+        assert!(body.contains(USER_PROMPT_NUDGE_MARKER));
+        assert!(body.contains(SESSION_START_NUDGE_MARKER));
+        assert!(body.contains(STATUSLINE_MARKER));
+        // Stop is intentionally NOT installed (its output never reaches the agent).
+        assert!(!body.contains("--event stop"));
+        assert!(!body.contains("\"Stop\""));
+    }
+
+    #[test]
+    fn nudge_surface_install_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        install_nudge_surface(tmp.path()).unwrap();
+        install_nudge_surface(tmp.path()).unwrap();
+        let body = std::fs::read_to_string(settings_path(tmp.path())).unwrap();
+        assert_eq!(body.matches(POST_TOOL_USE_COMMAND).count(), 1);
+        assert_eq!(body.matches(USER_PROMPT_NUDGE_COMMAND).count(), 1);
+        assert_eq!(body.matches(STATUSLINE_COMMAND).count(), 1);
+    }
+
+    #[test]
+    fn nudge_surface_coexists_with_the_session_and_staleness_hooks() {
+        let tmp = TempDir::new().unwrap();
+        install_claude_hook(tmp.path()).unwrap(); // session-active (UserPromptSubmit)
+        install_session_start_hook(tmp.path()).unwrap(); // staleness (SessionStart)
+        install_nudge_surface(tmp.path()).unwrap();
+        let body = std::fs::read_to_string(settings_path(tmp.path())).unwrap();
+        // Both the pre-existing aristo hooks and the new nudge hooks are present.
+        assert!(body.contains(HOOK_MARKER)); // session active
+        assert!(body.contains(SESSION_START_MARKER)); // staleness
+        assert!(body.contains(USER_PROMPT_NUDGE_MARKER));
+        assert!(body.contains(SESSION_START_NUDGE_MARKER));
+    }
+
+    #[test]
+    fn statusline_install_does_not_clobber_an_existing_one() {
+        let tmp = TempDir::new().unwrap();
+        let settings = settings_path(tmp.path());
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        std::fs::write(
+            &settings,
+            r#"{ "statusLine": { "type": "command", "command": "my_custom_bar" } }"#,
+        )
+        .unwrap();
+        assert!(
+            !install_statusline(tmp.path()).unwrap(),
+            "must not overwrite a user statusLine"
+        );
+        let body = std::fs::read_to_string(&settings).unwrap();
+        assert!(body.contains("my_custom_bar"));
+        assert!(!body.contains(STATUSLINE_COMMAND));
+        // …and uninstall leaves the user's statusLine alone (not ours).
+        assert!(!uninstall_statusline(tmp.path()).unwrap());
+        assert!(std::fs::read_to_string(&settings)
+            .unwrap()
+            .contains("my_custom_bar"));
+    }
+
+    #[test]
+    fn nudge_surface_uninstall_removes_only_aristo_entries() {
+        let tmp = TempDir::new().unwrap();
+        install_nudge_surface(tmp.path()).unwrap();
+        uninstall_nudge_surface(tmp.path()).unwrap();
+        let body = std::fs::read_to_string(settings_path(tmp.path())).unwrap();
+        assert!(!body.contains(POST_TOOL_USE_MARKER));
+        assert!(!body.contains(USER_PROMPT_NUDGE_MARKER));
+        assert!(!body.contains(STATUSLINE_COMMAND));
     }
 }

--- a/crates/aristo-cli/src/commands/mod.rs
+++ b/crates/aristo-cli/src/commands/mod.rs
@@ -22,4 +22,5 @@ pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod stamp;
 pub(crate) mod status;
+pub(crate) mod statusline;
 pub(crate) mod verify;

--- a/crates/aristo-cli/src/commands/nudge.rs
+++ b/crates/aristo-cli/src/commands/nudge.rs
@@ -1,9 +1,22 @@
 //! `aristo nudge` — the nudge/progress engine's union function + surfaces
 //! (Phase 18 #9, S0d). With no `--event` it prints what the engine would
-//! surface (human introspection); with `--event <post-tool-use|stop|
-//! session-start>` it runs as a Claude Code hook emitter and ALWAYS exits 0
-//! (a nudge must never break the agent). The hook install + the live spike
-//! that validates the Stop-hook contract land in S0d.3.
+//! surface (human introspection); with `--event <post-tool-use|
+//! user-prompt-submit|session-start>` it runs as a Claude Code hook emitter
+//! and ALWAYS exits 0 (a nudge must never break the agent).
+//!
+//! **Surface contract (v2, validated by the S0a spike — corrects SPINE-PLAN
+//! D10).** A hook only reaches the agent's context via
+//! `hookSpecificOutput.additionalContext` JSON — a plain `<system-reminder>`
+//! to stdout lands in the transcript but NOT in the model's context (proven:
+//! the old Stop/PostToolUse plain-stdout reminders never reached the agent;
+//! the SessionStart additionalContext did). And `Stop` does not deliver at
+//! all. So every surface here emits `additionalContext`, and the per-turn
+//! human nudge rides `UserPromptSubmit` (fires at the start of every turn,
+//! incl. the first — reliably reaches the agent without forcing continuation).
+//! `Stop` is dropped (an old `--event stop` parses as unknown → silent).
+//! `SessionStart` is compute-only: it captures the edit-window baseline and
+//! resets the counter, surfacing nothing (the next `UserPromptSubmit` carries
+//! the backlog). The ambient user-facing surface is `aristo statusline`.
 //!
 //! The union function [`build_inputs`] is the COMPUTE join the scorer reads:
 //! the index-derived [`Metrics`] plus the runtime facts only the cli can see
@@ -28,15 +41,18 @@ use crate::{CliError, CliResult, Workspace};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HookEvent {
     PostToolUse,
-    Stop,
+    UserPromptSubmit,
     SessionStart,
 }
 
 fn parse_event(raw: &str) -> Option<HookEvent> {
     match raw {
         "post-tool-use" | "PostToolUse" => Some(HookEvent::PostToolUse),
-        "stop" | "Stop" => Some(HookEvent::Stop),
+        "user-prompt-submit" | "UserPromptSubmit" => Some(HookEvent::UserPromptSubmit),
         "session-start" | "SessionStart" => Some(HookEvent::SessionStart),
+        // `stop`/`Stop` deliberately unhandled → silent: a Stop hook's stdout
+        // never reaches the agent, so the per-turn nudge moved to
+        // UserPromptSubmit. An already-installed `--event stop` no-ops here.
         _ => None,
     }
 }
@@ -85,11 +101,13 @@ fn emit_for_event(
             if aggressiveness.is_off() {
                 return Ok(());
             }
-            let inputs = build_inputs(ws, config, &state)?;
-            let decision = score(&inputs, aggressiveness);
-            // Agent surface (authoring_debt). Throttle it too so it doesn't
-            // nag on every edit once over threshold.
-            if let Some(f) = decision.agent.iter().find(|f| f.id == "authoring_debt") {
+            // authoring_debt scores off the counter alone — NO build_inputs /
+            // source walk (this hook fires on every edit; it must stay cheap).
+            // Agent surface via additionalContext (the only channel that
+            // reaches the agent); throttled so it doesn't nag once over the
+            // threshold.
+            let edits = state.edits_since_annotation;
+            if let Some(f) = crate::nudge::score_authoring_debt(edits, aggressiveness) {
                 if throttle::may_surface(
                     state.throttle.get(f.id),
                     now,
@@ -97,7 +115,7 @@ fn emit_for_event(
                     f.metric,
                     f.base,
                 ) {
-                    emit_agent_reminder(inputs.edits_since_annotation);
+                    print_additional_context("PostToolUse", &authoring_debt_context(edits));
                     state.throttle.insert(
                         f.id.to_string(),
                         throttle::record_after_surface(now, f.metric),
@@ -106,14 +124,16 @@ fn emit_for_event(
                 }
             }
         }
-        HookEvent::Stop => {
+        HookEvent::UserPromptSubmit => {
+            // The consolidated human nudge — at the START of each turn (incl.
+            // the first), reaching the agent via additionalContext without
+            // forcing continuation. Surface if ANY fired human signal clears
+            // its throttle; the cooldown gates per-turn spam.
             if aggressiveness.is_off() {
                 return Ok(());
             }
             let inputs = build_inputs(ws, config, &state)?;
             let decision = score(&inputs, aggressiveness);
-            // Consolidated human nudge: surface if ANY fired human signal
-            // clears its throttle. Update records for the ones that did.
             let cleared: Vec<crate::nudge::Fired> = decision
                 .human
                 .iter()
@@ -129,7 +149,10 @@ fn emit_for_event(
                 .cloned()
                 .collect();
             if !cleared.is_empty() {
-                emit_stop_reminder(&decision, &inputs);
+                print_additional_context(
+                    "UserPromptSubmit",
+                    &review_nudge_context(&decision, &inputs),
+                );
                 for f in &cleared {
                     state.throttle.insert(
                         f.id.to_string(),
@@ -140,8 +163,9 @@ fn emit_for_event(
             }
         }
         HookEvent::SessionStart => {
-            // Capture the edit-window baseline + reset the edit counter, then
-            // re-surface any standing backlog as additionalContext.
+            // Compute-only: capture the edit-window baseline + reset the edit
+            // counter. Surface NOTHING — the next UserPromptSubmit carries the
+            // backlog (SessionStart surfacing is premature + once-only).
             let inputs = build_inputs(ws, config, &state)?;
             state.baseline = Some(Baseline {
                 score: inputs.metrics.visible_score,
@@ -159,13 +183,6 @@ fn emit_for_event(
             });
             state.edits_since_annotation = 0;
             let _ = state.save(&state_path);
-            if aggressiveness.is_off() {
-                return Ok(());
-            }
-            let decision = score(&inputs, aggressiveness);
-            if !decision.human.is_empty() {
-                emit_session_start_context(&decision, &inputs);
-            }
         }
     }
     Ok(())
@@ -320,54 +337,63 @@ fn print_readout(
     }
 }
 
-// ─── hook emit (D10: the CLI nudges the AGENT; the agent talks to the human) ──
+// ─── hook emit: the agent's context is reached ONLY via additionalContext ──
+// A hook only injects into the model's context through
+// `hookSpecificOutput.additionalContext` (the S0a spike proved a plain
+// `<system-reminder>` to stdout does not). The CLI nudges the AGENT; the agent
+// is the one that talks to the human (pops the review skill / AskUserQuestion).
 
-/// PostToolUse agent reminder: prod the coding agent to capture intent.
-fn emit_agent_reminder(edits: usize) {
-    println!("<system-reminder>");
-    println!(
+#[aristo::intent(
+    "A hook reaches the agent's context ONLY through \
+     `hookSpecificOutput.additionalContext`; a plain string (even a literal \
+     `<system-reminder>`) printed to a hook's stdout lands in the transcript \
+     but never in the model's context (the S0a spike: the old Stop/PostToolUse \
+     stdout reminders never reached the agent, the SessionStart \
+     additionalContext did). Every agent-facing nudge MUST use this JSON \
+     envelope — emitting bare text would be a silently-dead nudge.",
+    verify = "test",
+    id = "nudge_reaches_agent_only_via_additional_context"
+)]
+/// The Claude Code hook `additionalContext` envelope for `event_name` — the
+/// only channel that injects into the agent's context.
+fn additional_context_json(event_name: &str, context: &str) -> serde_json::Value {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": context,
+        }
+    })
+}
+
+/// Emit the `additionalContext` envelope to stdout.
+fn print_additional_context(event_name: &str, context: &str) {
+    println!("{}", additional_context_json(event_name, context));
+}
+
+/// PostToolUse agent nudge body: prod the coding agent to capture intent.
+fn authoring_debt_context(edits: usize) -> String {
+    format!(
         "Aristo: {edits} source edits since your last annotation. If any of \
-         them embodied a non-obvious decision (a chosen invariant, a \
-         refactor trap, an intentional-not-incomplete choice), capture it now \
-         with an `aristo::intent` while the rationale is fresh — see the \
+         them embodied a non-obvious decision (a chosen invariant, a refactor \
+         trap, an intentional-not-incomplete choice), capture it now with an \
+         `aristo::intent` while the rationale is fresh — see the \
          aristo-authoring skill. Skip if the edits were purely mechanical."
-    );
-    println!("</system-reminder>");
+    )
 }
 
-/// Stop consolidated nudge: a hook can't pop an AskUserQuestion (D10), so it
-/// nudges the AGENT to offer the user the recommended review at a natural
-/// pause. Subject-only — about the user's own annotations/verification.
-fn emit_stop_reminder(decision: &Decision, inputs: &EngineInputs) {
-    println!("<system-reminder>");
-    println!("Aristo progress nudge — {}.", backlog_summary(inputs));
-    if let Some(rec) = decision.recommended() {
-        println!(
-            "At a natural pause, offer the user: {}. Don't interrupt mid-task.",
-            recommended_phrase(rec)
-        );
-    }
-    println!("</system-reminder>");
-}
-
-/// SessionStart additionalContext: re-surface standing backlog so the agent
-/// can offer a review early in the session. Same JSON shape the skills hook
-/// uses.
-fn emit_session_start_context(decision: &Decision, inputs: &EngineInputs) {
-    let mut context = format!("Aristo: {}.", backlog_summary(inputs));
+/// UserPromptSubmit consolidated nudge body: a hook can't pop an
+/// AskUserQuestion, so it nudges the AGENT to offer the user the recommended
+/// review at a natural pause. Subject-only — about the user's own
+/// annotations/verification.
+fn review_nudge_context(decision: &Decision, inputs: &EngineInputs) -> String {
+    let mut context = format!("Aristo progress nudge — {}.", backlog_summary(inputs));
     if let Some(rec) = decision.recommended() {
         context.push_str(&format!(
-            " When the user reaches a natural pause, offer: {}.",
+            " At a natural pause, offer the user: {}. Don't interrupt mid-task.",
             recommended_phrase(rec)
         ));
     }
-    let json = serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "SessionStart",
-            "additionalContext": context,
-        }
-    });
-    println!("{json}");
+    context
 }
 
 /// A subject-only one-line summary of the standing backlog.
@@ -420,5 +446,45 @@ fn recommended_phrase(signal_id: &str) -> &'static str {
         "proof_review_backlog" => "a review of the freshly-verified proofs",
         "score_slump" => "shoring up coverage — annotate or verify to recover the score",
         _ => "a review of the outstanding aristo items",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additional_context_envelope_carries_event_and_context() {
+        let v = additional_context_json("UserPromptSubmit", "hello backlog");
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "UserPromptSubmit");
+        assert_eq!(
+            v["hookSpecificOutput"]["additionalContext"],
+            "hello backlog"
+        );
+        // It is JSON (the only channel that injects), NOT a bare <system-reminder>.
+        let s = v.to_string();
+        assert!(s.contains("hookSpecificOutput"));
+        assert!(!s.contains("<system-reminder>"));
+    }
+
+    #[test]
+    fn parse_event_drops_stop_and_keeps_the_v2_events() {
+        assert_eq!(parse_event("post-tool-use"), Some(HookEvent::PostToolUse));
+        assert_eq!(
+            parse_event("user-prompt-submit"),
+            Some(HookEvent::UserPromptSubmit)
+        );
+        assert_eq!(parse_event("session-start"), Some(HookEvent::SessionStart));
+        // Stop is dropped — an already-installed `--event stop` no-ops silently.
+        assert_eq!(parse_event("stop"), None);
+        assert_eq!(parse_event("Stop"), None);
+        assert_eq!(parse_event("nonsense"), None);
+    }
+
+    #[test]
+    fn authoring_debt_context_names_the_count_and_the_skill() {
+        let c = authoring_debt_context(4);
+        assert!(c.contains("4 source edits"));
+        assert!(c.contains("aristo-authoring"));
     }
 }

--- a/crates/aristo-cli/src/commands/statusline.rs
+++ b/crates/aristo-cli/src/commands/statusline.rs
@@ -1,0 +1,125 @@
+//! `aristo statusline` — a compact ambient status segment for the Claude Code
+//! `statusLine` (Phase 18 #9, nudge surface v2). Prints one line like
+//! `aristo  3 review · 2 unverified · Apprentice` for the terminal status bar.
+//!
+//! This is the USER-facing ambient surface (the agent-facing nudges ride the
+//! PostToolUse / UserPromptSubmit hooks). It is read-only and stays cheap: it
+//! reads the index (counts) + the git-untracked nudge-state (reviewed map +
+//! the cached tier from the edit-window baseline) and does NOT walk source —
+//! the status bar re-renders constantly, so a per-render source walk would be
+//! too expensive. The tier is therefore "as of the session baseline".
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use aristo_core::index::VerifyLevel;
+
+use crate::commands::show::read_index;
+use crate::nudge::intents::authored_intents;
+use crate::nudge::state::{NudgeState, STATE_FILENAME};
+use crate::{CliResult, Workspace};
+
+#[aristo::intent(
+    "The statusline is read-only and TOLERANT: on any failure — no workspace, \
+     an unreadable index, or nudges globally off — it prints nothing and exits \
+     0. The status bar re-renders on every turn, so a statusline that errored \
+     or wrote files would corrupt the bar or thrash the workspace on every \
+     keystroke. Silence is the correct degraded state.",
+    verify = "test",
+    id = "statusline_is_read_only_and_tolerant"
+)]
+pub(crate) fn run() -> CliResult<()> {
+    // The Claude Code statusLine command receives a JSON payload on stdin with
+    // the session's cwd; fall back to the process cwd.
+    let start = cwd_from_stdin();
+    let Ok(ws) = Workspace::find(start.as_deref()) else {
+        return Ok(()); // not an aristo workspace → empty segment
+    };
+    if ws.load_config().nudges.aggressiveness.is_off() {
+        return Ok(()); // honor the global opt-out
+    }
+    let Ok(index) = read_index(&ws.index_path()) else {
+        return Ok(());
+    };
+    let state = NudgeState::load(&ws.aristo_dir().join(STATE_FILENAME));
+    let intents = authored_intents(&index);
+
+    let unreviewed = state.unreviewed_count(
+        intents
+            .iter()
+            .map(|i| (i.id.as_str(), i.text_hash.as_str(), i.body_hash.as_str())),
+    );
+    let unverified = intents
+        .iter()
+        .filter(|i| !matches!(i.verify, VerifyLevel::Bool(false)) && !i.status.is_terminal_clean())
+        .count();
+    // Cached tier from the edit-window baseline (cheap — no source walk).
+    let tier = state.baseline.as_ref().map(|b| b.tier.clone());
+
+    if let Some(line) = statusline(unreviewed, unverified, tier.as_deref()) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+/// Build the compact status segment, or `None` when there is nothing to show
+/// (no backlog and no known tier → no aristo segment in the bar).
+fn statusline(unreviewed: usize, unverified: usize, tier: Option<&str>) -> Option<String> {
+    let mut parts = Vec::new();
+    if unreviewed > 0 {
+        parts.push(format!("{unreviewed} review"));
+    }
+    if unverified > 0 {
+        parts.push(format!("{unverified} unverified"));
+    }
+    if let Some(t) = tier {
+        parts.push(t.to_string());
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(format!("aristo  {}", parts.join(" · ")))
+    }
+}
+
+/// Extract the session cwd from the statusLine stdin payload, if present.
+fn cwd_from_stdin() -> Option<PathBuf> {
+    let mut buf = String::new();
+    if std::io::stdin().read_to_string(&mut buf).is_err() || buf.trim().is_empty() {
+        return None;
+    }
+    let json: serde_json::Value = serde_json::from_str(&buf).ok()?;
+    let dir = json
+        .get("workspace")
+        .and_then(|w| w.get("current_dir"))
+        .and_then(|v| v.as_str())
+        .or_else(|| json.get("cwd").and_then(|v| v.as_str()))?;
+    Some(PathBuf::from(dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_when_nothing_to_surface() {
+        assert_eq!(statusline(0, 0, None), None);
+    }
+
+    #[test]
+    fn shows_backlog_and_tier_compactly() {
+        assert_eq!(
+            statusline(3, 2, Some("Apprentice")).as_deref(),
+            Some("aristo  3 review · 2 unverified · Apprentice")
+        );
+    }
+
+    #[test]
+    fn omits_zero_counts_but_keeps_tier() {
+        assert_eq!(
+            statusline(0, 0, Some("Adept")).as_deref(),
+            Some("aristo  Adept")
+        );
+        assert_eq!(statusline(5, 0, None).as_deref(), Some("aristo  5 review"));
+    }
+}

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -191,13 +191,21 @@ enum Commands {
 
     /// The nudge/progress engine. With no `--event`, prints what the engine
     /// would surface right now (human introspection). With `--event`, runs as
-    /// a Claude Code hook emitter (`post-tool-use` / `stop` / `session-start`)
-    /// — always exits 0 so a nudge can never break the agent's workflow.
+    /// a Claude Code hook emitter (`post-tool-use` / `user-prompt-submit` /
+    /// `session-start`) — always exits 0 so a nudge can never break the
+    /// agent's workflow. Agent-facing output uses `additionalContext` (the
+    /// only channel that reaches the model); `Stop` is intentionally not
+    /// served (its output never reaches the agent).
     Nudge {
         /// Hook event to serve (omit for the human readout).
         #[arg(long)]
         event: Option<String>,
     },
+
+    /// Ambient one-line status segment for the Claude Code `statusLine`
+    /// (e.g. `aristo  3 review · 2 unverified · Apprentice`). Read-only;
+    /// prints nothing when there's no workspace or nudges are off.
+    Statusline,
 
     /// Review newly-authored intents (#7). With no flags, lists what awaits
     /// review (split into new-this-session vs backlog when a baseline exists).
@@ -927,6 +935,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
         Commands::Status => commands::status::run(),
         Commands::Metrics { json } => commands::metrics::run(json),
         Commands::Nudge { event } => commands::nudge::run(event),
+        Commands::Statusline => commands::statusline::run(),
         Commands::Review { mark, json } => commands::review::run(json, mark),
         Commands::Lint { check, fix, strict } => commands::lint::run(check, fix, strict),
         Commands::Verify {

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -260,6 +260,40 @@ pub fn score(inputs: &EngineInputs, aggressiveness: Aggressiveness) -> Decision 
     decision
 }
 
+#[aristo::intent(
+    "Scoring the authoring-debt (agent) signal needs ONLY the edit counter — \
+     never the index-derived Metrics. The PostToolUse hook that drives it \
+     fires on every edit, so it must not walk the source tree per edit; this \
+     scores the one signal straight from the counter, reusing the registry's \
+     base and the identical `pressure * factor >= 1` fire rule so it can't \
+     drift from `score`.",
+    verify = "test",
+    id = "score_authoring_debt_needs_no_index_walk"
+)]
+/// Score ONLY the `authoring_debt` signal, from the edit counter alone — no
+/// `EngineInputs`/`Metrics` and so no source walk (PostToolUse fires on every
+/// edit and must stay cheap). Returns the [`Fired`] (carrying metric + base
+/// for the throttle) when it fires.
+pub fn score_authoring_debt(
+    edits_since_annotation: usize,
+    aggressiveness: Aggressiveness,
+) -> Option<Fired> {
+    let signal = SIGNALS.iter().find(|s| s.id == "authoring_debt")?;
+    let metric = edits_since_annotation as f64;
+    let pressure = metric / signal.base;
+    if pressure * aggressiveness.factor() >= 1.0 {
+        Some(Fired {
+            id: signal.id,
+            audience: signal.audience,
+            pressure,
+            metric,
+            base: signal.base,
+        })
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -406,6 +440,31 @@ mod tests {
         let d = score(&i, Aggressiveness::Medium);
         assert!(d.agent.iter().any(|f| f.id == "authoring_debt"));
         assert!(d.human.iter().all(|f| f.id != "authoring_debt"));
+    }
+
+    #[test]
+    fn score_authoring_debt_agrees_with_full_score() {
+        // The counter-only fast path must match what the full scorer decides
+        // for authoring_debt at the same edit count + aggressiveness.
+        for edits in [0usize, 2, 3, 10] {
+            for agg in [
+                Aggressiveness::Off,
+                Aggressiveness::Low,
+                Aggressiveness::Medium,
+                Aggressiveness::High,
+            ] {
+                let mut i = inputs();
+                i.edits_since_annotation = edits;
+                let full = score(&i, agg)
+                    .agent
+                    .iter()
+                    .any(|f| f.id == "authoring_debt");
+                let fast = score_authoring_debt(edits, agg).is_some();
+                assert_eq!(full, fast, "edits={edits} agg={agg:?}");
+            }
+        }
+        // Off is a hard silence even at a huge count.
+        assert!(score_authoring_debt(1000, Aggressiveness::Off).is_none());
     }
 
     #[test]

--- a/crates/aristo-cli/tests/nudge_command.rs
+++ b/crates/aristo-cli/tests/nudge_command.rs
@@ -1,6 +1,7 @@
 //! `aristo nudge` — engine readout integration tests (S0d.1).
 
 use assert_cmd::Command;
+use predicates::boolean::PredicateBooleanExt;
 use predicates::str::contains;
 use std::fs;
 use std::path::Path;
@@ -72,7 +73,97 @@ fn nudge_is_silent_when_aggressiveness_off() {
 }
 
 #[test]
-fn nudge_stop_event_emits_consolidated_agent_reminder() {
+fn nudge_user_prompt_submit_emits_additional_context() {
+    // The per-turn human nudge now rides UserPromptSubmit and reaches the
+    // agent via hookSpecificOutput.additionalContext — NOT a plain
+    // <system-reminder> (which a hook can't inject into the agent's context).
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "user-prompt-submit"])
+        .assert()
+        .success()
+        .stdout(contains("hookSpecificOutput"))
+        .stdout(contains("UserPromptSubmit"))
+        .stdout(contains("additionalContext"))
+        .stdout(contains("unverified"))
+        .stdout(contains("<system-reminder>").not());
+}
+
+#[test]
+fn nudge_post_tool_use_emits_additional_context_at_threshold() {
+    // PostToolUse bumps the edit counter from stdin; at the base-3 threshold
+    // (medium) it surfaces the authoring nudge — via additionalContext.
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(tmp.path(), "pub fn a() {}\n");
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    // Edits 1 and 2: below threshold → silent.
+    for _ in 0..2 {
+        aristo_in(tmp.path())
+            .args(["nudge", "--event", "post-tool-use"])
+            .write_stdin(r#"{"tool_name":"Edit"}"#)
+            .assert()
+            .success()
+            .stdout(predicates::str::is_empty());
+    }
+    // Edit 3: crosses the base-3 threshold → emits additionalContext.
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "post-tool-use"])
+        .write_stdin(r#"{"tool_name":"Edit"}"#)
+        .assert()
+        .success()
+        .stdout(contains("hookSpecificOutput"))
+        .stdout(contains("PostToolUse"))
+        .stdout(contains("source edits"))
+        .stdout(contains("<system-reminder>").not());
+}
+
+#[test]
+fn nudge_session_start_is_compute_only_captures_baseline_but_surfaces_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    // SessionStart captures the baseline (state) but surfaces NOTHING — the
+    // next UserPromptSubmit carries the backlog.
+    aristo_in(tmp.path())
+        .args(["nudge", "--event", "session-start"])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+
+    let state = fs::read_to_string(tmp.path().join(".aristo/nudge-state.toml")).unwrap();
+    assert!(
+        state.contains("[baseline]"),
+        "session-start must persist a baseline: {state}"
+    );
+}
+
+#[test]
+fn nudge_stop_event_is_silently_ignored() {
+    // Stop is dropped in v2 (its output never reaches the agent). An
+    // already-installed `--event stop` must no-op, never error.
     let tmp = tempfile::tempdir().unwrap();
     aristo_in(tmp.path()).arg("init").assert().success();
     write_lib(
@@ -88,33 +179,7 @@ fn nudge_stop_event_emits_consolidated_agent_reminder() {
         .args(["nudge", "--event", "stop"])
         .assert()
         .success()
-        .stdout(contains("<system-reminder>"))
-        .stdout(contains("offer the user"));
-}
-
-#[test]
-fn nudge_session_start_captures_baseline_in_state() {
-    let tmp = tempfile::tempdir().unwrap();
-    aristo_in(tmp.path()).arg("init").assert().success();
-    write_lib(
-        tmp.path(),
-        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
-    );
-    aristo_in(tmp.path())
-        .args(["stamp", "--skip-canon"])
-        .assert()
-        .success();
-
-    aristo_in(tmp.path())
-        .args(["nudge", "--event", "session-start"])
-        .assert()
-        .success();
-
-    let state = fs::read_to_string(tmp.path().join(".aristo/nudge-state.toml")).unwrap();
-    assert!(
-        state.contains("[baseline]"),
-        "session-start must persist a baseline: {state}"
-    );
+        .stdout(predicates::str::is_empty());
 }
 
 #[test]
@@ -137,9 +202,9 @@ fn nudge_hook_event_is_silent_when_off() {
         .assert()
         .success();
 
-    // off → the Stop hook emits nothing at all.
+    // off → the UserPromptSubmit hook emits nothing at all.
     aristo_in(tmp.path())
-        .args(["nudge", "--event", "stop"])
+        .args(["nudge", "--event", "user-prompt-submit"])
         .assert()
         .success()
         .stdout(predicates::str::is_empty());

--- a/crates/aristo-cli/tests/statusline_command.rs
+++ b/crates/aristo-cli/tests/statusline_command.rs
@@ -1,0 +1,79 @@
+//! `aristo statusline` — ambient status segment integration tests
+//! (Phase 18 #9, nudge surface v2).
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+use std::path::Path;
+
+fn aristo_in(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aristo").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write_lib(root: &Path, content: &str) {
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), content).unwrap();
+}
+
+#[test]
+fn statusline_shows_backlog_for_an_unverified_unreviewed_intent() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .arg("statusline")
+        .assert()
+        .success()
+        .stdout(contains("aristo"))
+        .stdout(contains("review"))
+        .stdout(contains("unverified"));
+}
+
+#[test]
+fn statusline_is_silent_outside_a_workspace() {
+    // Tolerant: no aristo workspace → empty segment, exit 0 (never disrupt
+    // the status bar).
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path())
+        .arg("statusline")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn statusline_is_silent_when_aggressiveness_off() {
+    let tmp = tempfile::tempdir().unwrap();
+    aristo_in(tmp.path()).arg("init").assert().success();
+    let cfg = tmp.path().join("aristo.toml");
+    let contents = fs::read_to_string(&cfg).unwrap();
+    fs::write(
+        &cfg,
+        contents.replace("aggressiveness = \"medium\"", "aggressiveness = \"off\""),
+    )
+    .unwrap();
+    write_lib(
+        tmp.path(),
+        r#"#[aristo::intent("does a thing", verify = "test", id = "a")] fn a() {}"#,
+    );
+    aristo_in(tmp.path())
+        .args(["stamp", "--skip-canon"])
+        .assert()
+        .success();
+
+    aristo_in(tmp.path())
+        .arg("statusline")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}


### PR DESCRIPTION
The S0a live-hook spike disproved SPINE-PLAN **D10**'s premise on two counts, both seen live in a real Claude Code session:
1. A hook reaches the agent's context **only** via `hookSpecificOutput.additionalContext` — a plain `<system-reminder>` printed to stdout lands in the transcript, not the model's context.
2. **`Stop` doesn't deliver at all** (its output never reaches the agent next turn).

This rebuilds the surface accordingly and wires the now-unblocked **S0d.3 auto-install**. (GSD's own patterns independently confirm: no Stop hook, SessionStart reserved for utilities, agent nudges via PostToolUse `additionalContext` + a statusline.)

## Surface (`commands/nudge.rs`)
- Every emit uses `additionalContext` (the only agent-reaching channel).
- Per-turn human nudge → **UserPromptSubmit** (start of each turn incl. the first; reaches the agent; doesn't force continuation) — replaces Stop.
- **Stop dropped** (`--event stop` → unknown → silent no-op, so an old install can't break).
- **SessionStart compute-only** (captures the edit-window baseline, surfaces nothing).
- PostToolUse authoring nudge scores from the edit counter via `nudge::score_authoring_debt` — **no per-edit source walk** (the hook fires on every edit).

## New ambient surface: `aristo statusline`
`aristo  N review · N unverified · Tier`. Read-only + tolerant (empty on any failure / nudges-off), cheap (cached tier, no source walk).

## Auto-install (S0d.3)
`aristo install-skills` (Claude Code) now writes the PostToolUse + UserPromptSubmit + SessionStart nudge hooks **and** the statusLine — idempotent, coexisting with the existing session/staleness hooks; the statusLine is set **only when absent** (never clobbers a user's). Runtime-gated by `[nudges] aggressiveness` (off → silent).

## Validation
- **Live spike**: PostToolUse + UserPromptSubmit reach the agent **verbatim** via additionalContext; SessionStart correctly silent; statusLine renders.
- 6 new unit/integration tests (envelope, parse-event drops Stop, score_authoring_debt agrees with full score, statusline builder + tolerance, install idempotency + no-clobber + coexistence) + updated nudge integration tests.
- `cargo fmt --check` · full test · `clippy -D warnings` · `rustdoc -D warnings` · `aristo stamp --check` (0 drift) — all pass.
- SPINE-PLAN D10 amended with the corrected contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)