### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-29
+
+Minor release: a new fault-injection primitive plus the full aretta-bench instrument response. **`fault_point!`** is the fault-injection counterpart to `yield_point!` — it returns a `Decision` the SUT branches on, backed by a capturing `set_fault_hook`, for injecting *interior* faults (additive; `yield_point!` / `set_hook` are unchanged). The instrument cookbook gains Recipes 9–14 and the `aristo-instrumenting` skill is expanded, closing the gap reports from the aretta-bench suite and the Turso fork. Two `#[derive(Inspect)]` codegen fixes (lint-clean generated accessors, field-spanned clone errors) round it out. No breaking changes.
+
 ### Added
 - macros: `fault_point!("label")` — a fault-injection counterpart to `yield_point!`. It returns a `Decision` (`Continue` / `Inject(u64)`) the SUT branches on to inject a fault, backed by a capturing, stateful `set_fault_hook` so a harness can express "fail the Nth call" without a process-global static. aristo carries *when* to inject plus an opaque code; the SUT owns *what* the fault is (return its own error, drop bytes). Additive and `aristo_instrument`-gated — `yield_point!` / `set_hook` are unchanged. Reach for it only for *interior* faults (a point inside one operation with no I/O-seam call); seam-boundary faults live in the harness's own fault-I/O impl.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,14 +102,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aristo"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aristo-macros",
 ]
 
 [[package]]
 name = "aristo-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aristo",
  "globset",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-macros"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aristo",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/aretta-ai/aristo"
@@ -26,13 +26,13 @@ keywords = ["annotation", "verification", "intent", "proof", "sdk"]
 # Each crate's manifest sets `readme = "../../README.md"` directly.
 
 [workspace.dependencies]
-aristo = { path = "crates/aristo", version = "0.3.1" }
-aristo-core = { path = "crates/aristo-core", version = "0.3.1" }
+aristo = { path = "crates/aristo", version = "0.4.0" }
+aristo-core = { path = "crates/aristo-core", version = "0.4.0" }
 # default-features = false at the workspace level so the `aristo` meta-crate
 # can route the user's `aristo_check` feature through (member crates that
 # want defaults on can override per-dep, and the macro crate itself has
 # its own default-on for direct `cargo test` runs).
-aristo-macros = { path = "crates/aristo-macros", version = "0.3.1", default-features = false }
+aristo-macros = { path = "crates/aristo-macros", version = "0.4.0", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
Cuts **v0.4.0** — an additive feature minor bundling the full aretta-bench + Turso instrument response. Unblocks the Turso fork's `fault_point!` migration against a clean `aristo = "0.4"` (instead of a git rev).

## What's in 0.4.0
- **`fault_point!`** (feat) — fault-injection counterpart to `yield_point!`: returns a `Decision` the SUT branches on, backed by a capturing `set_fault_hook`, for interior faults. **Additive** — `yield_point!` / `set_hook` are unchanged.
- **Instrument docs** — Recipes 9–14 (layered derive, projection-to-tag, private-module re-export, crash-seam, `fault_point!`, keyed lookups) + an expanded `aristo-instrumenting` skill; closes the aretta-bench gap report and the Turso-fork audit (incl. the "0.3.0 didn't drop scalars" clarification).
- **Inspect codegen fixes** — `#[allow(clippy::type_complexity)]` on generated accessors; field-spanned clone-bound errors.

## Mechanics
- Bumps `[workspace.package]` + the 3 inter-crate dep requirements `0.3.1` → `0.4.0` (and `Cargo.lock`).
- Promotes CHANGELOG `[Unreleased]` → `[0.4.0] — 2026-06-29`. No breaking changes.

## Verification
Full §6 green locally incl. `--features aristo_instrument`: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` (default + instrument), `cargo test --workspace` (default + instrument) — 0 failures.

## Publish (after merge — reserved for a human per RELEASING.md)
Tag `v0.4.0` on `main` → `release.yml` publishes the 4 crates in dependency order via OIDC trusted publishing. Recovery if a transient partial publish: `gh workflow run release.yml --ref main` (idempotent since 0.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)