### PR TITLE
feat: route aristo-cli data-plane requests via aristo.toml [instance] url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 ## [Unreleased]
 
 ### Added
-- config: `aristo.toml` gains an `[instance]` section with a `url` key that pins this project's data-plane requests to a specific Aretta deployment (e.g. a per-repo conductor at `https://<slug>.aretta.ai`). Resolution precedence is `ARETTA_API_URL` (env) > `[instance] url` > the signed-in account server; the value is normalized like `--server` (bare host → `https://`, trailing `/` stripped). Auth/login is unchanged — the token is still minted against the account server; this only redirects where verified-data requests go. (Wired into `verify` + canon match in the next change.)
+- config: `aristo.toml` gains an `[instance]` section with a `url` key that pins this project's data-plane requests to a specific Aretta deployment (e.g. a per-repo conductor at `https://<slug>.aretta.ai`). Resolution precedence is `ARETTA_API_URL` (env) > `[instance] url` > the signed-in account server; the value is normalized like `--server` (bare host → `https://`, trailing `/` stripped). Auth/login is unchanged — the token is still minted against the account server; this only redirects where verified-data requests go.
 
 ### Changed
+- cli: `aristo verify` and canon match (`stamp` / `canon refresh` / `canon migrate`) now resolve their data-plane base URL through the project's `[instance] url`, so a repo pinned to a per-repo conductor routes there automatically — locally and in CI — without `aristo auth login --server`. `ARETTA_API_URL` still overrides, and behavior is unchanged when `[instance]` is absent.
 - cli: `aristo canon show` and `aristo canon request-verify` now report "coming soon" (exit 64) instead of calling the canon API — the two per-entry canon read/write endpoints are being reworked to route against the per-instance data plane. `stamp` / `canon refresh` / `canon list` / `canon accept` / `canon unbind` are unaffected.
 
 ## [0.4.0] — 2026-06-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+### Added
+- config: `aristo.toml` gains an `[instance]` section with a `url` key that pins this project's data-plane requests to a specific Aretta deployment (e.g. a per-repo conductor at `https://<slug>.aretta.ai`). Resolution precedence is `ARETTA_API_URL` (env) > `[instance] url` > the signed-in account server; the value is normalized like `--server` (bare host → `https://`, trailing `/` stripped). Auth/login is unchanged — the token is still minted against the account server; this only redirects where verified-data requests go. (Wired into `verify` + canon match in the next change.)
+
 ### Changed
 - cli: `aristo canon show` and `aristo canon request-verify` now report "coming soon" (exit 64) instead of calling the canon API — the two per-entry canon read/write endpoints are being reworked to route against the per-instance data plane. `stamp` / `canon refresh` / `canon list` / `canon accept` / `canon unbind` are unaffected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+### Changed
+- cli: `aristo canon show` and `aristo canon request-verify` now report "coming soon" (exit 64) instead of calling the canon API — the two per-entry canon read/write endpoints are being reworked to route against the per-instance data plane. `stamp` / `canon refresh` / `canon list` / `canon accept` / `canon unbind` are unaffected.
+
 ## [0.4.0] — 2026-06-29
 
 Minor release: a new fault-injection primitive plus the full aretta-bench instrument response. **`fault_point!`** is the fault-injection counterpart to `yield_point!` — it returns a `Decision` the SUT branches on, backed by a capturing `set_fault_hook`, for injecting *interior* faults (additive; `yield_point!` / `set_hook` are unchanged). The instrument cookbook gains Recipes 9–14 and the `aristo-instrumenting` skill is expanded, closing the gap reports from the aretta-bench suite and the Turso fork. Two `#[derive(Inspect)]` codegen fixes (lint-clean generated accessors, field-spanned clone errors) round it out. No breaking changes.

--- a/crates/aristo-cli/src/commands/canon/migrate.rs
+++ b/crates/aristo-cli/src/commands/canon/migrate.rs
@@ -107,8 +107,7 @@ pub(crate) fn run() -> CliResult<()> {
     } else {
         match aristo_core::auth::resolve_full() {
             Ok(creds) => {
-                let base_url = std::env::var("ARETTA_API_URL")
-                    .unwrap_or_else(|_| creds.server.as_str().to_string());
+                let base_url = crate::data_plane::resolve_base(&creds.server);
                 Box::new(HttpCanonClient::new(base_url, &creds.token))
             }
             Err(_) => {

--- a/crates/aristo-cli/src/commands/canon/request_verify.rs
+++ b/crates/aristo-cli/src/commands/canon/request_verify.rs
@@ -1,90 +1,17 @@
 //! `aristo canon request-verify <canon_id> [--notes <text>]` — record
 //! a demand signal for verification backing on a canon entry.
 //!
-//! Per canon-strategy.md §CS11, this is idempotent on
-//! `(canon_id, repo_full_name, user_id)` server-side — repeat calls
-//! with a fresh `--notes` replace the previous note, but the
-//! "first submission" timestamp is preserved.
-//!
-//! The user runs this when they've bound an annotation at the
-//! `kanon:` tier and want to push Aretta to invest in a verification
-//! mechanism for that canon entry. The server tallies demand signals
-//! to inform the verifier-investment roadmap.
-
-use aristo_core::canon::{
-    CanonClient, CanonError, HttpCanonClient, MockCanonClient, RequestVerifyBody,
-};
+//! Coming soon. Demand-signal submission is being reworked to resolve
+//! against the per-instance data plane (see `[instance]` in
+//! `aristo.toml`); until that lands the command reports the deferral
+//! instead of calling a canon endpoint. Prior behavior: `POST
+//! /canon/request-verify` recorded an idempotent demand signal.
 
 use crate::{CliError, CliResult};
 
-pub(crate) fn run(canon_id: &str, notes: Option<String>) -> CliResult<()> {
-    let client: Box<dyn CanonClient> = if let Some(mock) = MockCanonClient::from_env() {
-        Box::new(mock)
-    } else {
-        match aristo_core::auth::resolve_full() {
-            Ok(creds) => {
-                let base_url = std::env::var("ARETTA_API_URL")
-                    .unwrap_or_else(|_| creds.server.as_str().to_string());
-                Box::new(HttpCanonClient::new(base_url, &creds.token))
-            }
-            Err(_) => {
-                return Err(CliError::Other {
-                    message: "canon API requires authentication.\n  \
-                              Run `aristo auth login` to sign in.\n  \
-                              `aristo canon request-verify` is a paid-tier feature; \
-                              see canon-strategy.md §CS1."
-                        .into(),
-                    exit_code: 1,
-                });
-            }
-        }
-    };
-
-    let body = RequestVerifyBody {
-        canon_id: canon_id.to_string(),
-        notes,
-    };
-    let response = client.request_verify(&body).map_err(canon_error_to_cli)?;
-
-    match response.status.as_str() {
-        "submitted" => {
-            println!(
-                "ok: verification demand signal recorded for `{}`.",
-                response.canon_id
-            );
-        }
-        "updated" => {
-            let prev = response.previously_submitted_at.as_deref().unwrap_or("?");
-            println!(
-                "ok: verification demand signal updated for `{}` \
-                 (first submitted {prev}).",
-                response.canon_id
-            );
-        }
-        other => {
-            // Server might add new status values; keep the body
-            // future-compatible.
-            println!(
-                "ok: request-verify returned status `{other}` for `{}`.",
-                response.canon_id
-            );
-        }
-    }
-    if let Some(current_backing) = &response.current_backing {
-        println!("   note: this entry already has backing: {current_backing}");
-    } else {
-        println!(
-            "   note: this canon entry has no verification backing yet for your \
-             scope. Demand signals like yours drive Aretta's verifier-investment \
-             roadmap."
-        );
-    }
-    Ok(())
-}
-
-fn canon_error_to_cli(e: CanonError) -> CliError {
-    CliError::Other {
-        message: format!("canon API error: {e}"),
-        exit_code: 1,
-    }
+pub(crate) fn run(_canon_id: &str, _notes: Option<String>) -> CliResult<()> {
+    Err(CliError::NotImplemented {
+        what: "aristo canon request-verify",
+        hint: "coming soon (reworking for per-instance data-plane routing)",
+    })
 }

--- a/crates/aristo-cli/src/commands/canon/runner.rs
+++ b/crates/aristo-cli/src/commands/canon/runner.rs
@@ -216,8 +216,7 @@ fn build_client(_config: &CanonConfig) -> (Box<dyn CanonClient>, bool) {
     // free tier (Noop, with the nudge).
     match aristo_core::auth::resolve_full() {
         Ok(creds) => {
-            let base_url = std::env::var("ARETTA_API_URL")
-                .unwrap_or_else(|_| creds.server.as_str().to_string());
+            let base_url = crate::data_plane::resolve_base(&creds.server);
             (
                 Box::new(HttpCanonClient::new(base_url, &creds.token)),
                 false,

--- a/crates/aristo-cli/src/commands/canon/show.rs
+++ b/crates/aristo-cli/src/commands/canon/show.rs
@@ -1,163 +1,18 @@
-//! `aristo canon show <canon_id>` — fetch the canon entry detail via
-//! `GET /canon/entry/<canon_id>` and render the full per-entry view.
+//! `aristo canon show <canon_id>` — render the full per-entry canon
+//! detail view.
 //!
-//! This is the surface behind the `[d]etail` choice in
-//! cli-sessions.md Flow 3. The user wants the longer pedagogical
-//! description, the example shape, and the references. This render
-//! is the canon-entry detail dump; the user-facing trust card
-//! lands in PR #10 as the canon-aware extension of `aristo show`.
-//!
-//! ## Access policy (per CS10 / canon-strategy.md)
-//!
-//! The `/canon/entry/<id>` endpoint is accessible to any paid-tier
-//! user; there is no match-history gate. The server enforces the
-//! "your scope or a public scope" filter on `related_entries` so the
-//! card never leaks the IP of overlay scopes the user doesn't have.
-
-use aristo_core::canon::{CanonClient, CanonError, HttpCanonClient, MockCanonClient};
+//! Coming soon. The canon detail view is being reworked to resolve
+//! against the per-instance data plane (see `[instance]` in
+//! `aristo.toml`); until that lands the command reports the deferral
+//! instead of calling a canon endpoint. Prior behavior: `GET
+//! /canon/entry/<canon_id>` rendered category / property / backing /
+//! statement / references for the entry.
 
 use crate::{CliError, CliResult};
 
-pub(crate) fn run(canon_id: &str, version: Option<String>) -> CliResult<()> {
-    // Same client selection precedence as the stamp/critique runner:
-    // ARISTO_CANON_FIXTURE wins for test mode; else auth resolves to
-    // HttpCanonClient; else error out (no canon-API call possible).
-    let client: Box<dyn CanonClient> = if let Some(mock) = MockCanonClient::from_env() {
-        Box::new(mock)
-    } else {
-        match aristo_core::auth::resolve_full() {
-            Ok(creds) => {
-                // ARETTA_API_URL still wins as an explicit override
-                // (useful for tests); otherwise use the server URL
-                // persisted with the token.
-                let base_url = std::env::var("ARETTA_API_URL")
-                    .unwrap_or_else(|_| creds.server.as_str().to_string());
-                Box::new(HttpCanonClient::new(base_url, &creds.token))
-            }
-            Err(_) => {
-                return Err(CliError::Other {
-                    message: "canon API requires authentication.\n  \
-                              Run `aristo auth login` to sign in.\n  \
-                              `aristo canon show` is a paid-tier feature; see \
-                              canon-strategy.md §CS1."
-                        .into(),
-                    exit_code: 1,
-                });
-            }
-        }
-    };
-
-    let entry = client
-        .get_entry(canon_id, version.as_deref())
-        .map_err(canon_error_to_cli)?;
-
-    // Pick the primary scope for single-value rendering. `:vanilla`
-    // is always in the effective set; named flavors come second. We
-    // intentionally don't sum across scopes — the trust card shows
-    // the verification commitment for the user's *current* scope.
-    let primary_scope = entry
-        .effective_scopes
-        .iter()
-        .find(|s| *s != ":vanilla")
-        .cloned()
-        .unwrap_or_else(|| ":vanilla".to_string());
-
-    println!();
-    println!("canon entry: {}", entry.canon_id);
-    if entry.is_deprecated {
-        println!(
-            "version:     {} (deprecated; active is {})",
-            entry.version, entry.active_version
-        );
-    } else {
-        println!("version:     {}", entry.version);
-    }
-    println!("scope:       {}", entry.effective_scopes.join(", "));
-    println!("category:    {}", entry.category);
-    println!("property:    {}", entry.property_type);
-    println!("applies to:  {}", entry.applies_to.join(", "));
-    match entry.backed_by.get(&primary_scope) {
-        Some(Some(backing)) => {
-            println!("backed by:   {backing}  (scope {primary_scope})");
-        }
-        Some(None) | None => {
-            println!("backed by:   — (kanon: tier; no verification backing yet for your scope)");
-        }
-    }
-    println!();
-    println!("statement:");
-    println!("  {}", entry.canonical_text);
-    if !entry.description.is_empty() {
-        println!();
-        println!("description:");
-        for line in entry.description.lines() {
-            println!("  {line}");
-        }
-    }
-    if !entry.invariant_sketch.is_empty() {
-        println!();
-        println!("invariant sketch:");
-        for line in entry.invariant_sketch.lines() {
-            println!("  {line}");
-        }
-    }
-    if !entry.examples.is_empty() {
-        println!();
-        println!("example shape (abstract — not your code):");
-        for line in entry.examples[0].lines() {
-            println!("  {line}");
-        }
-    }
-    let refs = &entry.references;
-    if !refs.literature.is_empty() || !refs.related_entries.is_empty() || !refs.external.is_empty()
-    {
-        println!();
-        println!("references:");
-        for lit in &refs.literature {
-            println!("  • {lit}");
-        }
-        for url in &refs.external {
-            println!("  • {url}");
-        }
-        // Related entries are bare canon_id strings — the wire
-        // doesn't carry per-entry prefix tiers (would require a
-        // follow-up call per related id). Phase 1 renders bare; a
-        // future "show --enrich" mode could fetch tier per related.
-        for related_id in &refs.related_entries {
-            println!("  • {related_id}");
-        }
-    }
-    println!();
-    Ok(())
-}
-
-fn canon_error_to_cli(e: CanonError) -> CliError {
-    match &e {
-        CanonError::NotEnabled => CliError::Other {
-            message: "canon API is disabled for this client.\n  \
-                      Run `aristo auth login` if you haven't, or check \
-                      `[canon] enabled = true` in aristo.toml."
-                .into(),
-            exit_code: 1,
-        },
-        CanonError::Auth(_) => CliError::Other {
-            message: format!(
-                "canon API auth error: {e}.\n  \
-                 Try `aristo auth logout` then `aristo auth login` with a fresh token."
-            ),
-            exit_code: 1,
-        },
-        CanonError::Network(_) | CanonError::Timeout => CliError::Other {
-            message: format!(
-                "canon API unreachable: {e}.\n  \
-                 Check your network; the cached state in `.aristo/canon-matches.toml` \
-                 remains valid for previously-matched annotations."
-            ),
-            exit_code: 1,
-        },
-        _ => CliError::Other {
-            message: format!("canon API error: {e}"),
-            exit_code: 1,
-        },
-    }
+pub(crate) fn run(_canon_id: &str, _version: Option<String>) -> CliResult<()> {
+    Err(CliError::NotImplemented {
+        what: "aristo canon show",
+        hint: "coming soon (reworking for per-instance data-plane routing)",
+    })
 }

--- a/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
+++ b/crates/aristo-cli/src/commands/verify/canon_dispatch.rs
@@ -298,9 +298,9 @@ pub(crate) fn run_canon_dispatch(
         });
     }
 
-    // 5. Build the HTTP client. ARETTA_API_URL overrides for tests.
-    let base_url =
-        std::env::var("ARETTA_API_URL").unwrap_or_else(|_| creds.server.as_str().to_string());
+    // 5. Build the HTTP client. Data-plane base: ARETTA_API_URL >
+    //    aristo.toml [instance] url > the signed-in server.
+    let base_url = crate::data_plane::resolve_base(&creds.server);
     let client: Box<dyn VerifyClient> = if let Some(mock) = test_mock_client_from_env() {
         mock
     } else {
@@ -361,8 +361,7 @@ fn exit_error_for(verdict: &waiver::WaiverVerdict) -> CliError {
 /// Skips POST + push-first precheck entirely.
 pub(crate) fn run_view_session(session_id: &str, wait: bool) -> CliResult<()> {
     let creds = aristo_core::auth::resolve_full().map_err(no_auth_to_cli_error)?;
-    let base_url =
-        std::env::var("ARETTA_API_URL").unwrap_or_else(|_| creds.server.as_str().to_string());
+    let base_url = crate::data_plane::resolve_base(&creds.server);
     let client: Box<dyn VerifyClient> = if let Some(mock) = test_mock_client_from_env() {
         mock
     } else {

--- a/crates/aristo-cli/src/data_plane.rs
+++ b/crates/aristo-cli/src/data_plane.rs
@@ -1,0 +1,28 @@
+//! Resolve the base URL for **data-plane** requests — verify session
+//! dispatch and canon match — from `ARETTA_API_URL` (env) > the
+//! project's `aristo.toml` `[instance] url` > the signed-in account
+//! server. The precedence itself lives in
+//! [`aristo_core::auth::data_plane_base`]; this wrapper only gathers
+//! the impure inputs (the real env var + the nearest workspace's
+//! config) and delegates.
+
+use aristo_core::auth::{data_plane_base, ServerUrl};
+
+use crate::workspace::Workspace;
+
+/// Base URL for verify/canon data-plane requests, given the signed-in
+/// account `server` (from resolved credentials).
+///
+/// Reads `ARETTA_API_URL` and the nearest `aristo.toml`'s
+/// `[instance] url` best-effort: a command run outside a workspace (or
+/// with a malformed config) still resolves via env + `server`, so this
+/// never fails. `ARETTA_API_URL` and `[instance] url` take precedence
+/// over `server`, so a repo (or CI) can target a per-repo conductor
+/// without re-authenticating.
+pub(crate) fn resolve_base(server: &ServerUrl) -> String {
+    let env_override = std::env::var("ARETTA_API_URL").ok();
+    let instance = Workspace::find(None)
+        .ok()
+        .and_then(|ws| ws.load_config().instance.url);
+    data_plane_base(env_override.as_deref(), instance.as_deref(), server)
+}

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -7,6 +7,7 @@
 //! for the binary's own glue).
 
 mod commands;
+mod data_plane;
 mod error;
 mod filter;
 /// The nudge/progress engine (Phase 18 #9). Public so the as-yet-unwired

--- a/crates/aristo-cli/tests/canon_list_show_refresh_command.rs
+++ b/crates/aristo-cli/tests/canon_list_show_refresh_command.rs
@@ -59,40 +59,6 @@ results = [
     std::fs::write(fixture_dir.join("match.toml"), body).unwrap();
 }
 
-fn write_entry_fixture(fixture_dir: &Path) {
-    let entry_dir = fixture_dir.join("entry/cell_written_exactly_once_per_page_edit");
-    std::fs::create_dir_all(&entry_dir).unwrap();
-    // Per-scope wire shape (README §L2 "backed_by map per scope"):
-    let body = r#"
-canon_id = "cell_written_exactly_once_per_page_edit"
-version = "v0.2.1"
-active_version = "v0.2.1"
-is_deprecated = false
-canon_version = "v0.2.0"
-canonical_text = "edit_page writes each cell exactly once"
-applies_to = ["fn", "method"]
-category = "concurrency"
-property_type = "safety"
-description = "Standard concurrency invariant for page-edit code paths."
-invariant_sketch = ""
-examples = ["fn edit(target: &mut Page) {}"]
-effective_scopes = [":vanilla"]
-
-[backed_by]
-":vanilla" = "specialized neural checker"
-
-[prefix_tier_by_scope]
-":vanilla" = "aristos:"
-
-[references]
-literature = ["Lamport, \"Concurrent Reading and Writing\" (CACM 20:11, 1977)"]
-related_entries = ["balance_no_duplicate_cells"]
-external = []
-"#;
-    std::fs::write(entry_dir.join("active.toml"), body).unwrap();
-    std::fs::write(entry_dir.join("v0.2.1.toml"), body).unwrap();
-}
-
 const SOURCE: &str = r#"
 #[aristo::intent(
     "each cell should be written exactly once per page edit",
@@ -192,69 +158,28 @@ fn list_after_accept_shows_accepted_match() {
     );
 }
 
-// ─── canon show ──────────────────────────────────────────────────────────
+// ─── canon show (coming soon) ─────────────────────────────────────────────
 
 #[test]
-fn show_renders_canon_entry_detail_from_fixture() {
+fn show_reports_coming_soon() {
+    // `canon show` is deferred (coming soon) pending the per-instance
+    // data-plane rework: it makes no canon-API call and no longer
+    // depends on auth or a fixture — any invocation reports the
+    // NotImplemented deferral (exit 64).
     let ws = setup_workspace(SOURCE);
-    let fixture = ws.path().join("fixtures/canon");
-    write_match_fixture(&fixture);
-    write_entry_fixture(&fixture);
-
-    let out = aristo_in(ws.path())
-        .env("ARISTO_CANON_FIXTURE", &fixture)
-        .args(["canon", "show", "cell_written_exactly_once_per_page_edit"])
-        .output()
-        .unwrap();
-    assert!(
-        out.status.success(),
-        "show failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("canon entry:"), "got: {stdout}");
-    assert!(stdout.contains("v0.2.1"), "got: {stdout}");
-    assert!(stdout.contains("concurrency"), "got: {stdout}");
-    assert!(
-        stdout.contains("safety"),
-        "expected property_type; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("specialized neural checker"),
-        "expected backed_by; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("Standard concurrency invariant"),
-        "expected description; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("example shape"),
-        "expected example shape; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("Lamport"),
-        "expected literature reference; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("balance_no_duplicate_cells"),
-        "expected related entry; got: {stdout}"
-    );
-}
-
-#[test]
-fn show_without_auth_and_no_fixture_refuses() {
-    let ws = setup_workspace(SOURCE);
-    // No ARISTO_CANON_FIXTURE env var, no token: show must refuse.
     let out = aristo_in(ws.path())
         .args(["canon", "show", "anything"])
         .output()
         .unwrap();
-    assert!(!out.status.success());
+    assert!(
+        !out.status.success(),
+        "coming-soon command must exit non-zero"
+    );
+    assert_eq!(out.status.code(), Some(64), "NotImplemented exit code");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("authentication") || stderr.contains("login"),
-        "expected auth diagnostic; got: {stderr}"
+        stderr.contains("canon show") && stderr.contains("not implemented yet"),
+        "expected coming-soon diagnostic; got: {stderr}"
     );
 }
 

--- a/crates/aristo-cli/tests/canon_unbind_request_verify_command.rs
+++ b/crates/aristo-cli/tests/canon_unbind_request_verify_command.rs
@@ -57,17 +57,6 @@ results = [
     std::fs::write(fixture_dir.join("match.toml"), body).unwrap();
 }
 
-fn write_request_verify_fixture(fixture_dir: &Path, status: &str) {
-    std::fs::create_dir_all(fixture_dir).unwrap();
-    let body = format!(
-        r#"
-status = "{status}"
-canon_id = "cell_written_exactly_once_per_page_edit"
-"#
-    );
-    std::fs::write(fixture_dir.join("request-verify.toml"), body).unwrap();
-}
-
 const SOURCE: &str = r#"
 #[aristo::intent(
     "each cell should be written exactly once per page edit",
@@ -176,84 +165,27 @@ fn unbind_non_canon_bound_id_errors() {
     );
 }
 
-// ─── canon request-verify ────────────────────────────────────────────────
+// ─── canon request-verify (coming soon) ──────────────────────────────────
 
 #[test]
-fn request_verify_submitted_status_renders_first_submission_message() {
-    let ws = setup_workspace(SOURCE);
-    let fixture = ws.path().join("fixtures/canon");
-    write_request_verify_fixture(&fixture, "submitted");
-
-    let out = aristo_in(ws.path())
-        .env("ARISTO_CANON_FIXTURE", &fixture)
-        .args([
-            "canon",
-            "request-verify",
-            "cell_written_exactly_once_per_page_edit",
-            "--notes",
-            "critical for our audit pipeline",
-        ])
-        .output()
-        .unwrap();
-    assert!(
-        out.status.success(),
-        "request-verify failed: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains("demand signal recorded"),
-        "expected submitted message; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("cell_written_exactly_once_per_page_edit"),
-        "got: {stdout}"
-    );
-}
-
-#[test]
-fn request_verify_updated_status_renders_updated_message() {
-    let ws = setup_workspace(SOURCE);
-    let fixture = ws.path().join("fixtures/canon");
-    std::fs::create_dir_all(&fixture).unwrap();
-    std::fs::write(
-        fixture.join("request-verify.toml"),
-        r#"
-status = "updated"
-canon_id = "foo_bar"
-previously_submitted_at = "2026-04-01T12:00:00Z"
-"#,
-    )
-    .unwrap();
-
-    let out = aristo_in(ws.path())
-        .env("ARISTO_CANON_FIXTURE", &fixture)
-        .args(["canon", "request-verify", "foo_bar"])
-        .output()
-        .unwrap();
-    assert!(out.status.success());
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains("updated"),
-        "expected updated message; got: {stdout}"
-    );
-    assert!(
-        stdout.contains("2026-04-01"),
-        "expected prior timestamp; got: {stdout}"
-    );
-}
-
-#[test]
-fn request_verify_without_auth_and_no_fixture_refuses() {
+fn request_verify_reports_coming_soon() {
+    // `canon request-verify` is deferred (coming soon) pending the
+    // per-instance data-plane rework: it makes no canon-API call and no
+    // longer depends on auth or a fixture — any invocation reports the
+    // NotImplemented deferral (exit 64).
     let ws = setup_workspace(SOURCE);
     let out = aristo_in(ws.path())
         .args(["canon", "request-verify", "anything"])
         .output()
         .unwrap();
-    assert!(!out.status.success());
+    assert!(
+        !out.status.success(),
+        "coming-soon command must exit non-zero"
+    );
+    assert_eq!(out.status.code(), Some(64), "NotImplemented exit code");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("authentication") || stderr.contains("login"),
-        "got: {stderr}"
+        stderr.contains("canon request-verify") && stderr.contains("not implemented yet"),
+        "expected coming-soon diagnostic; got: {stderr}"
     );
 }

--- a/crates/aristo-core/src/auth/mod.rs
+++ b/crates/aristo-core/src/auth/mod.rs
@@ -46,7 +46,7 @@ pub use error::AuthError;
 pub use git::derive_repo_full_name;
 pub use oauth::{oauth_exchange, oauth_start, CliTokenResponse, GitHubUser, OAuthInit};
 pub use resolve::{resolve, resolve_full, resolve_full_with, resolve_with, ResolvedCreds, ENV_VAR};
-pub use server::ServerUrl;
+pub use server::{data_plane_base, ServerUrl};
 pub use store::{
     clear, clear_with, clear_with_home, config_dir, credentials_path, save, save_full,
     save_full_with, save_with, save_with_home, CredentialsRecord, CREDENTIALS_FILENAME,

--- a/crates/aristo-core/src/auth/server.rs
+++ b/crates/aristo-core/src/auth/server.rs
@@ -75,6 +75,56 @@ impl std::fmt::Display for ServerUrl {
     }
 }
 
+/// Resolve the base URL for **data-plane** requests — verify-session
+/// dispatch and canon match. Precedence, highest first:
+///
+/// 1. `env_override` — the `ARETTA_API_URL` env var (CI / test /
+///    staging redirect). Returned verbatim, preserving the prior
+///    `env::var(...).unwrap_or_else(...)` behavior at the call sites.
+/// 2. `instance` — the project's `[instance] url` from `aristo.toml`,
+///    normalized through [`ServerUrl::parse`] (a bare host gets
+///    `https://`, a trailing `/` is stripped). Blank/whitespace is
+///    ignored.
+/// 3. `server` — the signed-in account's server; its default already
+///    resolves to `https://code.aretta.ai`, so it is also the final
+///    fallback.
+///
+/// This is the **data plane**, distinct from the auth/control plane:
+/// the `arta_*` token is minted against `server`, but verified-data
+/// requests are addressed here. Env and config take precedence so a
+/// repo can pin its data plane to a per-repo conductor
+/// (`https://<slug>.aretta.ai`) without re-authenticating.
+///
+/// Kept pure — env is passed in, not read here — so it is
+/// unit-testable under the workspace's `unsafe_code` ban on
+/// `std::env::set_var`.
+#[aristo::intent(
+    "Data-plane base-URL precedence is exactly ARETTA_API_URL (env) > \
+     aristo.toml [instance] url > the account server, in that order and \
+     no other. The env override is returned verbatim (preserving the \
+     prior override behavior and CI/test redirects); the [instance] url \
+     is normalized via ServerUrl::parse; server.as_str() is the final \
+     fallback (its default is code.aretta.ai). Reordering these tiers, \
+     or normalizing or dropping the verbatim env override, would \
+     silently misroute verify and canon-match requests to the wrong \
+     Aretta deployment.",
+    verify = "neural",
+    id = "data_plane_base_precedence"
+)]
+pub fn data_plane_base(
+    env_override: Option<&str>,
+    instance: Option<&str>,
+    server: &ServerUrl,
+) -> String {
+    if let Some(v) = env_override {
+        return v.to_string();
+    }
+    if let Some(inst) = instance.map(str::trim).filter(|s| !s.is_empty()) {
+        return ServerUrl::parse(inst).as_str().to_string();
+    }
+    server.as_str().to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +208,38 @@ mod tests {
             format!("{}", ServerUrl::Custom("https://x.example.com".into())),
             "https://x.example.com"
         );
+    }
+
+    #[test]
+    fn data_plane_base_env_override_wins_verbatim() {
+        // ARETTA_API_URL (passed in) beats both instance and server, and
+        // is returned verbatim — no normalization — so CI/test redirects
+        // behave exactly as before.
+        let s = data_plane_base(
+            Some("https://ci.example.com"),
+            Some("https://turso.aretta.ai"),
+            &ServerUrl::Prod,
+        );
+        assert_eq!(s, "https://ci.example.com");
+    }
+
+    #[test]
+    fn data_plane_base_instance_beats_server_and_is_normalized() {
+        // No env override: the [instance] url wins over the account
+        // server, and a bare host + trailing slash is normalized.
+        let s = data_plane_base(None, Some("turso.aretta.ai/"), &ServerUrl::Prod);
+        assert_eq!(s, "https://turso.aretta.ai");
+    }
+
+    #[test]
+    fn data_plane_base_blank_instance_is_ignored() {
+        let s = data_plane_base(None, Some("   "), &ServerUrl::Dev);
+        assert_eq!(s, "https://dev.aretta.ai");
+    }
+
+    #[test]
+    fn data_plane_base_falls_back_to_server() {
+        let s = data_plane_base(None, None, &ServerUrl::Prod);
+        assert_eq!(s, "https://code.aretta.ai");
     }
 }

--- a/crates/aristo-core/src/config/mod.rs
+++ b/crates/aristo-core/src/config/mod.rs
@@ -64,6 +64,31 @@ pub struct ConfigFile {
     pub canon: CanonConfig,
     #[serde(default)]
     pub nudges: NudgesConfig,
+    #[serde(default)]
+    pub instance: InstanceConfig,
+}
+
+// ─── [instance] ────────────────────────────────────────────────────────────
+
+/// `[instance]` — pins this project's **data-plane** requests (verify
+/// session dispatch + canon match) to a specific Aretta deployment,
+/// e.g. a per-repo conductor at `https://<slug>.aretta.ai`. Absent →
+/// data-plane requests fall back to the signed-in account server
+/// (default `https://code.aretta.ai`). `ARETTA_API_URL` (env)
+/// overrides this for CI / tests.
+///
+/// Distinct from the auth/control-plane server the `arta_*` token is
+/// minted against (persisted in the credentials file): the token
+/// authenticates the request; `url` decides where verified-data
+/// requests are sent.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InstanceConfig {
+    /// Base URL of the per-repo Aretta instance (e.g.
+    /// `https://turso.aretta.ai`). Normalized like the `--server`
+    /// flag: a bare host gets `https://`, a trailing `/` is stripped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 // ─── [verify] ──────────────────────────────────────────────────────────────
@@ -531,6 +556,7 @@ mod tests {
         assert!((config.canon.threshold_stamp - 0.85).abs() < f64::EPSILON);
         assert!((config.canon.threshold_critique - 0.65).abs() < f64::EPSILON);
         assert_eq!(config.nudges.aggressiveness, Aggressiveness::Medium);
+        assert!(config.instance.url.is_none());
     }
 
     #[test]
@@ -694,6 +720,21 @@ threshold = 200
     }
 
     #[test]
+    fn instance_section_round_trips() {
+        let config: ConfigFile =
+            toml::from_str("[instance]\nurl = \"https://turso.aretta.ai\"\n").unwrap();
+        assert_eq!(
+            config.instance.url.as_deref(),
+            Some("https://turso.aretta.ai")
+        );
+        // Absent [instance] → None.
+        let empty: ConfigFile = toml::from_str("").unwrap();
+        assert!(empty.instance.url.is_none());
+        // Unknown key under [instance] is rejected (deny_unknown_fields).
+        assert!(toml::from_str::<ConfigFile>("[instance]\nhost = \"x\"\n").is_err());
+    }
+
+    #[test]
     fn full_config_round_trips() {
         let mut config = ConfigFile::default();
         config.verify.default_method = Some(VerifyMethod::Full);
@@ -714,6 +755,7 @@ threshold = 200
         config.corpus.contribute = true;
         config.doc.commit_artifacts = false;
         config.doc.position = DocPosition::After;
+        config.instance.url = Some("https://turso.aretta.ai".into());
 
         let toml_text = toml::to_string(&config).unwrap();
         let back: ConfigFile = toml::from_str(&toml_text).unwrap();

--- a/schemas/aristo-config.schema.json
+++ b/schemas/aristo-config.schema.json
@@ -45,6 +45,14 @@
         }
       ]
     },
+    "instance": {
+      "default": {},
+      "allOf": [
+        {
+          "$ref": "#/definitions/InstanceConfig"
+        }
+      ]
+    },
     "lint": {
       "default": {
         "pre_commit": "check",
@@ -244,6 +252,20 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "InstanceConfig": {
+      "description": "`[instance]` — pins this project's **data-plane** requests (verify session dispatch + canon match) to a specific Aretta deployment, e.g. a per-repo conductor at `https://<slug>.aretta.ai`. Absent → data-plane requests fall back to the signed-in account server (default `https://code.aretta.ai`). `ARETTA_API_URL` (env) overrides this for CI / tests.\n\nDistinct from the auth/control-plane server the `arta_*` token is minted against (persisted in the credentials file): the token authenticates the request; `url` decides where verified-data requests are sent.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Base URL of the per-repo Aretta instance (e.g. `https://turso.aretta.ai`). Normalized like the `--server` flag: a bare host gets `https://`, a trailing `/` is stripped.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Lets a repo pin its **data-plane** requests (verify session dispatch + canon match) to a specific Aretta deployment — e.g. a per-repo conductor at `https://<slug>.aretta.ai` — via a committed `aristo.toml` `[instance] url`, so a local `aristo verify` / `stamp` routes to the right instance without `ARETTA_API_URL` in the environment or a global `aristo auth login --server`. Auth/login is untouched.

### Why

`aristo-cli` resolves its request base as `ARETTA_API_URL (env) || creds.server`, defaulting to `code.aretta.ai`. CI sets the `ARETTA_API_URL` repo Variable to the per-repo conductor, but a **local** `aristo verify` has nothing to read, so it falls back to the default (the wrong instance). `creds.server` is global-per-machine (and forced to Prod when the token comes from `ARETTA_TOKEN`), so it can't carry a per-repo target. This adds a committed, per-repo knob.

The per-repo conductor is a **data-plane superset** of the CLI surface — it serves `/verify/sessions` and a real `/canon/match` — but is **not** an auth issuer (it only introspects a proxy-minted Bearer). So auth stays central; only the data plane moves.

## Changes (3 commits)

1. **`feat(cli)` canon show / request-verify → "coming soon"** — the two commands now return `CliError::NotImplemented` (exit 64) instead of calling `GET /canon/entry` / `POST /canon/request-verify` (both conductor stubs). This leaves the only data-plane endpoints the CLI hits as `/canon/match` + `/verify/sessions`, both real on a per-repo conductor. Integration tests updated to the deferral; orphaned fixtures dropped.
2. **`feat(core)` `[instance] url` + resolver** — new `aristo.toml` `[instance]` section; pure `data_plane_base(env, instance, server)` with precedence **env `ARETTA_API_URL` > `[instance] url` > account server** (env verbatim; instance normalized via `ServerUrl::parse`). Schema regenerated (schema-sync gate); unit-tested; precedence annotated with `#[aristo::intent]`.
3. **`feat(cli)` wire it in** — `resolve_base` loads the nearest `aristo.toml` `[instance] url` best-effort and is adopted at verify dispatch, verify `--view`, the `/canon/match` caller (stamp / refresh), and canon migrate. Replaces the four copy-pasted base-URL sites with the single wrapper.

## Behavior / compatibility

- **Auth/login unchanged** — the `arta_*` token is still minted against the account server; this only redirects verified-data requests.
- `ARETTA_API_URL` still overrides (CI path unchanged, verbatim).
- No change when `[instance]` is absent.

## Follow-up (out of scope)

- `docs/ROADMAP.md` is silent on this (off-roadmap, user-directed); a ROADMAP line + a `DECISIONS.md` entry recording the data-plane / `[instance]` precedent would be good hygiene.
- The conductor's `/canon/entry` + `/canon/request-verify` remain stubs; re-enabling `canon show` / `request-verify` is deferred pending that rework.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
