### PR TITLE
docs: name Inspect's SkipMap-only scope as debt, not design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+- docs(adr, roadmap, skill): clarify that the `Inspect` derive's `SkipMap`-only constraint in v0.2.5 / v0.2.6 is **implementation debt**, not a deferred-by-design choice. The slice-37 locked API was type-agnostic (per-shape codegen for collections, scalars, and atomics); the narrowing happened during slice-37 implementation when the `extract_skipmap_kv` dispatch from the original handoff's v1 scope was kept and the design amendment we'd locked got dropped on the floor. The ADR's new "Implementation debt" section, the ROADMAP's reframed Phase-3 listing, and the `aristo-instrumenting` skill's content-gate guidance all now name the gap honestly. No code change — v0.2.6's macro surface is unchanged. The widening (per-shape codegen for `BTreeMap`, `HashMap`, `Vec`, scalars, atomics) is purely additive and breaks no v0.2.6 consumer; it lands when the work is prioritised.
+
 ## [0.2.6] — 2026-06-09
 
 Patch — fixes a generic-struct codegen bug in the `Inspect` derive that v0.2.5 shipped. The Turso fork's `MvStore<Clock: LogicalClock>` was the canary; any `#[derive(Inspect)]` struct with generic params would have hit the same E0107 "missing generics for struct" error at the consumer side. The fix lands alongside a new trybuild pass case that locks the generics-handling shape in place.

--- a/crates/aristo-cli/src/skills/aristo-instrumenting.md
+++ b/crates/aristo-cli/src/skills/aristo-instrumenting.md
@@ -38,7 +38,7 @@ Apply this when considering a candidate instrumentation site. The gate filters o
 
 1. **Does a verification or differential-testing harness actually need this?** If no harness exists or is planned, don't pre-instrument speculatively. The macros aren't free — `#[derive(Inspect)]` emits per-field accessors; `yield_point!` produces a runtime call site.
 2. **Is the alternative materially worse?** A hand-written accessor is sometimes clearer than `#[derive(Inspect)]` when the projection logic is complex. Use the macro when it reduces boilerplate, not just for symmetry.
-3. **Does the SUT shape support it?** `Inspect` works for `SkipMap<K, V>` in v1. Other collections, scalars, and atomics aren't supported — for those, hand-write the accessor and revisit when a future slice expands the macro.
+3. **Does the SUT shape support it?** `Inspect` is type-agnostic by design, but the v0.2.5 / v0.2.6 implementation ships with `SkipMap<K, V>` field support only — other collections (`BTreeMap`, `HashMap`, `Vec`), scalars, and atomics error at the macro level with `"only supports SkipMap<K, V> fields in v1"`. This is implementation debt, not a deferred-by-design constraint (see `docs/decisions/instrument-surface.md` § "Implementation debt"). For those shapes today, hand-write the accessor; flag the gap when the user hits it so they know to track the widening.
 
 If the answers are no / no / no, skip the macro and either hand-write the accessor or defer.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,10 @@ Total: **13–18 commits, ~3–4 weeks of focused work** under aristo's CLAUDE.m
 
 - **Catalog format CLI** (handoff §8 Q5). A future `aristo instrument catalog` subcommand that codifies the `ACCESSORS.md` row schema is a Phase 3 candidate; consumer side stays a convention for now.
 - **Skill suite extras.** `aristo-instrumenting-philosophy.md` (per CLAUDE.md §10A) lands once feedback cases accumulate. `aristo-instrument-suggestions.md` (parallel to `aristo-intent-suggestions.md`) lands when a second consumer is on board to ground recommendations.
-- **`Inspect` beyond `SkipMap`.** `BTreeMap`, `HashMap`, `Vec`, atomic loads, scalar projections of `Option<T>` are deliberately deferred. v1 covers the only shape every current consumer needs.
+
+### Implementation debt landed in v0.2.5 / v0.2.6 (not deferred design)
+
+- **`Inspect` field-shape widening.** The slice-37 locked API was type-agnostic — bare `#[inspect]` cloning into the appropriate snapshot shape for any field type, `#[inspect(T)]` projecting via `From<&V>` similarly, with collection-vs-scalar coverage in the trybuild matrix. The v0.2.5 / v0.2.6 implementation narrowed to `SkipMap<K, V>` fields only as a shipping shortcut; the macro errors with `"only supports SkipMap<K, V> fields in v1"` for anything else. This is **implementation debt to close**, not deferred design — widening is additive and breaks no v0.2.6 consumer. See `docs/decisions/instrument-surface.md` § "Implementation debt".
 
 ### Verification target
 
@@ -59,7 +62,7 @@ End-to-end success criterion: the Turso fork at `../turso-mvcc-diff` (branch `ar
 
 ## Future phases (sketch)
 
-- **Phase 3 — catalog tool + skill suite expansion.** `aristo instrument catalog` CLI; `aristo-instrumenting-philosophy.md` from accumulated cases; `aristo-instrument-suggestions.md`.
+- **Phase 3 — catalog tool + skill suite expansion.** `aristo instrument catalog` CLI; `aristo-instrumenting-philosophy.md` from accumulated cases; `aristo-instrument-suggestions.md`. (The "Inspect beyond SkipMap" item that previously appeared here is **implementation debt**, not Phase 3 design — see the "Implementation debt landed in v0.2.5 / v0.2.6" section above.)
 - **Phase 4 — second AI-consumer onboarding.** HelixDB or future SUT integration; mining new patterns from a second consumer's feedback loop.
 
 These are sketches, not commitments — Phase 2's outcome will reshape them.

--- a/docs/decisions/instrument-surface.md
+++ b/docs/decisions/instrument-surface.md
@@ -82,13 +82,26 @@ The handoff places `_pending/instrument/<NN>_<name>.md` scenarios for the trybui
 ### Negative
 
 - Adds one feature flag + one runtime symbol to the meta-crate's public surface. Not free, but bounded.
-- v1 supports `SkipMap` only for `Inspect`. Other collection types (`BTreeMap`, `HashMap`, `Vec`) and scalar fields error at the macro level with a clear deferred-to-Phase-3 message. Consumers with other collections hand-write the accessor.
+- **`Inspect` ships narrower than the locked design** (see "Implementation debt" below). Consumers with non-`SkipMap` field types hand-write the accessor until the debt closes.
 
-### Out of scope (Phase 3 candidates)
+## Implementation debt — `Inspect` narrowed to `SkipMap`
+
+The locked slice-37 design was **type-agnostic**: bare `#[inspect]` cloning V into the appropriate snapshot shape for the field type (`Vec<(K, V)>` for `SkipMap` / `BTreeMap` / `HashMap`, `Vec<V>` for `Vec<V>`, owned `V` for scalars and atomics), and `#[inspect(T)]` projecting via `From<&V>` similarly. The locked-API table in the slice-37 discussion explicitly enumerated per-shape return types and called out "collection + scalar" trybuild coverage.
+
+What v0.2.5 / v0.2.6 actually shipped is **`SkipMap` fields only** — any other field type errors at the macro level with `"only supports SkipMap<K, V> fields in v1 (other collection types and scalars are deferred to a future release)"`. The error text and the original "Out of scope (Phase 3 candidates)" list both made the gap look like a deferred-by-design choice; it wasn't. It was an implementation shortcut taken during slice-37 codegen — the `extract_skipmap_kv` dispatch was reused from the handoff doc's narrower v1 scope and the design amendment we'd actually locked got dropped on the floor.
+
+This section exists to record the gap honestly so future readers don't reverse-engineer the narrowing as a locked design choice. The narrow surface is what's stable in v0.2.5 / v0.2.6; widening to the full locked-design shape is **purely additive** (no consumer of v0.2.6's surface breaks) and is genuine outstanding work — implementation debt to close, not deferred design. Tracked in the "Outstanding implementation work" list below.
+
+## Outstanding implementation work
+
+Closing these doesn't change the surface for existing consumers; each is additive.
+
+- **`Inspect` field-shape widening.** Per-shape codegen for `BTreeMap<K, V>`, `HashMap<K, V>`, `Vec<V>`, scalars, atomics, and the scalar projection of `Option<T>` form. Matches the slice-37 locked-API table. Trybuild matrix widens to cover each shape × each mode.
+- **`yield_point!` in `const fn` detection.** Macro-level diagnostic when the call site is `const fn`, replacing the cryptic rustc downstream error. v1 lets rustc speak; worth a custom diagnostic if it proves confusing in real use.
+
+## Out of scope (genuine Phase 3 candidates)
 
 - **Catalog format CLI** (handoff §8 Q5). A future `aristo instrument catalog` subcommand that codifies the `ACCESSORS.md` row schema. Not in v0.2.5; consumer side stays a convention.
-- **Inspect beyond SkipMap.** BTreeMap, HashMap, Vec, atomic loads, scalar projections of `Option<T>` — deferred.
-- **`yield_point!` in `const fn`.** Detection + clear error. v1 lets the natural rustc error fire ("calls in const fns are limited to ...").
 - **Skill suite expansion.** `aristo-instrumenting-philosophy.md` (per CLAUDE.md §10A) lands once feedback cases accumulate. `aristo-instrument-suggestions.md` (parallel to `aristo-intent-suggestions.md`) lands when a second consumer is on board to ground recommendations.
 
 ## References


### PR DESCRIPTION
## Summary

The slice-37 design discussion locked a **type-agnostic** `Inspect` derive (per-shape codegen for collections + scalars + atomics). What shipped in v0.2.5 / v0.2.6 narrows it to `SkipMap<K, V>` fields only — the `extract_skipmap_kv` dispatch from the handoff doc's narrower v1 scope got kept during implementation, and the design amendment we'd locked got dropped on the floor. The ADR's original "Out of scope (Phase 3 candidates)" list framed this as deferred design; it wasn't.

## Changes

- **ADR** (`docs/decisions/instrument-surface.md`): new "Implementation debt" section names the gap honestly. Phase-3 listing split into "Outstanding implementation work" (debt) vs "Out of scope" (genuine Phase 3 — catalog CLI + skill suite expansion).
- **ROADMAP** (`docs/ROADMAP.md`): adds an "Implementation debt landed in v0.2.5 / v0.2.6" section. Phase 3 sketch no longer claims field-shape widening.
- **Skill** (`crates/aristo-cli/src/skills/aristo-instrumenting.md`): content-gate guidance names the constraint as implementation debt so future agents flag the gap correctly when users hit it.

## Verification

- §6 gates green (fmt, check, clippy, test).
- No code change — v0.2.6's macro surface is unchanged.
- Widening (when prioritised) is purely additive and breaks no v0.2.6 consumer.

## Notes

The CHANGELOG \`[Unreleased]\` bullet describes the docs correction in customer-facing language. Per CLAUDE.md §12 (specs are the truth — never rewrite to match impl), this commit raises the conflict explicitly and amends the docs to record the honest history rather than silently letting the narrowed spec become canon.