### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-06-28
+
+### Added
+- `aristo metrics --json` now reports `by_verify_level` (intents per pipeline: neural / test / full / default-true / off-false) and `status_distribution` (annotation counts by verification status, kebab-case keys) — the full breakdown `aristo status` shows as text, now machine-readable from one payload for tooling and dashboards (metrics schema v2).
+
 ### Changed
 - ci: the release workflow now publishes crates idempotently (any crate already at the target version is skipped) and supports a manual re-run, so a partial publish caused by a transient crates.io/network error can be re-run to completion instead of erroring on "already uploaded".
 - skills: the `aristo-instrumenting` skill now covers projector visibility across modules — a `with =` projector over a module-private value type should be `pub(super)`, not `pub(crate)` (which trips rustc's `private_interfaces` lint).
@@ -27,7 +32,6 @@ Minor release with two breaking changes. **Workflow:** `.aristo/index.toml` is n
 - docs: `docs/instrument-recipes.md` and `docs/instrument-conventions.md` are refreshed for the clone / projection forms — a named-projector recipe (with filter / fan-out) for foreign or concurrent collections, plus bare-`#[inspect]` clone, inline-closure, and atomic / lock-guarded recipes — replacing the removed `#[inspect(T)]` / `snapshot =` examples.
 
 ### Added
-- `aristo metrics --json` now reports `by_verify_level` (intents per pipeline: neural / test / full / default-true / off-false) and `status_distribution` (annotation counts by verification status, kebab-case keys) — the full breakdown `aristo status` shows as text, now machine-readable from one payload for tooling and dashboards (metrics schema v2).
 - `aristo verify --audit [--strict]`: a no-network, no-token proof-freshness gate for CI.
 - `aristo init --hook`: opt-in installer for the (now deprecated) local pre-commit hook.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,14 +102,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aristo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aristo-macros",
 ]
 
 [[package]]
 name = "aristo-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aristo",
  "globset",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aristo",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/aretta-ai/aristo"
@@ -26,13 +26,13 @@ keywords = ["annotation", "verification", "intent", "proof", "sdk"]
 # Each crate's manifest sets `readme = "../../README.md"` directly.
 
 [workspace.dependencies]
-aristo = { path = "crates/aristo", version = "0.3.0" }
-aristo-core = { path = "crates/aristo-core", version = "0.3.0" }
+aristo = { path = "crates/aristo", version = "0.3.1" }
+aristo-core = { path = "crates/aristo-core", version = "0.3.1" }
 # default-features = false at the workspace level so the `aristo` meta-crate
 # can route the user's `aristo_check` feature through (member crates that
 # want defaults on can override per-dep, and the macro crate itself has
 # its own default-on for direct `cargo test` runs).
-aristo-macros = { path = "crates/aristo-macros", version = "0.3.0", default-features = false }
+aristo-macros = { path = "crates/aristo-macros", version = "0.3.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
Patch release bundling the three post-0.3.0 `[Unreleased]` items into one tag so they ship together.

## What's in 0.3.1
- **metrics:** `aristo metrics --json` now emits `by_verify_level` + `status_distribution` (metrics schema v2) — real `aristo-core`/`aristo-cli` code from PR #50 that merged after the `v0.3.0` tag and hasn't shipped to crates.io yet.
- **ci:** the release workflow publishes idempotently (skips crates already at the target version) and supports `workflow_dispatch` re-run — recovers a partial publish without erroring on "already uploaded".
- **skills:** `aristo-instrumenting` documents the projector-visibility gotcha (`pub(super)`, not `pub(crate)`, over a module-private value type).

## Mechanics
- Bumps `[workspace.package]` + the three inter-crate dep requirements `0.3.0` → `0.3.1` (and `Cargo.lock`).
- Promotes CHANGELOG `[Unreleased]` → `[0.3.1] — 2026-06-28`; also corrected the metrics bullet, which had landed under `[0.3.0]` despite shipping after that tag.

## Verification
Full §6 suite green locally: `cargo fmt --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (0 failures).

## Publish (after merge — reserved for a human per RELEASING.md)
Tagging `v0.3.1` on `main` triggers `release.yml` → crates.io publish (`aristo-macros` → `aristo` → `aristo-core` → `aristo-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)