### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-07-01
+
 ### Added
 - config: `aristo.toml` gains an `[instance]` section with a `url` key that pins this project's data-plane requests to a specific Aretta deployment (e.g. a per-repo conductor at `https://<slug>.aretta.ai`). Resolution precedence is `ARETTA_API_URL` (env) > `[instance] url` > the signed-in account server; the value is normalized like `--server` (bare host → `https://`, trailing `/` stripped). Auth/login is unchanged — the token is still minted against the account server; this only redirects where verified-data requests go.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,14 +102,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aristo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aristo-macros",
 ]
 
 [[package]]
 name = "aristo-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aristo",
  "globset",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aristo-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aristo",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/aretta-ai/aristo"
@@ -26,13 +26,13 @@ keywords = ["annotation", "verification", "intent", "proof", "sdk"]
 # Each crate's manifest sets `readme = "../../README.md"` directly.
 
 [workspace.dependencies]
-aristo = { path = "crates/aristo", version = "0.4.0" }
-aristo-core = { path = "crates/aristo-core", version = "0.4.0" }
+aristo = { path = "crates/aristo", version = "0.4.1" }
+aristo-core = { path = "crates/aristo-core", version = "0.4.1" }
 # default-features = false at the workspace level so the `aristo` meta-crate
 # can route the user's `aristo_check` feature through (member crates that
 # want defaults on can override per-dep, and the macro crate itself has
 # its own default-on for direct `cargo test` runs).
-aristo-macros = { path = "crates/aristo-macros", version = "0.4.0", default-features = false }
+aristo-macros = { path = "crates/aristo-macros", version = "0.4.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
Release commit for **v0.4.1** — the per-repo Aristo data-plane routing feature (`[instance] url`) merged in #59, now version-bumped for publish.

Diff vs main = the version bump only (the feature commits are already on main via #59):
- `[workspace.package]` + internal dep pins `0.4.0` → `0.4.1`
- `Cargo.lock` refreshed
- CHANGELOG `[Unreleased]` → `[0.4.1] — 2026-07-01`

Merging this to `main` then pushing tag `v0.4.1` triggers `release.yml` (crates.io Trusted Publishing / OIDC) to publish all four crates. §6 checks (fmt/clippy/test) green on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)