### PR TITLE
feat(metrics): add by-verify-level and status-distribution to `aristo metrics --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 - `aristo init` now gitignores the full set of runtime `.aristo/` artifacts (the index cache, sessions, verify/critique queues, nudge state, critiques, proof backups, and the orphan-proof archive), appending to an existing `.gitignore` idempotently. Durable state (proofs, docs, specs, feedback, expectations, canon-matches) stays tracked.
 
 ### Added
+- `aristo metrics --json` now reports `by_verify_level` (intents per pipeline: neural / test / full / default-true / off-false) and `status_distribution` (annotation counts by verification status, kebab-case keys) — the full breakdown `aristo status` shows as text, now machine-readable from one payload for tooling and dashboards (metrics schema v2).
 - `aristo verify --audit [--strict]`: a no-network, no-token proof-freshness gate for CI.
 - `aristo init --hook`: opt-in installer for the (now deprecated) local pre-commit hook.
 

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -315,6 +315,8 @@ mod tests {
             },
             tier,
             visible_score: score,
+            by_verify_level: Default::default(),
+            status_distribution: Default::default(),
         }
     }
 

--- a/crates/aristo-core/src/index/enums.rs
+++ b/crates/aristo-core/src/index/enums.rs
@@ -14,7 +14,12 @@ pub enum AnnotationKind {
 
 /// Current verification state. The wire form uses kebab-case to keep
 /// `pending-deepen` readable on disk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+///
+/// `Ord` follows declaration order (most-trusted first), which gives the
+/// `aristo metrics --json` `status_distribution` map a stable key order.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
     /// Verified at the strongest method available; signature is current.

--- a/crates/aristo-core/src/metrics.rs
+++ b/crates/aristo-core/src/metrics.rs
@@ -21,11 +21,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::badge::{compute_tier, Tier};
-use crate::index::{IndexEntry, IndexFile, VerifyLevel, VerifyMethod};
+use crate::index::{IndexEntry, IndexFile, Status, VerifyLevel, VerifyMethod};
 
 /// Schema version for the `aristo metrics --json` payload. Bump on any
-/// breaking change to [`Metrics`]'s shape so consumers can gate.
-pub const METRICS_SCHEMA_VERSION: u32 = 1;
+/// breaking change to [`Metrics`]'s shape so consumers can gate. v2 added the
+/// `by_verify_level` and `status_distribution` breakdowns (additive).
+pub const METRICS_SCHEMA_VERSION: u32 = 2;
 
 /// Index-derived project metrics — counts, the unverified backlog, and the
 /// tier/score. Serializes to the `aristo metrics --json` payload.
@@ -57,6 +58,30 @@ pub struct Metrics {
     pub tier: Tier,
     /// The `[0, 1]` visible score backing the tier.
     pub visible_score: f64,
+    /// Intents bucketed by their declared `verify` level — the pipeline each
+    /// targets (`assume`s have no verify level and are excluded).
+    pub by_verify_level: VerifyLevelCounts,
+    /// All annotations (intents + assumes) bucketed by current [`Status`].
+    /// Keyed by the kebab-case wire form (`verified`, `stale`, `unknown`, …),
+    /// in declaration order; absent states are omitted (treat as 0).
+    pub status_distribution: BTreeMap<Status, usize>,
+}
+
+/// Intent counts by declared `verify` level (the breakdown `aristo status`
+/// renders as text; surfaced here so one `Metrics` payload feeds every
+/// consumer).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct VerifyLevelCounts {
+    /// `verify = "neural"` intents.
+    pub neural: usize,
+    /// `verify = "test"` intents.
+    pub test: usize,
+    /// `verify = "full"` intents.
+    pub full: usize,
+    /// `verify = true` intents (resolve to the project default at run time).
+    pub default_true: usize,
+    /// `verify = false` intents (documentation-only; never verifiable).
+    pub off_false: usize,
 }
 
 #[aristo::intent(
@@ -84,11 +109,21 @@ impl Metrics {
         let mut assumes = 0usize;
         let mut verifiable = 0usize;
         let mut verified_clean = 0usize;
+        let mut by_verify_level = VerifyLevelCounts::default();
+        let mut status_distribution: BTreeMap<Status, usize> = BTreeMap::new();
 
         for entry in index.entries.values() {
             match entry {
                 IndexEntry::Intent(e) => {
                     intents += 1;
+                    match e.verify {
+                        VerifyLevel::Method(VerifyMethod::Neural) => by_verify_level.neural += 1,
+                        VerifyLevel::Method(VerifyMethod::Test) => by_verify_level.test += 1,
+                        VerifyLevel::Method(VerifyMethod::Full) => by_verify_level.full += 1,
+                        VerifyLevel::Bool(true) => by_verify_level.default_true += 1,
+                        VerifyLevel::Bool(false) => by_verify_level.off_false += 1,
+                    }
+                    *status_distribution.entry(e.status).or_insert(0) += 1;
                     // verify=false intents are documentation-only: never
                     // verifiable, so excluded from the backlog and rate.
                     if !matches!(e.verify, VerifyLevel::Bool(false)) {
@@ -98,7 +133,10 @@ impl Metrics {
                         }
                     }
                 }
-                IndexEntry::Assume(_) => assumes += 1,
+                IndexEntry::Assume(e) => {
+                    assumes += 1;
+                    *status_distribution.entry(e.status).or_insert(0) += 1;
+                }
             }
         }
 
@@ -121,6 +159,8 @@ impl Metrics {
             verification_rate,
             tier: computation.tier,
             visible_score: computation.visible_score,
+            by_verify_level,
+            status_distribution,
         }
     }
 }
@@ -248,6 +288,51 @@ mod tests {
             intent(VerifyLevel::Bool(true), Status::Unknown),
         ]);
         assert_eq!(m.verified_clean + m.unverified, m.verifiable);
+    }
+
+    #[test]
+    fn by_verify_level_buckets_intents_by_pipeline() {
+        let m = metrics_of(vec![
+            intent(VerifyLevel::Method(VerifyMethod::Neural), Status::Neural),
+            intent(VerifyLevel::Method(VerifyMethod::Test), Status::Tested),
+            intent(VerifyLevel::Method(VerifyMethod::Full), Status::Verified),
+            intent(VerifyLevel::Method(VerifyMethod::Full), Status::Stale),
+            intent(VerifyLevel::Bool(true), Status::Unknown),
+            intent(VerifyLevel::Bool(false), Status::Unknown),
+            assume(), // assumes carry no verify level
+        ]);
+        assert_eq!(m.by_verify_level.neural, 1);
+        assert_eq!(m.by_verify_level.test, 1);
+        assert_eq!(m.by_verify_level.full, 2);
+        assert_eq!(m.by_verify_level.default_true, 1);
+        assert_eq!(m.by_verify_level.off_false, 1);
+    }
+
+    #[test]
+    fn status_distribution_counts_intents_and_assumes_omitting_absent_states() {
+        let m = metrics_of(vec![
+            intent(VerifyLevel::Method(VerifyMethod::Full), Status::Verified),
+            intent(VerifyLevel::Method(VerifyMethod::Neural), Status::Unknown),
+            assume(), // Status::Unknown
+        ]);
+        assert_eq!(m.status_distribution.get(&Status::Verified), Some(&1));
+        assert_eq!(
+            m.status_distribution.get(&Status::Unknown),
+            Some(&2),
+            "1 intent + 1 assume in Unknown"
+        );
+        assert_eq!(m.status_distribution.get(&Status::Stale), None);
+    }
+
+    #[test]
+    fn status_distribution_serializes_with_kebab_keys() {
+        let m = metrics_of(vec![intent(
+            VerifyLevel::Method(VerifyMethod::Full),
+            Status::PendingDeepen,
+        )]);
+        let v = serde_json::to_value(&m).unwrap();
+        assert_eq!(v["status_distribution"]["pending-deepen"], 1);
+        assert_eq!(v["schema_version"], 2);
     }
 
     #[test]

--- a/schemas/aristo-index.schema.json
+++ b/schemas/aristo-index.schema.json
@@ -318,7 +318,7 @@
       "pattern": "^sha256:[0-9a-f]{64}$"
     },
     "Status": {
-      "description": "Current verification state. The wire form uses kebab-case to keep `pending-deepen` readable on disk.",
+      "description": "Current verification state. The wire form uses kebab-case to keep `pending-deepen` readable on disk.\n\n`Ord` follows declaration order (most-trusted first), which gives the `aristo metrics --json` `status_distribution` map a stable key order.",
       "oneOf": [
         {
           "description": "Verified at the strongest method available; signature is current.",


### PR DESCRIPTION
## Summary
Extends the canonical `Metrics` payload (`aristo metrics --json`) with the two breakdowns the conductor dashboard's posture tiles need, computed in the existing single `from_index` pass (no new metrics source — preserves the one-metrics-source rule; no separate `status --json`).

- `by_verify_level` (`VerifyLevelCounts`: neural / test / full / default_true / off_false)
- `status_distribution` (`BTreeMap<Status, usize>`, present states only, stable kebab keys)
- `METRICS_SCHEMA_VERSION` 1 → 2; `Status` derives `Ord`/`PartialOrd` for stable distribution key order
- +3 metrics tests; CHANGELOG; regenerated `schemas/aristo-index.schema.json`

## Why
Powers the conductor dashboard Overview posture tiles (tier ladder, verification-rate, status distribution, by-verify-level) — consumed via a background-cached `GET /metrics`. See aretta-conductor PR #19.

## Checks
`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
