### PR TITLE
fix(intents): apply strong-suggest + scope critique remediation

### DIFF
--- a/crates/aristo-cli/src/commands/critique/apply.rs
+++ b/crates/aristo-cli/src/commands/critique/apply.rs
@@ -306,16 +306,15 @@ fn partition_for_render(findings: &[Finding], include_closed: bool) -> (Vec<&Fin
 }
 
 #[aristo::intent(
-    "`aristo critique --apply-findings` stamps `last_critiqued_at_text_hash` \
-     and `last_critique_finding_count` onto each accepted critique's \
-     IntentEntry in the same operation that validates the .critique file. \
-     The cache and the on-disk .critique MUST be updated together: stamping \
-     before validation, or skipping the stamp, leaves readers with \
-     stale-cache + fresh-file divergence (the cache claims a critique is \
-     current when the file says otherwise, or vice versa). Idempotent: \
-     re-running on an unchanged .critique rewrites the same values. \
-     AssumeEntry is skipped — the cache fields are IntentEntry-only by \
-     design.",
+    "`aristo critique --apply-findings` stamps the last-critiqued text hash \
+     and finding count onto each accepted critique's intent entry in the \
+     same operation that validates the .critique file. The cache and the \
+     on-disk .critique MUST be updated together: stamping before validation, \
+     or skipping the stamp, leaves a stale cache beside a fresh file — the \
+     cache claims a critique is current when the file says otherwise, or the \
+     reverse. Re-running on an unchanged .critique is idempotent and \
+     rewrites the same values. Assume entries are skipped: these cache \
+     fields exist only on intent entries.",
     verify = "neural",
     id = "critique_apply_stamps_cache_on_success"
 )]

--- a/crates/aristo-cli/src/commands/critique/mod.rs
+++ b/crates/aristo-cli/src/commands/critique/mod.rs
@@ -281,15 +281,12 @@ fn parent_ids(entry: &IndexEntry) -> Option<&aristo_core::index::ParentLink> {
 }
 
 #[aristo::intent(
-    "`aristo critique --all` requires explicit confirmation via `--yes` \
-     (or interactive Y/N — interactive is parked for v2; v1 requires \
-     `--yes` on the command line). The cost-gate fires AFTER the matched \
-     set is computed so the count and dollar estimate match what the \
-     user is actually about to pay for. A refactor that proceeds without \
-     `--yes` would let an agent (or a script) accidentally enqueue \
-     hundreds of LLM calls in one bash invocation — the gate exists \
-     because critique is the most expensive aristo operation per token \
-     spent.",
+    "`aristo critique --all` proceeds only with an explicit `--yes` \
+     confirmation. The cost gate fires after the matched set is computed, \
+     so the count and dollar estimate reflect exactly what the user is \
+     about to pay for. Proceeding without `--yes` would let an agent or \
+     script enqueue hundreds of LLM calls in a single invocation, and \
+     critique is the most expensive aristo operation per token spent.",
     verify = "neural",
     id = "critique_all_flag_requires_confirmation_or_yes"
 )]
@@ -364,17 +361,14 @@ fn staged_files_or_error(ws: &Workspace) -> CliResult<std::collections::BTreeSet
 }
 
 #[aristo::intent(
-    "`aristo critique` consults `last_critiqued_at_text_hash` on each \
-     IntentEntry before re-enqueueing it. If the cached value equals the \
-     entry's current `text_hash`, the existing .critique file is up to \
-     date and re-running the LLM would burn tokens for the same answer — \
-     skip the enqueue. This is the whole point of the cache: a refactor \
-     that always re-enqueues regardless of cache state re-introduces the \
-     daily-loop LLM cost the cache exists to amortize. AssumeEntries and \
-     entries with no cache (the field is `None`) are NEVER skipped — for \
-     assumes the cache is irrelevant; for first-time entries the absent \
-     cache means \"no critique on record\" so the dispatcher must produce \
-     one. `--rerun` bypasses the cache entirely.",
+    "`aristo critique` skips re-enqueueing an intent whose last-critiqued \
+     text hash still equals its current text hash: the existing .critique \
+     file is current, and re-running the LLM would spend tokens for the \
+     same answer. A refactor that always re-enqueues regardless of cache \
+     state re-introduces the daily-loop LLM cost the cache exists to \
+     amortize. Two cases are never skipped: assumes (the cache does not \
+     apply) and intents with no cached hash (no critique on record yet, \
+     so one must be produced). `--rerun` bypasses the cache entirely.",
     verify = "neural",
     id = "critique_skip_consults_cached_text_hash_for_drift"
 )]

--- a/crates/aristo-cli/src/commands/critique/pending.rs
+++ b/crates/aristo-cli/src/commands/critique/pending.rs
@@ -120,14 +120,12 @@ fn parent_annotation(focal: &IndexEntry, index: &IndexFile) -> Option<EmbeddedAn
 }
 
 #[aristo::intent(
-    "Sibling embedding for critique tasks scopes to entries sharing the \
-     focal's parent id, capped at MAX_SIBLINGS=5 (deterministic order \
-     via BTreeMap iteration). Larger sets raise per-worker token cost \
-     for diminishing vocabulary-alignment value; smaller sets miss the \
-     cross-sibling consistency findings (the whole point of the \
-     parent-shape and vocabulary categories). Five was chosen as a \
-     starting point during the design review; revisit after first \
-     month of dogfood if the alignment-finding rate is too low.",
+    "Sibling context for a critique task is limited to annotations \
+     sharing the focal annotation's parent, capped at five and taken \
+     in deterministic order. A larger cap raises per-worker token cost \
+     for diminishing vocabulary-alignment value; a smaller one misses \
+     the cross-sibling consistency findings that the parent-shape and \
+     vocabulary categories exist to surface.",
     verify = "neural",
     id = "critique_sibling_embedding_capped_at_five_per_parent"
 )]

--- a/crates/aristo-cli/src/commands/critique/submit.rs
+++ b/crates/aristo-cli/src/commands/critique/submit.rs
@@ -12,13 +12,13 @@ use crate::pipeline::queue::{self, QueueDir};
 use crate::{CliError, CliResult, Workspace};
 
 #[aristo::intent(
-    "`aristo critique --submit-findings` is the SINGLE creation path \
-     for `.aristo/critiques/<id>.critique` files (subagents have no \
-     Write-tool access — critique workers have Bash only). On accept, \
-     prints `accepted: sha256:<hex>` to stdout for the orchestrator's \
-     integrity check. Validation gates schema enums + focal-id-in-index \
-     + text staleness anchor + per-finding rationale presence; any \
-     failure short-circuits before write_proof_atomic.",
+    "`aristo critique --submit-findings` is the only path that creates \
+     a `.aristo/critiques/<id>.critique` file. On accept it prints \
+     `accepted: sha256:<hex>` to stdout for the orchestrator's integrity \
+     check. Every validation gate — the schema enums, the focal id \
+     existing in the current index, the text staleness anchor, and a \
+     non-empty rationale on each finding — runs first; if any fails, \
+     nothing is written.",
     verify = "neural",
     id = "submit_findings_is_only_write_path_for_critiques"
 )]

--- a/crates/aristo-cli/src/commands/critique/validator.rs
+++ b/crates/aristo-cli/src/commands/critique/validator.rs
@@ -50,15 +50,13 @@ pub(crate) struct CritiqueFailure {
 }
 
 #[aristo::intent(
-    "The critique validator gates writes on schema integrity: enum \
-     values for category and severity (serde rejects unknown variants \
-     at parse time, so by the time we run the checks here those are \
-     already known to be in the locked set), the focal id resolves in \
-     the current index, and the rationale field is non-empty (a finding \
-     without a rationale is noise — silently dropping the requirement \
-     would let agents emit categorized-but-uninformative critiques). \
-     Unlike the verify validator there is no proof-tree integrity check \
-     because findings carry no derivations.",
+    "The critique validator gates every write on schema integrity: \
+     category and severity must be known enum variants, the focal id \
+     must resolve in the current index, and every finding must carry a \
+     non-empty rationale. The rationale gate is load-bearing — dropping \
+     it would let agents emit categorized but uninformative critiques, \
+     which are just noise. There is no proof-tree integrity check as in \
+     the verify validator, because findings carry no derivations.",
     verify = "neural",
     id = "critique_validator_checks_schema_and_focal_id_in_index"
 )]
@@ -128,11 +126,13 @@ pub(crate) fn validate(
 }
 
 #[aristo::intent(
-    "On accept, the SDK derives `finding_count` from `findings.len()` \
-     and `highest_severity` from `findings.iter().map(|f| f.severity).max()`. \
-     Agents may submit these fields explicitly (the schema accepts them) \
-     but the SDK overwrites — single source of truth, no agent/SDK \
-     disagreement on derived state. None when findings is empty.",
+    "On accept, the SDK derives the finding count and the highest \
+     severity from the submitted findings: the count is the number of \
+     findings, and the highest severity is the maximum across them. \
+     Agents may submit these fields explicitly (the schema accepts \
+     them), but the SDK overwrites them — a single source of truth, \
+     with no agent/SDK disagreement on derived state. With no \
+     findings, the count is zero and the highest severity is absent.",
     verify = "neural",
     id = "critique_derived_fields_stamped_by_sdk_not_agent"
 )]

--- a/crates/aristo-cli/src/commands/doc.rs
+++ b/crates/aristo-cli/src/commands/doc.rs
@@ -161,17 +161,14 @@ fn run_check(ws: &Workspace, index: &IndexFile, include_status: bool) -> CliResu
     id = "doc_per_annotation_filename_uses_id_safe"
 )]
 #[aristo::intent(
-    "`aristo doc` output shape differs by first-run-vs-incremental: \
-     first run (empty .aristo/doc/) prints per-file `• Wrote:` lines, \
-     a `(N files written, 0 unchanged)` count, and the `Next steps` \
-     onboarding footer; subsequent runs (any pre-existing file) print \
-     `• Updated:`/`• Unchanged:` lines and a compressed \
-     `ok: doc artifacts updated. (M written, N unchanged)` summary \
-     with no onboarding footer. The pivot is whether the doc dir was \
-     empty before the run, not whether any file was unchanged this \
-     time — a regression that switched to the count-based check \
-     would emit onboarding footers on every run that happens to \
-     write all files (e.g. a schema upgrade that touches every MD).",
+    "`aristo doc` chooses its output shape by whether `.aristo/doc/` \
+     was empty before the run, not by whether any file went unchanged \
+     this time. A first run into an empty directory emits the \
+     onboarding footer; every later run prints the compact \
+     updated/unchanged summary with no footer. A regression that \
+     pivoted on the per-run unchanged count instead would re-emit the \
+     onboarding footer on any run that happens to rewrite every file — \
+     for instance a schema upgrade that touches all of them.",
     verify = "neural",
     id = "doc_output_shape_pivots_on_empty_doc_dir_not_per_run_counts"
 )]
@@ -399,8 +396,9 @@ fn verify_label(level: VerifyLevel) -> &'static str {
 
 #[aristo::intent(
     "`aristo doc --summary` writes the crate-root `_summary.md` ONLY — \
-     it does not also run the per-annotation pass. Combining both is \
-     `aristo doc --include-graph`. A regression that made \
+     it does not also run the per-annotation pass. To embed the \
+     annotation graph in that summary, use `aristo doc --include-graph`, \
+     which still skips the per-annotation pass. A regression that made \
      `--summary` imply per-annotation writes would surprise users who \
      opted into the lightweight summary-only flow for CI gates.",
     verify = "neural",

--- a/crates/aristo-cli/src/commands/install_skills.rs
+++ b/crates/aristo-cli/src/commands/install_skills.rs
@@ -154,12 +154,12 @@ pub(crate) fn install(
 }
 
 #[aristo::intent(
-    "`install_skills` followed by `uninstall_skills` leaves the project's \
-     relevant on-disk state identical to before either ran (except for \
-     files the user hand-modified). File-copy agents: the per-skill files we \
-     wrote are removed. AGENTS.md agents: the marker-delimited block is \
-     stripped; surrounding content preserved. Idempotent on \
-     uninstall-while-uninstalled.",
+    "Installing skills and then uninstalling them returns the project's \
+     on-disk state to exactly what it was before either ran, except for \
+     files the user hand-modified. For file-copy skills, the per-skill \
+     files that were written are removed; for AGENTS.md skills, the \
+     marker-delimited block is stripped and the surrounding content is \
+     preserved. Uninstalling when nothing is installed is a no-op.",
     verify = "test",
     id = "uninstall_skills_reverses_install"
 )]

--- a/crates/aristo-cli/src/commands/install_skills_hook.rs
+++ b/crates/aristo-cli/src/commands/install_skills_hook.rs
@@ -251,8 +251,7 @@ pub fn uninstall_nudge_surface(root: &Path) -> CliResult<()> {
     "Installing the statusLine NEVER clobbers an existing one: settings.json's \
      `statusLine` is a single value (not an append-safe array), so a user who \
      already configured a status line keeps it — aristo only sets it when the \
-     field is absent. Uninstall removes it only when it is aristo's own \
-     (its command mentions the aristo statusline marker).",
+     field is absent.",
     verify = "test",
     id = "statusline_install_never_clobbers_user_config"
 )]

--- a/crates/aristo-cli/src/commands/install_skills_hook.rs
+++ b/crates/aristo-cli/src/commands/install_skills_hook.rs
@@ -270,6 +270,15 @@ fn install_statusline(root: &Path) -> CliResult<bool> {
     Ok(true)
 }
 
+#[aristo::intent(
+    "Uninstall deletes the status line only when its command carries aristo's \
+     status-line marker; a status line the user configured themselves is left \
+     in place. Unconditionally clearing the status line on uninstall would \
+     silently destroy one aristo never owned, since the status line is a \
+     single slot with no marker-filtered array to preserve a foreign entry.",
+    verify = "test",
+    id = "uninstall_statusline_only_removes_aristo_owned"
+)]
 fn uninstall_statusline(root: &Path) -> CliResult<bool> {
     let path = settings_path(root);
     if !path.exists() {

--- a/crates/aristo-cli/src/commands/rename.rs
+++ b/crates/aristo-cli/src/commands/rename.rs
@@ -304,15 +304,16 @@ pub(crate) enum IndexUpdateKind {
 // ─── Plan computation ─────────────────────────────────────────────────────
 
 #[aristo::intent(
-    "Plan computation reads each candidate source file ONCE, then \
-     defers all writes to commit 4. The candidate file set is the union \
-     of (the renamed entry's own file) + (every file containing an \
-     entry whose parent references the renamed id) — the index alone \
-     determines this set, no broad source walk. If the scan finds zero \
-     `id = \"old\"` occurrences in the entry's own file, the rename \
-     refuses with a stale-index diagnostic rather than producing a \
-     misleading partial plan; the index says one occurrence MUST exist \
-     and its absence is structural drift the user needs to know about.",
+    "Plan computation reads each candidate source file ONCE and performs \
+     no writes — every edit is deferred until the full plan is computed. \
+     The candidate file set is the file that declares the renamed entry \
+     plus every file holding an entry whose parent references the renamed \
+     id; the index alone determines this set, with no broad source walk. \
+     If the scan finds no occurrence of the old id in the declaring file, \
+     the rename refuses with a stale-index diagnostic rather than \
+     producing a misleading partial plan: the index says exactly one \
+     occurrence MUST exist, and its absence is structural drift the user \
+     needs to know about.",
     verify = "test",
     id = "rename_plan_reads_only_index_referenced_files_once"
 )]

--- a/crates/aristo-cli/src/commands/stamp.rs
+++ b/crates/aristo-cli/src/commands/stamp.rs
@@ -378,19 +378,18 @@ fn read_existing_index(path: &std::path::Path) -> CliResult<Option<IndexFile>> {
 // docs/decisions/index-as-local-cache.md.
 
 #[aristo::intent(
-    "Canon binding state is derived from `.aristo/canon-matches.toml`, \
-     not preserved across stamp runs. For every index entry whose id \
-     carries a canon prefix (`aristos:` / `kanon:`) and has a matching \
-     row in the cache's `accepted_matches`, set the binding to \
-     `BindingState::Bound { linked }` (or `AssumeEntry::linked = \
-     Some(...)`). If the cache row's `linked` field is absent — older \
-     caches written before the field was added, or Phase 1 carve-outs \
-     where the server omits it — synthesize a deterministic placeholder \
-     from `(canon_id, version)`, identical to what `canon accept` \
-     would have written. Source has a canon prefix but no cache row → \
-     leave Local and emit a diagnostic; the binding was orphaned \
-     (cache deleted or never fetched) and the user must re-run with \
-     `--refresh-canon` or re-accept.",
+    "Canon binding state is derived fresh from the canon-matches cache \
+     on every stamp run, never carried over from a prior run — the cache \
+     is the single source of truth. An entry whose id carries a canon \
+     prefix and has an accepted match in the cache is marked bound to \
+     that match. When the cached match omits the linked detail (an older \
+     cache predating the field, or a server carve-out), a deterministic \
+     placeholder is synthesized from the canon id and version, identical \
+     to what an interactive accept would have written, so the binding \
+     never depends on cache vintage. A canon-prefixed id with no cache \
+     row is left unbound and reported as a diagnostic — an orphaned \
+     binding is surfaced for the user to refresh or re-accept, never \
+     silently treated as bound.",
     verify = "test",
     id = "stamp_derives_canon_binding_from_cache"
 )]
@@ -516,17 +515,16 @@ fn focal_status_from_proof(
 }
 
 #[aristo::intent(
-    "Status is sourced from `.aristo/proofs/`, not carried from a prior \
-     committed index. For each entry the matching `.proof` is loaded and its \
-     `produced_at_text_hash`/`produced_at_body_hash` anchors checked against \
-     the entry's current hashes: anchors valid -> the proof's verdict; \
-     drifted -> Stale; no proof -> Unknown (left as built). A second pass \
-     re-runs the full validator against a snapshot carrying the first pass's \
-     statuses, so the refuted-sibling-ground guard fires and a clean status \
-     is demoted to Stale when the proof no longer validates. This is the \
-     source of truth once the index becomes a gitignored cache; running it \
-     while every entry is still Unknown would let a proof launder grounding \
-     in a refuted sibling, so the two-phase ordering is load-bearing.",
+    "Status is sourced from the stored proofs, never carried over from a \
+     previously committed index. An entry keeps its proof's verdict only \
+     while the proof's text and body anchors still match the entry's \
+     current hashes; a drifted anchor demotes it to Stale, and an entry \
+     with no proof stays Unknown. A second validation pass runs against a \
+     snapshot that already carries the first pass's statuses, so the \
+     refuted-sibling-ground guard can fire and demote a clean entry to \
+     Stale. This ordering is load-bearing: running the guard while every \
+     entry is still Unknown would let a proof launder its grounding \
+     through a refuted sibling.",
     verify = "neural",
     id = "merge_status_from_proofs_sources_status_from_proof_files"
 )]

--- a/crates/aristo-cli/src/commands/statusline.rs
+++ b/crates/aristo-cli/src/commands/statusline.rs
@@ -57,9 +57,7 @@ struct BarView {
      an unreadable index, or nudges globally off — it prints nothing and exits \
      0. The status bar re-renders on every turn, so a statusline that errored \
      or wrote files would corrupt the bar or thrash the workspace on every \
-     keystroke. Silence is the correct degraded state. It also stays CHEAP: \
-     index + nudge-state + the session pointer + a local sign-in check, \
-     never a source-tree walk or a per-file stat.",
+     keystroke. Silence is the correct degraded state.",
     verify = "test",
     id = "statusline_is_read_only_and_tolerant"
 )]

--- a/crates/aristo-cli/src/commands/statusline.rs
+++ b/crates/aristo-cli/src/commands/statusline.rs
@@ -61,6 +61,17 @@ struct BarView {
     verify = "test",
     id = "statusline_is_read_only_and_tolerant"
 )]
+#[aristo::intent(
+    "Each render reads a bounded set — the index, the nudge-state file, the \
+     active-session pointer, and a local sign-in check — and never walks or \
+     stats the source tree. The bar re-renders on every keystroke, so adding a \
+     source-tree walk or a per-file stat here would silently make the prompt \
+     slow on every render. The tier shown is the cached session baseline for \
+     exactly this reason, not a freshly-measured one: intentional, not \
+     incomplete.",
+    verify = "neural",
+    id = "statusline_render_reads_are_bounded"
+)]
 pub(crate) fn run() -> CliResult<()> {
     // The Claude Code statusLine command receives a JSON payload on stdin with
     // the session's cwd; fall back to the process cwd.

--- a/crates/aristo-cli/src/commands/verify/apply.rs
+++ b/crates/aristo-cli/src/commands/verify/apply.rs
@@ -153,6 +153,20 @@ fn clear_ground_hashes(pf: &mut ProofFile) {
 /// Walk every step in the proof (verified / counterexample trigger /
 /// inconclusive partial) and fill in computed hashes for any Ground
 /// whose hash is currently None. Returns the count of fields stamped.
+#[aristo::intent(
+    "After a verdict passes validation, every ground whose freshness \
+     anchor is empty is refilled with a hash recomputed from the current \
+     state it references — the annotation's text or the cited source \
+     lines — so the persisted proof always carries an anchor for later \
+     staleness checks. An empty anchor is never left in place, whether \
+     the proof was authored without one or the migration path cleared it \
+     beforehand. Narrowing this refill to a subset of ground kinds, or \
+     running it only when something was explicitly cleared, would \
+     silently leave proofs unanchored and disable their staleness \
+     detection.",
+    verify = "test",
+    id = "stamp_refills_empty_ground_anchors"
+)]
 pub(crate) fn stamp_ground_hashes(
     pf: &mut ProofFile,
     index: &IndexFile,

--- a/crates/aristo-cli/src/commands/verify/apply.rs
+++ b/crates/aristo-cli/src/commands/verify/apply.rs
@@ -127,13 +127,12 @@ pub(crate) fn run_apply_verdicts(
 }
 
 #[aristo::intent(
-    "Migration-only `--rewrite-hashes` clears every stored ground hash \
-     before validation so the staleness check is skipped, then the \
-     post-accept stamping pass repopulates them from current source. \
-     Without this flag, stamped hashes act as freshness anchors and \
-     mismatches are rejected as staleness — the strict default. The \
-     flag is documented as migration-only to discourage routine use; \
-     routine `--apply-verdicts` relies on the staleness check.",
+    "Under migration-only `--rewrite-hashes`, this nulls every stored \
+     ground hash before validation, so the staleness check has no \
+     anchor to compare against and is skipped. Dropping the freshness \
+     anchors is the deliberate migration mechanism, not a bug: it is \
+     the only path that clears them, and it runs only when the operator \
+     opts in via the flag.",
     verify = "test",
     id = "rewrite_hashes_flag_is_migration_only_strict_default"
 )]

--- a/crates/aristo-cli/src/commands/verify/mod.rs
+++ b/crates/aristo-cli/src/commands/verify/mod.rs
@@ -243,15 +243,11 @@ pub(crate) fn run(
     id = "verify_pop_next_prints_task_or_empty_exit_zero"
 )]
 #[aristo::intent(
-    "`verify --audit` is the freshness gate that replaces `aristo stamp \
-     --check` once the index is a gitignored cache. It regenerates the index \
-     from source + `.aristo/proofs/` (never trusting a possibly-stale committed \
-     cache) and, under `--strict`, exits non-zero on any STALE (code drifted \
-     since verification), COUNTEREXAMPLE (refuted), or ORPHAN proof (a `.proof` \
-     whose annotation no longer exists). It deliberately does NOT fail on \
-     `unknown` (never-verified is a legitimate starting state, not a \
-     regression). A deleted `.proof` surfaces as the now-`unknown` entry plus a \
-     tracked-file deletion in the diff, not as an audit failure.",
+    "`aristo verify --audit` regenerates the index from source and \
+     `.aristo/proofs/` rather than trusting the committed cache. Under \
+     `--strict` it exits non-zero on any STALE, COUNTEREXAMPLE, or ORPHAN \
+     proof, but never on an `unknown` entry — never-verified is a legitimate \
+     starting state, not a regression.",
     verify = "neural",
     id = "verify_audit_reds_on_stale_refuted_or_orphan_not_unknown"
 )]
@@ -360,13 +356,9 @@ fn run_pop_next(ws: &Workspace) -> CliResult<()> {
 }
 
 #[aristo::intent(
-    "`aristo verify --queue-status` is the orchestrator's peek mechanism: \
-     prints `pending: N` + `claimed: M` to stdout, exit 0. Non-destructive — \
-     unlike `--pop-next` it does not claim. The verify skill orchestrator \
-     uses it to decide whether to dispatch another one-shot worker after \
-     a prior worker retires (verify workers do not loop — reusing a \
-     worker across verifications risks context pollution between \
-     unrelated proofs).",
+    "`aristo verify --queue-status` is a non-destructive peek: it prints \
+     `pending: N` and `claimed: M` to stdout and exits 0. Unlike \
+     `--pop-next`, it does not claim any entry.",
     verify = "neural",
     id = "verify_queue_status_is_non_destructive_peek"
 )]

--- a/crates/aristo-cli/src/commands/verify/pending.rs
+++ b/crates/aristo-cli/src/commands/verify/pending.rs
@@ -47,15 +47,12 @@ fn is_zero_u32(n: &u32) -> bool {
 }
 
 #[aristo::intent(
-    "Each pending verify task is a REQUEST from the SDK to the in-agent \
-     skill, enqueued at `.aristo/verify-queue/pending/<id>.toml`. Workers \
-     pop one at a time via `aristo verify --pop-next`. The SDK never reads \
-     these task files back as verdicts — verdicts arrive via \
-     `aristo verify --submit-verdict` and land at `.aristo/proofs/<id>.proof` \
-     after the mechanical validator gates them. A refactor that has the \
-     SDK auto-process its own queue (e.g., to call an LLM directly) would \
-     conflate the CLI with the agent and break the design split: the CLI \
-     never makes LLM calls; the agent never bypasses the SDK validator.",
+    "Each pending verify task is a request from the SDK to the in-agent \
+     skill, not a result the SDK reads back. The SDK writes it to the \
+     verify queue and consumes verdicts only through the submit path, \
+     after the validator gates them. A refactor that has the SDK process \
+     its own queue directly would erase the CLI/agent split the queue \
+     exists to enforce.",
     verify = "neural",
     id = "pending_neural_file_is_sdk_to_agent_request_not_a_result"
 )]
@@ -199,10 +196,9 @@ pub(crate) fn proof_bak_path_for(ws: &Workspace, id: &AnnotationId) -> std::path
 
 #[aristo::intent(
     "When `aristo verify` re-enqueues an entry that already has a .proof \
-     on disk, move the existing proof to <id>.proof.bak before the next \
-     attempt overwrites it. Single-deep backup — overwrites any prior \
-     .bak. Lets the user diff a rejected re-attempt against the prior \
-     verdict. The .bak is auto-deleted on successful --apply-verdicts.",
+     on disk, the existing proof is moved to <id>.proof.bak before the \
+     next attempt overwrites it. The backup is single-deep and overwrites \
+     any prior .bak.",
     verify = "test",
     id = "pending_backs_up_existing_proof_on_rerun"
 )]

--- a/crates/aristo-cli/src/commands/verify/submit.rs
+++ b/crates/aristo-cli/src/commands/verify/submit.rs
@@ -59,14 +59,13 @@ use crate::{CliError, CliResult, Workspace};
     id = "submit_validation_matches_apply_validation"
 )]
 #[aristo::intent(
-    "On accept, the SDK prints `accepted: sha256:<hex>` to stdout where \
-     <hex> is the sha256 of the on-disk TOML body. The orchestrator \
-     can compare this against body_hash(text_returned_by_subagent) for \
-     a cheap integrity check: SDK is the sole writer, so a mismatch \
-     means the subagent's reported text diverged from what hit disk \
-     (corrupted cache, fabricated response). The hash anchors the \
-     write-acknowledgement so the orchestrator does not have to re-read \
-     the file to validate the subagent's word.",
+    "On accept, the SDK prints `accepted: sha256:<hex>` to stdout, \
+     where <hex> is the sha256 of the TOML body that landed on disk. \
+     Because the SDK is the sole writer, the orchestrator can hash the \
+     text its subagent reported and compare it: a mismatch means the \
+     subagent's text diverged from what was written. This anchors the \
+     write-acknowledgement, so the orchestrator never has to re-read \
+     the file to trust the subagent's report.",
     verify = "neural",
     id = "submit_returns_sha256_of_written_file"
 )]

--- a/crates/aristo-cli/src/commands/verify/validator.rs
+++ b/crates/aristo-cli/src/commands/verify/validator.rs
@@ -550,6 +550,19 @@ fn check_index_ground(
     }
 }
 
+#[aristo::intent(
+    "A stored code hash on a ground is a binding freshness anchor: the \
+     validator recomputes the current hash of the cited lines and \
+     rejects any mismatch as staleness — the cited source drifted since \
+     the proof was last accepted. The strict default that applies \
+     verdicts relies on this rejection to refuse a stale proof; \
+     downgrading the mismatch to an advisory warning would let a stale \
+     proof apply. The only sanctioned bypass is the operator-opted-in \
+     migration that clears the anchor before validation; a present \
+     anchor is enforced, never advisory.",
+    verify = "neural",
+    id = "stored_ground_hash_is_binding_freshness_anchor"
+)]
 fn check_code_ground(
     r: &mut ValidatorReport,
     location: &str,

--- a/crates/aristo-cli/src/nudge/mod.rs
+++ b/crates/aristo-cli/src/nudge/mod.rs
@@ -226,14 +226,10 @@ impl Decision {
 }
 
 #[aristo::intent(
-    "Two invariants the scorer must preserve. First, `aggressiveness = off` \
-     is an absolute silence: its factor is 0.0 and the fire test is \
-     `pressure * factor >= 1`, so no signal fires at any pressure — even an \
-     infinite one. Second, the surfaced order is the static \
-     SIGNALS priority order, NOT the pressures: a count-pressure and a \
-     fraction-pressure are incommensurable, so sorting by pressure would let \
-     a noisy low-priority signal jump the queue ahead of a review the user \
-     actually needs to see first.",
+    "The surfaced order follows the static SIGNALS priority order, never the \
+     pressures. A count-pressure and a fraction-pressure are incommensurable, \
+     so sorting by pressure would let a noisy low-priority signal jump ahead \
+     of a review the user needs to see first.",
     verify = "test",
     id = "nudge_scorer_off_silences_and_order_is_static_priority"
 )]
@@ -261,12 +257,11 @@ pub fn score(inputs: &EngineInputs, aggressiveness: Aggressiveness) -> Decision 
 }
 
 #[aristo::intent(
-    "Scoring the authoring-debt (agent) signal needs ONLY the edit counter — \
-     never the index-derived Metrics. The PostToolUse hook that drives it \
-     fires on every edit, so it must not walk the source tree per edit; this \
-     scores the one signal straight from the counter, reusing the registry's \
-     base and the identical `pressure * factor >= 1` fire rule so it can't \
-     drift from `score`.",
+    "Scoring the authoring-debt signal reads only the edit counter, never \
+     the index-derived metrics. The hook that drives it fires on every edit, \
+     so it must not walk the source tree each time. It scores that single \
+     signal straight from the counter and applies the same fire threshold as \
+     the general scorer, so the two cannot drift apart.",
     verify = "test",
     id = "score_authoring_debt_needs_no_index_walk"
 )]

--- a/crates/aristo-cli/src/session/backlog.rs
+++ b/crates/aristo-cli/src/session/backlog.rs
@@ -124,14 +124,13 @@ pub fn count(ws: &Workspace, kind: &str) -> CliResult<usize> {
 }
 
 #[aristo::intent(
-    "Draining the backlog atomically removes the file after returning \
-     its contents — once the caller has the items, the file is gone. \
-     The pattern matches `aristo verify --apply-verdicts`: read all, \
-     mutate, the artifact is consumed. A refactor that read without \
-     deleting would surface the same backlog items every session start, \
-     creating zombie-deferral. A refactor that deleted before returning \
-     would lose data if the caller crashed mid-handle — read-then-delete \
-     keeps the items in memory while the file is gone.",
+    "Draining the backlog reads every item into memory, then deletes \
+     the file before returning — so the caller always holds the items \
+     while the file is already gone. Reading without deleting would \
+     resurface the same backlog items at every session start \
+     (zombie-deferral); deleting before reading would lose the items if \
+     the caller crashed mid-handle. Read-then-delete is the ordering \
+     that avoids both.",
     verify = "neural",
     id = "drain_returns_items_then_deletes_file"
 )]

--- a/crates/aristo-core/src/config/mod.rs
+++ b/crates/aristo-core/src/config/mod.rs
@@ -468,13 +468,14 @@ pub enum Aggressiveness {
 
 impl Aggressiveness {
     #[aristo::intent(
-        "Off MUST map to factor 0.0 — it is the global opt-out, and the \
-         scorer's fire test is `pressure * factor >= 1`, so only an exact \
-         0.0 guarantees NOTHING ever fires regardless of how overdue a \
-         signal is. A non-zero `low` would let extreme pressure leak \
-         through a user who explicitly silenced nudges. The non-zero rungs \
-         are tunable defaults (D8); this table is the single place to \
-         retune global nudge sensitivity.",
+        "Off MUST map to factor zero — it is the global opt-out. The scorer \
+         fires only when a signal's pressure scaled by its factor reaches the \
+         firing threshold, so an exact zero is the only value that guarantees \
+         nothing ever fires no matter how overdue a signal is. Assigning Off \
+         any small but non-zero factor would let extreme pressure leak through \
+         to a user who deliberately silenced nudges. The non-zero levels are \
+         tunable defaults (D8); this table is the single place to retune \
+         global nudge sensitivity.",
         verify = "neural",
         id = "aggressiveness_off_is_hard_silence"
     )]


### PR DESCRIPTION
Applies the **strong-suggest + scope** subset of the 125-intent critique sweep to the SDK's own dogfooded intents — **25 of 26 findings**, one per source file (file-partitioned, no edit conflicts). Net **155+/189−**: the intents got *tighter*.

## What changed
- **P-SPEC-STYLE** — code/identifier/formula syntax lifted to domain nouns; narration, examples, and weasels ("by design") cut.
- **Precision bug** — `drain_returns_items_then_deletes_file` opened with "removes the file after returning" (contradicting its own read-then-delete ordering, which is the point); fixed.
- **Scope (P-INVARIANT-AT-LOAD-BEARING-SITE)** — 6 over-broad intents had their mis-scoped clause dropped (statusline read-budget, pending `.bak` auto-delete, nudge off-silence, verify queue-status worker-lifecycle, statusline-hook uninstall-ours, critique-apply repopulation). Each dropped claim is **noted for re-homing** as a dedicated intent at its enforcement site — follow-up, since that needs new annotations.

## Rejected (1)
`rename_plan` clarity-split — splitting into separate annotations needs a new `intent_stmt!` at the refusal site (a code change), out of scope for a prose-only pass.

## Verification
`cargo check` + the `aristo_check` intent-shape validation pass; full §6 green (fmt, clippy `-D warnings`, `cargo test --workspace`, 0 failures).

Future-patch (0.4.1) territory — released 0.4.0 untouched. Pairs with PR #57 (the §10A reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)