### PR TITLE
docs(skill): labeled suggestion view + deliberate annotation-scope guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+- skills: the `aristo-intent-suggestions` review applies the labeled `(NEW)` treatment to canon SUGGESTIONS too (not just primary matches): a suggested sibling or objective is shown as `Suggested intent (NEW): <text>` rather than a removal-style diff, and the placement preview now shows the enclosing scope's signature plus the first 1-2 body lines (so you can see which function you're annotating) with only the new annotation line marked as an addition.
+- skills: `aristo-authoring` and `aristo-intent-suggestions` now teach deliberate annotation placement. The element an annotation attaches to is the scope Aristo hashes for staleness, so a change inside it re-triggers verification: pick the smallest element where every internal change should force a re-check (too broad churns the proof on unrelated edits; too narrow lets real changes pass a now-stale proof silently), and use the statement form to tighten scope inside a larger function.
+
 ## [0.2.7] — 2026-06-16
 
 Patch: canon-match reliability and review-UX polish for the daily `stamp` loop. Raises the canon-match request timeout so cold-connection matches stop timing out spuriously, and replaces the confusing removal-style diff in the `aristo-intent-suggestions` review with a labeled before/after. Also lands the queued `Inspect`-scope documentation clarification.

--- a/crates/aristo-cli/src/skills/aristo-authoring.md
+++ b/crates/aristo-cli/src/skills/aristo-authoring.md
@@ -107,6 +107,16 @@ If you find yourself writing the same invariant twice on different functions in 
 - Keep it on the lower-level enforcement site (the one whose code would have to change to break the invariant).
 - Delete it from the higher-level orchestration site.
 
+## Scope: the annotation site is the staleness boundary
+
+The code element an annotation attaches to is not just a label, it is the **scope that triggers re-checking.** Aristo hashes the body of that element; when the body changes, the intent's verification goes stale and is re-checked on the next run. So choosing the site is choosing the boundary at which a code change forces the intent to be re-verified. Place it with deliberation:
+
+- **The site should encompass exactly the code whose change could affect the invariant.** Ask: "if someone edits this code, does the intent need to be re-checked?" The smallest element for which the answer is *yes for every change inside it, and no for changes outside it* is the right site.
+- **Too broad is churn.** Annotating a large function, `impl`, or `mod` when the invariant only concerns a few lines means every unrelated edit inside that span marks the proof stale and re-queues a re-check. The user learns to ignore staleness, which defeats the signal.
+- **Too narrow is dangerous.** Annotating a tiny helper that does *not* contain the load-bearing logic means real changes to the code that actually governs the invariant never drift the hash, so a now-invalid proof keeps reporting as verified. This is the worse failure: silent staleness.
+- **Use the statement form to tighten scope.** When the enclosing function does more than the invariant covers, attach `aristo::intent_stmt!(...)` to the specific statement, block, or loop that carries the property rather than putting the attribute on the whole function. The statement's span becomes the staleness boundary.
+- **Use the attribute form when the whole item is the unit.** If any change to the function / struct / impl could plausibly affect the property, the item-level attribute is correct and a tighter scope would miss real drift.
+
 ## One annotation, one invariant
 
 If a draft body has two distinct invariants, split them into two annotations OR move one to a more appropriate site. Mixed intents read as motivation prose and lose precision in both halves.

--- a/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
+++ b/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
@@ -163,8 +163,29 @@ so larger sets **paginate** (e.g. 5 siblings = a page of 4 + a page of 1); say "
   + Match (NEW):  <the canonical wording it will be rewritten to>
   ```
 
-- **Stage B adopt = ADD** a new annotation → render a **pure `+`** addition, with surrounding
-  lines shown as plain context (nothing is replaced).
+- **Stage B adopt = ADD** a new annotation. Same failure mode as Stage A applies: do **NOT** render
+  the suggested intent as a `−`/`+` diff or any block where the text is prefixed with `−`. Nothing
+  of the user's is touched, so a removal-style block is misleading. When you show a suggested
+  sibling or objective for a decision, label it:
+
+  ```
+  Suggested intent (NEW):
+    <the canonical text of the sibling / objective>
+  ```
+
+  When you show the **placement** (Phase 3), give enough context that the target scope is
+  unambiguous: include the signature line of the item the annotation attaches to (the `fn` / `impl`
+  / `struct` / etc. it sits directly above) **and** the first 1-2 lines inside that scope's body,
+  so the user can see *what* they are annotating, not just a bare insertion point. Render this
+  surrounding code as plain context and mark only the new annotation line as an addition. In a
+  ` ```diff ` fence, prefix just that one line with `+` (renders green); leave the existing code
+  unprefixed. Never prefix the existing code or the suggested text with `−`. Shape (placeholders):
+
+  ```diff
+  + #[aristo::intent(text = "<canonical text>", parent = "<kanon:objective>")]
+    <signature line of the target fn / impl / struct>
+        <first 1-2 lines of its body, as plain context>
+  ```
 - **The canonical text is fixed by canon.** "Edit text/site first" edits the *site* (or hands the
   site choice to the agent); it does **not** reword the canonical phrasing.
 
@@ -232,6 +253,9 @@ cluster gate:  Explore cluster · Reject cluster · Skip · Back
 per sibling:  Adopt · Reject · Skip      preview = aristo canon show <canon_id> card
 ```
 
+When you surface the suggested text for the decision, label it `Suggested intent (NEW):` (see the
+snippet rule) — never a `−`/`+` removal block.
+
 Record each: Adopt is buffered (don't write yet); Reject →
 `aristo session decide --item sibling:<key>#<canon-id> --bucket rejected [--note "..."]`
 (fingerprints the canon_id). Siblings matching a prior rejection are auto-suppressed (dedup ④,
@@ -243,11 +267,21 @@ its `applies_to` + `canonical_text` + `description` (via `aristo canon show <can
 **Site-finding is YOUR job** (the agent): locate the load-bearing site(s) where the invariant
 should be asserted. Propose a HIGH/MEDIUM-confidence primary site plus alternates.
 
+**Choose the site as a staleness boundary, not just a topical match.** The element you attach to is
+the scope Aristo hashes for re-checking: when its body changes, the adopted intent is re-verified.
+Pick the smallest element whose every change should force a re-check and whose surrounding changes
+should not (use the statement form to tighten scope inside a larger function). Too broad re-queues
+the proof on unrelated edits; too narrow lets real changes to the governing code pass a now-stale
+proof silently. See the `aristo-authoring` skill's "Scope: the annotation site is the staleness
+boundary" for the full rationale.
+
 **PHASE 3 — batch-CONFIRM placements** (multi-Q, navigable, ≤4/page):
 
 ```
 per adopt:  Confirm — write here · Try a different site · Edit text/site first · Skip
-  preview on Confirm         = surrounding code with the new intent as a PURE + addition
+  preview on Confirm         = the target scope's signature line + first 1-2 body lines as plain
+                               context, with ONLY the new annotation line marked as an addition (a
+                               single `+`/green line); never a removal block, never a bare insertion point
   preview on Different site   = the next candidate site (compare by arrowing)
   each candidate carries a confidence (HIGH/MEDIUM) in its sub-line
 ```
@@ -297,8 +331,10 @@ mutation and the session guard blocks it while a session is open.
 - ❌ Rendering a Stage A accept as a `−`/`+` diff. A diff prefixes every line of the user's wording
   with `−`, which reads as "all your text is being deleted" and is the confusion this rule removes.
   Stage A is a **labeled before/after** ("Your text:" vs "Match (NEW):").
-- ❌ Rendering a Stage B adopt as a `−`/`+` diff. Adopt is a **pure `+`** addition; nothing of the
-  user's is replaced.
+- ❌ Rendering a Stage B suggestion (sibling/objective) as a `−`/`+` diff or an all-`−` block. The
+  same removal-block confusion as Stage A applies: nothing of the user's is touched. Show the
+  suggested text labeled `Suggested intent (NEW):`, and the placement as plain context with only
+  the new annotation line marked `+` (green).
 - ❌ Inventing a bespoke decision card. The card is `aristo canon show <id>` output, reused.
 - ❌ Cramming more than 4 questions onto one page. The picker caps at 4 — paginate and say
   "page 1 of 2".


### PR DESCRIPTION
## Summary

Skill-only follow-ups to the v0.2.7 review-UX work.

### 1. Stage B suggestions get the labeled `(NEW)` treatment
The earlier change fixed the Stage A (primary match) removal-style diff, but Stage B (cluster suggestions) had the same visual problem. Now a suggested sibling/objective is shown as `Suggested intent (NEW): <text>` (never a `−`/`+` or all-`−` block), and the placement preview shows the **enclosing scope's signature line + first 1-2 body lines** with only the new annotation line marked as an addition — so the user can see *which function* they're annotating instead of a bare insertion point.

### 2. Deliberate annotation-scope guidance (`aristo-authoring` + `aristo-intent-suggestions`)
The element an annotation attaches to is the scope Aristo hashes for staleness: a change inside it re-triggers verification. Both skills now teach placing annotations so the site encompasses exactly the code whose change should force a re-check:
- too broad (large fn/impl/mod) churns the proof on unrelated edits, training the user to ignore staleness;
- too narrow (a helper missing the load-bearing logic) lets real changes pass a now-stale proof silently (the dangerous case);
- use the statement form to tighten scope inside a larger function.

## Verification
- `aristo-cli` builds clean; `install_skills_staleness` test green; skills re-pin cleanly.
- Skill-only changes (`include_str!`-embedded); no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)