### PR TITLE
feat: aristo canon catalogue — download the corpus (+ skill, + confidential notice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 - cli: `aristo canon catalogue` downloads the full canon catalogue from the data plane to a gitignored local snapshot at `.aristo/catalogue.json` (logged-in only; targets the per-repo conductor via `[instance] url`) and prints a summary (counts by category + backed/unbacked). `aristo init` now gitignores `.aristo/catalogue.json`.
 - cli: new `aristo-catalogue` skill (shipped by `aristo install-skills`) — teaches an agent to run `aristo canon catalogue` and browse/search the downloaded `.aristo/catalogue.json` snapshot to discover bindable canon entries, and makes explicit that the snapshot is a gitignored local cache (never commit it; re-run to refresh).
 - core/cli: the downloaded catalogue snapshot now carries a server-stamped proprietary/confidential `notice` at the top of `.aristo/catalogue.json` (and `aristo canon catalogue` echoes it) — marking the corpus as licensed-partner-internal, not for external/OSS commit. `CanonCatalogue` gains a `notice` field (serde-default, backward-compatible with conductors that don't send it).
+- cli: the `aristo-authoring` and `aristo-intent-suggestions` skills now route to `aristo canon catalogue` — authoring consults the catalogue for a reusable canon entry before writing novel prose (canon reuse over one-off claims); suggestions points to it for browsing the full corpus vs the per-intent matches it reviews.
 
 ## [0.4.1] — 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+### Added
+- core: `CanonClient::catalogue()` + the `CanonCatalogue` wire type — a `GET /catalogue` client method that fetches the full active canon corpus catalogue from the data plane (one entry per canon id, closed-IP fields stripped server-side). Backs the new `aristo canon catalogue` command.
+
 ## [0.4.1] — 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 ### Added
 - core: `CanonClient::catalogue()` + the `CanonCatalogue` wire type — a `GET /catalogue` client method that fetches the full active canon corpus catalogue from the data plane (one entry per canon id, closed-IP fields stripped server-side). Backs the new `aristo canon catalogue` command.
 - cli: `aristo canon catalogue` downloads the full canon catalogue from the data plane to a gitignored local snapshot at `.aristo/catalogue.json` (logged-in only; targets the per-repo conductor via `[instance] url`) and prints a summary (counts by category + backed/unbacked). `aristo init` now gitignores `.aristo/catalogue.json`.
+- cli: new `aristo-catalogue` skill (shipped by `aristo install-skills`) — teaches an agent to run `aristo canon catalogue` and browse/search the downloaded `.aristo/catalogue.json` snapshot to discover bindable canon entries, and makes explicit that the snapshot is a gitignored local cache (never commit it; re-run to refresh).
 
 ## [0.4.1] — 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ### Added
 - core: `CanonClient::catalogue()` + the `CanonCatalogue` wire type — a `GET /catalogue` client method that fetches the full active canon corpus catalogue from the data plane (one entry per canon id, closed-IP fields stripped server-side). Backs the new `aristo canon catalogue` command.
+- cli: `aristo canon catalogue` downloads the full canon catalogue from the data plane to a gitignored local snapshot at `.aristo/catalogue.json` (logged-in only; targets the per-repo conductor via `[instance] url`) and prints a summary (counts by category + backed/unbacked). `aristo init` now gitignores `.aristo/catalogue.json`.
 
 ## [0.4.1] — 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 - core: `CanonClient::catalogue()` + the `CanonCatalogue` wire type — a `GET /catalogue` client method that fetches the full active canon corpus catalogue from the data plane (one entry per canon id, closed-IP fields stripped server-side). Backs the new `aristo canon catalogue` command.
 - cli: `aristo canon catalogue` downloads the full canon catalogue from the data plane to a gitignored local snapshot at `.aristo/catalogue.json` (logged-in only; targets the per-repo conductor via `[instance] url`) and prints a summary (counts by category + backed/unbacked). `aristo init` now gitignores `.aristo/catalogue.json`.
 - cli: new `aristo-catalogue` skill (shipped by `aristo install-skills`) — teaches an agent to run `aristo canon catalogue` and browse/search the downloaded `.aristo/catalogue.json` snapshot to discover bindable canon entries, and makes explicit that the snapshot is a gitignored local cache (never commit it; re-run to refresh).
+- core/cli: the downloaded catalogue snapshot now carries a server-stamped proprietary/confidential `notice` at the top of `.aristo/catalogue.json` (and `aristo canon catalogue` echoes it) — marking the corpus as licensed-partner-internal, not for external/OSS commit. `CanonCatalogue` gains a `notice` field (serde-default, backward-compatible with conductors that don't send it).
 
 ## [0.4.1] — 2026-07-01
 

--- a/crates/aristo-cli/src/commands/canon/catalogue.rs
+++ b/crates/aristo-cli/src/commands/canon/catalogue.rs
@@ -1,0 +1,106 @@
+//! `aristo canon catalogue` — download the canon catalogue (the full
+//! list of available canon entries) from the data plane to a local,
+//! gitignored snapshot at `.aristo/catalogue.json`, then print a
+//! summary.
+//!
+//! Logged-in only: it presents the account's Bearer token to the
+//! per-repo conductor's `GET /catalogue` (Read-gated), addressed via
+//! the resolved data-plane base (`[instance] url` when set). The
+//! download is a regenerable local cache — `aristo init` gitignores it
+//! (see `ARISTO_GITIGNORE_ENTRIES`) — so agents can browse/search the
+//! corpus offline without re-fetching, and it is never committed.
+
+use std::collections::BTreeMap;
+
+use aristo_core::canon::{
+    CanonCatalogue, CanonClient, CanonError, HttpCanonClient, MockCanonClient,
+};
+
+use crate::commands::index::workspace_or_error;
+use crate::{CliError, CliResult};
+
+/// Workspace-relative path of the downloaded snapshot. Kept in sync
+/// with the `.aristo/catalogue.json` entry in `init`'s
+/// `ARISTO_GITIGNORE_ENTRIES`.
+const CATALOGUE_REL: &str = ".aristo/catalogue.json";
+
+pub(crate) fn run() -> CliResult<()> {
+    let ws = workspace_or_error()?;
+
+    // Client selection mirrors the canon runner/migrate: fixture (tests)
+    // wins, then authenticated HTTP, else a logged-out error.
+    let client: Box<dyn CanonClient> = if let Some(mock) = MockCanonClient::from_env() {
+        Box::new(mock)
+    } else {
+        match aristo_core::auth::resolve_full() {
+            Ok(creds) => {
+                let base_url = crate::data_plane::resolve_base(&creds.server);
+                Box::new(HttpCanonClient::new(base_url, &creds.token))
+            }
+            Err(_) => {
+                return Err(CliError::Other {
+                    message: "canon catalogue requires authentication.\n  \
+                              Run `aristo auth login` first."
+                        .into(),
+                    exit_code: 1,
+                });
+            }
+        }
+    };
+
+    let catalogue = client.catalogue().map_err(canon_error_to_cli)?;
+
+    // Persist the snapshot (pretty JSON) to the gitignored local cache.
+    let aristo_dir = ws.aristo_dir();
+    std::fs::create_dir_all(&aristo_dir).map_err(CliError::Io)?;
+    let out_path = aristo_dir.join("catalogue.json");
+    let json = serde_json::to_string_pretty(&catalogue).map_err(|e| CliError::Other {
+        message: format!("serializing catalogue: {e}"),
+        exit_code: 1,
+    })?;
+    std::fs::write(&out_path, json).map_err(CliError::Io)?;
+
+    print_summary(&catalogue);
+    Ok(())
+}
+
+fn print_summary(catalogue: &CanonCatalogue) {
+    let total = catalogue.entries.len();
+    println!(
+        "ok: downloaded {total} canon entr{} to {CATALOGUE_REL} (gitignored local snapshot)",
+        if total == 1 { "y" } else { "ies" }
+    );
+    if total == 0 {
+        println!(
+            "   note: the catalogue is empty — the instance has no canon corpus configured, \
+             or `[instance] url` isn't set to a conductor."
+        );
+        return;
+    }
+    let backed = catalogue
+        .entries
+        .iter()
+        .filter(|e| e.tier_label() == "aristos")
+        .count();
+    println!(
+        "   backed (aristos): {backed} · unbacked (kanon): {}",
+        total - backed
+    );
+    // Per-category counts, sorted, so the readout is browsable at a glance.
+    let mut by_category: BTreeMap<&str, usize> = BTreeMap::new();
+    for e in &catalogue.entries {
+        *by_category.entry(e.category.as_str()).or_default() += 1;
+    }
+    println!("   by category:");
+    for (cat, n) in &by_category {
+        println!("     {cat}: {n}");
+    }
+    println!("   read/search the full snapshot at {CATALOGUE_REL}");
+}
+
+fn canon_error_to_cli(e: CanonError) -> CliError {
+    CliError::Other {
+        message: format!("canon catalogue error: {e}"),
+        exit_code: 1,
+    }
+}

--- a/crates/aristo-cli/src/commands/canon/catalogue.rs
+++ b/crates/aristo-cli/src/commands/canon/catalogue.rs
@@ -65,6 +65,14 @@ pub(crate) fn run() -> CliResult<()> {
 }
 
 fn print_summary(catalogue: &CanonCatalogue) {
+    // Echo the server-stamped confidential notice up front (it is also
+    // the first field of the written snapshot).
+    if !catalogue.notice.is_empty() {
+        for line in &catalogue.notice {
+            println!("{line}");
+        }
+        println!();
+    }
     let total = catalogue.entries.len();
     println!(
         "ok: downloaded {total} canon entr{} to {CATALOGUE_REL} (gitignored local snapshot)",

--- a/crates/aristo-cli/src/commands/canon/mod.rs
+++ b/crates/aristo-cli/src/commands/canon/mod.rs
@@ -10,6 +10,7 @@
 //! cache pending → accepted move for an accepted canon match.
 
 pub(crate) mod accept;
+pub(crate) mod catalogue;
 pub(crate) mod list;
 pub(crate) mod migrate;
 pub(crate) mod refresh;

--- a/crates/aristo-cli/src/commands/init.rs
+++ b/crates/aristo-cli/src/commands/init.rs
@@ -218,6 +218,7 @@ pub(crate) fn run(_force: bool, ci: bool, ci_verify: bool, hook: bool) -> CliRes
 /// it stays tracked and propagates to CI and fresh clones.
 const ARISTO_GITIGNORE_ENTRIES: &[&str] = &[
     ".aristo/index.toml",
+    ".aristo/catalogue.json",
     ".aristo/sessions/",
     ".aristo/nudge-state.toml",
     ".aristo/verify-queue/",

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -773,6 +773,12 @@ pub(crate) enum CanonAction {
     /// application is planned.
     Migrate,
 
+    /// Download the canon catalogue (the full list of available canon
+    /// entries) to `.aristo/catalogue.json` — a gitignored local
+    /// snapshot — and print a summary. Requires authentication; served
+    /// by the per-repo conductor addressed via `[instance] url`.
+    Catalogue,
+
     /// List or inspect queued §17 proof-tree suggestions (the related
     /// canon entries dragged in alongside a primary match). Read-only:
     /// it does not open a review session or mutate the queue. To review
@@ -1083,6 +1089,7 @@ fn dispatch(cmd: Commands) -> CliResult<()> {
                 commands::canon::request_verify::run(&canon_id, notes)
             }
             CanonAction::Migrate => commands::canon::migrate::run(),
+            CanonAction::Catalogue => commands::canon::catalogue::run(),
             CanonAction::Suggestions {
                 objective,
                 counts,

--- a/crates/aristo-cli/src/skills/aristo-authoring.md
+++ b/crates/aristo-cli/src/skills/aristo-authoring.md
@@ -57,6 +57,16 @@ For every candidate annotation, ask:
 
 If both answers to (1) and (2) are no, **don't write the intent.** A perfectly-worded intent that fails the gate still adds noise.
 
+## Reuse before novel: consult the canon catalogue
+
+Once a candidate passes the gate, check whether the shared **canon corpus** already captures the invariant before writing novel prose — binding to an existing entry gives reusable, often verification-backed proof instead of a one-off claim.
+
+```bash
+aristo canon catalogue   # downloads the corpus to .aristo/catalogue.json (gitignored)
+```
+
+Search the snapshot's `canonical_text` / `category` for your invariant. On a hit, either phrase the intent to align with the entry's `canonical_text` (so `aristo stamp` matches + binds it) or bind directly via `id = "kanon:<canon_id>"`; prefer `aristos`-tier entries (verification-backed). No match → write your own. (The snapshot is a proprietary, gitignored local cache — see `/aristo-catalogue`; never commit it.)
+
 ## The shape of a good intent
 
 Write intents as English sentences with the precision of a spec. Closer to POSIX man pages, W3C normative language, Postgres documentation, or TigerBeetle's design docs than to formal logic.

--- a/crates/aristo-cli/src/skills/aristo-catalogue.md
+++ b/crates/aristo-cli/src/skills/aristo-catalogue.md
@@ -24,6 +24,8 @@ This requires sign-in — if it reports "requires authentication", tell the user
 
 **This file is a GITIGNORED local cache.** `aristo init` adds `.aristo/catalogue.json` to `.gitignore`; it is a regenerable snapshot, **never committed**. Do NOT `git add` it, do NOT treat it as a tracked artifact or reference it in committed code/docs, and re-run `aristo canon catalogue` to refresh it. If the command reports 0 entries, the instance has no canon corpus configured (or `[instance] url` isn't pointed at a conductor) — say so; never fabricate entries.
 
+**The snapshot's first field is a server-stamped `notice`** — a proprietary/confidential marking (this corpus is licensed to the design partner for internal use only). It is authoritative; surface it if the user asks about sharing the catalogue, never strip it, and treat it as a hard signal that this file must not leave the organization or land in any external/OSS repo.
+
 ## Step 2 — read / search the snapshot
 
 Read `.aristo/catalogue.json` and answer the user's question from it. Each entry has:

--- a/crates/aristo-cli/src/skills/aristo-catalogue.md
+++ b/crates/aristo-cli/src/skills/aristo-catalogue.md
@@ -1,0 +1,43 @@
+---
+name: aristo-catalogue
+description: Download and browse the Aristo canon catalogue — the full corpus of canon entries (reusable invariants/properties) you can bind annotations against. Runs `aristo canon catalogue` (logged-in only) to fetch this project's instance corpus to a gitignored local snapshot at `.aristo/catalogue.json`, then reads/searches that file to answer "what canon entries exist for X?" / "is there a canon entry about Y?" / "what can I bind to?". Read-only w.r.t. source; the snapshot is a local cache, never committed.
+sdk_version: {{SDK_VERSION}}
+---
+
+# Aristo catalogue
+
+When the user invokes this skill (typically by typing `/aristo-catalogue`, or asking "what canon entries are available?", "browse the canon catalogue", "is there a canon entry about <topic>?", "what can I bind against?"), fetch the canon catalogue and answer from it.
+
+The catalogue is the corpus of **canon entries** — the reusable, curated invariants/properties an annotation can bind to (the `aristos:` / `kanon:` tiers). This skill is **read-only** with respect to your source: it downloads a snapshot and reads it; it never stamps, binds, or edits code.
+
+## Step 1 — download the snapshot (logged-in)
+
+```bash
+aristo canon catalogue
+```
+
+This requires sign-in — if it reports "requires authentication", tell the user to run `aristo auth login` and stop. It fetches the catalogue from this project's Aristo instance (the per-repo conductor when `[instance] url` is set in `aristo.toml`, otherwise the default server) and writes it to:
+
+```
+.aristo/catalogue.json
+```
+
+**This file is a GITIGNORED local cache.** `aristo init` adds `.aristo/catalogue.json` to `.gitignore`; it is a regenerable snapshot, **never committed**. Do NOT `git add` it, do NOT treat it as a tracked artifact or reference it in committed code/docs, and re-run `aristo canon catalogue` to refresh it. If the command reports 0 entries, the instance has no canon corpus configured (or `[instance] url` isn't pointed at a conductor) — say so; never fabricate entries.
+
+## Step 2 — read / search the snapshot
+
+Read `.aristo/catalogue.json` and answer the user's question from it. Each entry has:
+
+- `canon_id` — the id to bind against (e.g. `#[aristo::intent(..., id = "kanon:<canon_id>")]`)
+- `canonical_text` — the invariant/property statement
+- `category`, `applies_to` — grouping + the kinds of items it applies to
+- `backed_by` — scopes that back it. Non-empty ⇒ `aristos` tier (verification-backed); empty ⇒ `kanon` tier (description-only)
+- `coverage_level`, `spec_refs` — backing depth + referenced spec ids
+
+To answer "is there a canon entry about X?", search `canonical_text` / `canon_id` / `category` for the topic (substring or fuzzy). Surface the best matches with their `canon_id`, tier (aristos/kanon), and `canonical_text`. When the user is annotating and asks "what should I bind to?", prefer `aristos`-tier entries (verification-backed) whose `canonical_text` matches their intent.
+
+## What this skill does NOT do
+
+- It does NOT stamp, bind, or edit source — use `/aristo-authoring` to write intents and `aristo canon accept` to bind a match.
+- It does NOT commit the snapshot — `.aristo/catalogue.json` is a gitignored local cache; treat it as disposable and refresh with `aristo canon catalogue`.
+- It does NOT run server-side verification — it only reads the downloaded corpus listing.

--- a/crates/aristo-cli/src/skills/aristo-help.md
+++ b/crates/aristo-cli/src/skills/aristo-help.md
@@ -24,6 +24,8 @@ When the user invokes this skill (typically `/aristo-help`, or "what aristo skil
 
 - **`aristo-status`** — a friendly, read-only project readout: tier + score, verification rate, counts, review backlog, pending canon, and the engine's recommended next action. **Benefit:** see where you stand at a glance, with one nudge toward the highest-value next step.
 
+- **`aristo-catalogue`** — download + browse the canon catalogue: the full corpus of canon entries (invariants/properties) you can bind against. Fetches this project's instance corpus to a gitignored local snapshot (`.aristo/catalogue.json`) and searches it to answer "what canon entries exist for X?" / "what should I bind to?". **Benefit:** discover reusable, verification-backed invariants to bind to, without leaving the terminal.
+
 - **`aristo-help`** — this overview.
 
 ## Example scenario flows

--- a/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
+++ b/crates/aristo-cli/src/skills/aristo-intent-suggestions.md
@@ -34,6 +34,8 @@ The skill is the **orchestrator for the whole loop**, not just a suggestions con
 Both are reviewed inside a single **`intent-review`** session, gated by the single-active-session
 guard.
 
+> **Browsing vs matching:** this skill reviews canon *matches/suggestions for intents you already wrote*. To browse the **full corpus** — every available canon entry, matched or not — run `/aristo-catalogue` (`aristo canon catalogue`), which downloads the catalogue to a gitignored snapshot for search/discovery.
+
 ## Step 0 — check for an active review session (FIRST, BEFORE ANY WORK)
 
 Run `aristo session active`. Three cases:

--- a/crates/aristo-cli/src/skills/mod.rs
+++ b/crates/aristo-cli/src/skills/mod.rs
@@ -121,6 +121,11 @@ const INSTRUMENTING: Skill = Skill {
     content: include_str!("aristo-instrumenting.md"),
 };
 
+const CATALOGUE: Skill = Skill {
+    name: "aristo-catalogue",
+    content: include_str!("aristo-catalogue.md"),
+};
+
 const BUNDLED: &[Skill] = &[
     AUTHORING,
     VERIFY,
@@ -130,6 +135,7 @@ const BUNDLED: &[Skill] = &[
     STATUS,
     HELP,
     INSTRUMENTING,
+    CATALOGUE,
 ];
 
 #[cfg(test)]

--- a/crates/aristo-cli/src/skills/mod.rs
+++ b/crates/aristo-cli/src/skills/mod.rs
@@ -152,6 +152,27 @@ mod tests {
     }
 
     #[test]
+    fn authoring_and_suggestions_route_to_the_catalogue() {
+        // The catalogue is woven into the authoring + intent-suggestions
+        // flows as a reuse/discovery step, not just a standalone skill.
+        let authoring = find("aristo-authoring")
+            .expect("aristo-authoring bundled")
+            .resolved_content();
+        assert!(
+            authoring.contains("aristo canon catalogue"),
+            "aristo-authoring must route to the canon catalogue for canon reuse"
+        );
+        let suggestions = find("aristo-intent-suggestions")
+            .expect("aristo-intent-suggestions bundled")
+            .resolved_content();
+        assert!(
+            suggestions.contains("aristo canon catalogue")
+                || suggestions.contains("aristo-catalogue"),
+            "aristo-intent-suggestions must reference the catalogue for full-corpus browsing"
+        );
+    }
+
+    #[test]
     fn future_skill_names_not_yet_bundled() {
         // Sentinels: these skills land in their consuming slices.
         assert!(find("aristo-mine-assertions").is_none()); // slice 24 (deferred)

--- a/crates/aristo-cli/tests/canon_catalogue_command.rs
+++ b/crates/aristo-cli/tests/canon_catalogue_command.rs
@@ -1,0 +1,117 @@
+//! End-to-end test for `aristo canon catalogue` — downloads the canon
+//! catalogue to a gitignored `.aristo/catalogue.json` snapshot via a
+//! fixture, and refuses when logged out.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn aristo_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aristo")
+}
+
+fn aristo_in(workspace: &Path) -> Command {
+    let mut c = Command::new(aristo_bin());
+    c.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        c.env("PATH", path);
+    }
+    #[cfg(target_os = "macos")]
+    if let Ok(p) = std::env::var("DYLD_FALLBACK_LIBRARY_PATH") {
+        c.env("DYLD_FALLBACK_LIBRARY_PATH", p);
+    }
+    let home = workspace.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    c.env("HOME", &home);
+    c.env("XDG_CONFIG_HOME", home.join("xdg"));
+    c.current_dir(workspace);
+    c
+}
+
+fn setup_workspace() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("aristo.toml"), "").unwrap();
+    std::fs::create_dir_all(tmp.path().join(".aristo")).unwrap();
+    tmp
+}
+
+fn write_catalogue_fixture(fixture_dir: &Path) {
+    std::fs::create_dir_all(fixture_dir).unwrap();
+    let body = r#"
+[[entries]]
+canon_id = "foo"
+version = "v0.2.1"
+canonical_text = "edit_page writes each cell exactly once"
+category = "invariants"
+applies_to = ["fn"]
+coverage_level = "tight"
+spec_refs = ["S-001"]
+backed_by = { ":vanilla" = "specialized neural checker" }
+
+[[entries]]
+canon_id = "bar"
+version = "v0.1.0"
+canonical_text = "sequence numbers stay monotonic"
+category = "concurrency"
+applies_to = ["fn"]
+coverage_level = "none"
+spec_refs = []
+backed_by = {}
+"#;
+    std::fs::write(fixture_dir.join("catalogue.toml"), body).unwrap();
+}
+
+#[test]
+fn catalogue_downloads_snapshot_to_gitignored_file() {
+    let ws = setup_workspace();
+    let fixture = ws.path().join("fixtures/canon");
+    write_catalogue_fixture(&fixture);
+
+    let out = aristo_in(ws.path())
+        .env("ARISTO_CANON_FIXTURE", &fixture)
+        .args(["canon", "catalogue"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "catalogue failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("downloaded 2 canon entries"),
+        "expected download summary; got: {stdout}"
+    );
+    assert!(
+        stdout.contains(".aristo/catalogue.json"),
+        "expected the snapshot path; got: {stdout}"
+    );
+
+    // The snapshot file was written and holds both entries + backing.
+    let snapshot = std::fs::read_to_string(ws.path().join(".aristo/catalogue.json")).unwrap();
+    assert!(snapshot.contains("foo"), "snapshot: {snapshot}");
+    assert!(snapshot.contains("bar"), "snapshot: {snapshot}");
+    assert!(
+        snapshot.contains("specialized neural checker"),
+        "snapshot: {snapshot}"
+    );
+}
+
+#[test]
+fn catalogue_without_auth_refuses() {
+    let ws = setup_workspace();
+    // No ARISTO_CANON_FIXTURE, no token: the command must refuse rather
+    // than silently no-op.
+    let out = aristo_in(ws.path())
+        .args(["canon", "catalogue"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("authentication") || stderr.contains("login"),
+        "expected auth diagnostic; got: {stderr}"
+    );
+}

--- a/crates/aristo-core/src/canon/client.rs
+++ b/crates/aristo-core/src/canon/client.rs
@@ -22,7 +22,8 @@
 use std::fmt;
 
 use super::types::{
-    CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody, RequestVerifyResponse,
+    CanonCatalogue, CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody,
+    RequestVerifyResponse,
 };
 
 /// Trait abstracting over the canon API endpoints (`POST /canon/match`,
@@ -55,6 +56,13 @@ pub trait CanonClient: Send + Sync {
     /// canon-strategy.md §CS11.
     fn request_verify(&self, body: &RequestVerifyBody)
         -> Result<RequestVerifyResponse, CanonError>;
+
+    /// Fetch the full active canon catalogue (`GET /catalogue`). One
+    /// entry per canon id at its active version; closed-IP fields are
+    /// stripped server-side. Requires auth (Read capability) and is
+    /// served by a per-repo conductor, addressed via the resolved
+    /// data-plane base.
+    fn catalogue(&self) -> Result<CanonCatalogue, CanonError>;
 }
 
 /// Errors surfaced by [`CanonClient`] methods. Cleaved by recovery

--- a/crates/aristo-core/src/canon/http_client.rs
+++ b/crates/aristo-core/src/canon/http_client.rs
@@ -26,7 +26,8 @@ use ureq::http::Response as HttpResponse;
 
 use super::client::{AuthError, CanonClient, CanonError};
 use super::types::{
-    CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody, RequestVerifyResponse,
+    CanonCatalogue, CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody,
+    RequestVerifyResponse,
 };
 use super::Token;
 
@@ -153,6 +154,11 @@ impl CanonClient for HttpCanonClient {
         body: &RequestVerifyBody,
     ) -> Result<RequestVerifyResponse, CanonError> {
         self.post_json("/canon/request-verify", body)
+    }
+
+    fn catalogue(&self) -> Result<CanonCatalogue, CanonError> {
+        // Top-level conductor route (NOT under `/canon/`).
+        self.get_json("/catalogue")
     }
 }
 

--- a/crates/aristo-core/src/canon/mock_client.rs
+++ b/crates/aristo-core/src/canon/mock_client.rs
@@ -41,7 +41,8 @@ use std::path::{Path, PathBuf};
 
 use super::client::{CanonClient, CanonError};
 use super::types::{
-    CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody, RequestVerifyResponse,
+    CanonCatalogue, CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody,
+    RequestVerifyResponse,
 };
 
 /// Fixture-backed canon client.
@@ -107,6 +108,10 @@ impl CanonClient for MockCanonClient {
         _body: &RequestVerifyBody,
     ) -> Result<RequestVerifyResponse, CanonError> {
         self.load(Path::new("request-verify.toml"))
+    }
+
+    fn catalogue(&self) -> Result<CanonCatalogue, CanonError> {
+        self.load(Path::new("catalogue.toml"))
     }
 }
 
@@ -323,6 +328,51 @@ current_backing = "specialized neural checker"
             resp.current_backing.as_deref(),
             Some("specialized neural checker")
         );
+    }
+
+    #[test]
+    fn catalogue_loads_fixture() {
+        use crate::canon::{CanonCatalogue, CanonCatalogueEntry};
+        let mut backed = std::collections::BTreeMap::new();
+        backed.insert(
+            ":vanilla".to_string(),
+            "specialized neural checker".to_string(),
+        );
+        let cat = CanonCatalogue {
+            entries: vec![
+                CanonCatalogueEntry {
+                    canon_id: "foo".into(),
+                    version: "v0.2.1".into(),
+                    canonical_text: "foo text".into(),
+                    category: "invariants".into(),
+                    applies_to: vec!["fn".into()],
+                    backed_by: backed,
+                    coverage_level: "tight".into(),
+                    spec_refs: vec!["S-001".into()],
+                },
+                CanonCatalogueEntry {
+                    canon_id: "bar".into(),
+                    version: "v0.1.0".into(),
+                    canonical_text: "bar text".into(),
+                    category: "invariants".into(),
+                    applies_to: vec!["fn".into()],
+                    backed_by: std::collections::BTreeMap::new(),
+                    coverage_level: "none".into(),
+                    spec_refs: vec![],
+                },
+            ],
+        };
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("catalogue.toml"),
+            toml::to_string(&cat).unwrap(),
+        )
+        .unwrap();
+        let client = MockCanonClient::new(tmp.path().to_path_buf());
+        let loaded = client.catalogue().unwrap();
+        assert_eq!(loaded, cat);
+        assert_eq!(loaded.entries[0].tier_label(), "aristos");
+        assert_eq!(loaded.entries[1].tier_label(), "kanon");
     }
 
     #[test]

--- a/crates/aristo-core/src/canon/mock_client.rs
+++ b/crates/aristo-core/src/canon/mock_client.rs
@@ -339,6 +339,7 @@ current_backing = "specialized neural checker"
             "specialized neural checker".to_string(),
         );
         let cat = CanonCatalogue {
+            notice: vec![],
             entries: vec![
                 CanonCatalogueEntry {
                     canon_id: "foo".into(),

--- a/crates/aristo-core/src/canon/mod.rs
+++ b/crates/aristo-core/src/canon/mod.rs
@@ -58,7 +58,8 @@ pub use mock_client::MockCanonClient;
 pub use noop_client::NoopCanonClient;
 pub use rewrite::{compute_rewrite, AcceptRewriteRequest, AttributeRewrite, RewriteError};
 pub use types::{
-    synthesize_phase1_linked, AnnotationMatchInput, CanonEntry, CanonMatch, CanonMatchRequest,
-    CanonMatchResponse, ClusterSuggestion, PrefixTier, References, Relationship, RequestVerifyBody,
-    RequestVerifyResponse, SuggestedEntry, VerificationMetadata,
+    synthesize_phase1_linked, AnnotationMatchInput, CanonCatalogue, CanonCatalogueEntry,
+    CanonEntry, CanonMatch, CanonMatchRequest, CanonMatchResponse, ClusterSuggestion, PrefixTier,
+    References, Relationship, RequestVerifyBody, RequestVerifyResponse, SuggestedEntry,
+    VerificationMetadata,
 };

--- a/crates/aristo-core/src/canon/noop_client.rs
+++ b/crates/aristo-core/src/canon/noop_client.rs
@@ -19,7 +19,8 @@
 
 use super::client::{CanonClient, CanonError};
 use super::types::{
-    CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody, RequestVerifyResponse,
+    CanonCatalogue, CanonEntry, CanonMatchRequest, CanonMatchResponse, RequestVerifyBody,
+    RequestVerifyResponse,
 };
 
 /// No-op canon client. Every method returns [`CanonError::NotEnabled`].
@@ -44,6 +45,10 @@ impl CanonClient for NoopCanonClient {
         &self,
         _body: &RequestVerifyBody,
     ) -> Result<RequestVerifyResponse, CanonError> {
+        Err(CanonError::NotEnabled)
+    }
+
+    fn catalogue(&self) -> Result<CanonCatalogue, CanonError> {
         Err(CanonError::NotEnabled)
     }
 }
@@ -84,6 +89,13 @@ mod tests {
                 notes: None,
             })
             .unwrap_err();
+        assert!(matches!(err, CanonError::NotEnabled));
+    }
+
+    #[test]
+    fn catalogue_returns_not_enabled() {
+        let client = NoopCanonClient;
+        let err = client.catalogue().unwrap_err();
         assert!(matches!(err, CanonError::NotEnabled));
     }
 

--- a/crates/aristo-core/src/canon/types.rs
+++ b/crates/aristo-core/src/canon/types.rs
@@ -457,6 +457,54 @@ pub struct RequestVerifyResponse {
     pub previously_submitted_at: Option<String>,
 }
 
+// ─── GET /catalogue ─────────────────────────────────────────────────────────
+
+/// Response for `GET /catalogue` — the full active canon corpus
+/// catalogue (one entry per canon id, at its active version). Closed-IP
+/// fields (alternative phrasings, match signals) are stripped
+/// server-side; this is the browsable trust-card surface. Served by a
+/// per-repo conductor; addressed via the resolved data-plane base.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CanonCatalogue {
+    #[serde(default)]
+    pub entries: Vec<CanonCatalogueEntry>,
+}
+
+/// One catalogue entry: the active version of a canon id (the server
+/// sorts entries by `(category, canon_id)`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CanonCatalogueEntry {
+    pub canon_id: String,
+    pub version: String,
+    pub canonical_text: String,
+    pub category: String,
+    #[serde(default)]
+    pub applies_to: Vec<String>,
+    /// Scopes that back this canon (scope -> backing string). Empty =
+    /// unbacked (the `kanon:` tier).
+    #[serde(default)]
+    pub backed_by: BTreeMap<String, String>,
+    pub coverage_level: String,
+    /// Spec ids (`S-XXX`) this canon references — the join key to the
+    /// coverage map.
+    #[serde(default)]
+    pub spec_refs: Vec<String>,
+}
+
+impl CanonCatalogueEntry {
+    /// Tier label derived from backing, mirroring the dashboard: an
+    /// entry backed by any scope is `aristos`, otherwise `kanon`. The
+    /// wire carries `backed_by`, not a tier field; this is the sole
+    /// derivation point so the CLI and any other consumer agree.
+    pub fn tier_label(&self) -> &'static str {
+        if self.backed_by.is_empty() {
+            "kanon"
+        } else {
+            "aristos"
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -851,5 +899,49 @@ mod tests {
         assert!(json.contains("annotation_text"), "got: {json}");
         assert!(json.contains("applies_to"), "got: {json}");
         assert!(json.contains("confidence_threshold"), "got: {json}");
+    }
+
+    #[test]
+    fn catalogue_tier_label_derives_from_backing() {
+        let mut backed = BTreeMap::new();
+        backed.insert(":vanilla".to_string(), "neural checker".to_string());
+        let backed_entry = CanonCatalogueEntry {
+            canon_id: "a".into(),
+            version: "v0.1.0".into(),
+            canonical_text: "a".into(),
+            category: "invariants".into(),
+            applies_to: vec!["fn".into()],
+            backed_by: backed,
+            coverage_level: "tight".into(),
+            spec_refs: vec!["S-001".into()],
+        };
+        let unbacked_entry = CanonCatalogueEntry {
+            backed_by: BTreeMap::new(),
+            ..backed_entry.clone()
+        };
+        assert_eq!(backed_entry.tier_label(), "aristos");
+        assert_eq!(unbacked_entry.tier_label(), "kanon");
+    }
+
+    #[test]
+    fn catalogue_json_round_trips_and_tolerates_empty() {
+        let cat = CanonCatalogue {
+            entries: vec![CanonCatalogueEntry {
+                canon_id: "a".into(),
+                version: "v0.1.0".into(),
+                canonical_text: "text".into(),
+                category: "invariants".into(),
+                applies_to: vec!["fn".into()],
+                backed_by: BTreeMap::new(),
+                coverage_level: "none".into(),
+                spec_refs: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&cat).unwrap();
+        let back: CanonCatalogue = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, cat);
+        // The server sends {"entries":[]} when no canon dir is configured.
+        let empty: CanonCatalogue = serde_json::from_str(r#"{"entries":[]}"#).unwrap();
+        assert!(empty.entries.is_empty());
     }
 }

--- a/crates/aristo-core/src/canon/types.rs
+++ b/crates/aristo-core/src/canon/types.rs
@@ -466,6 +466,12 @@ pub struct RequestVerifyResponse {
 /// per-repo conductor; addressed via the resolved data-plane base.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct CanonCatalogue {
+    /// Server-stamped proprietary / confidential notice (one line per
+    /// element), written at the top of the downloaded snapshot so the
+    /// marking travels with this proprietary corpus. Empty from servers
+    /// that don't send it (older conductors).
+    #[serde(default)]
+    pub notice: Vec<String>,
     #[serde(default)]
     pub entries: Vec<CanonCatalogueEntry>,
 }
@@ -926,6 +932,7 @@ mod tests {
     #[test]
     fn catalogue_json_round_trips_and_tolerates_empty() {
         let cat = CanonCatalogue {
+            notice: vec!["PROPRIETARY & CONFIDENTIAL".to_string()],
             entries: vec![CanonCatalogueEntry {
                 canon_id: "a".into(),
                 version: "v0.1.0".into(),
@@ -940,8 +947,15 @@ mod tests {
         let json = serde_json::to_string(&cat).unwrap();
         let back: CanonCatalogue = serde_json::from_str(&json).unwrap();
         assert_eq!(back, cat);
-        // The server sends {"entries":[]} when no canon dir is configured.
+        // The notice serializes FIRST (top of the downloaded snapshot).
+        assert!(
+            json.find("notice").unwrap() < json.find("entries").unwrap(),
+            "notice must serialize before entries: {json}"
+        );
+        // The server sends {"entries":[]} when no canon dir is configured,
+        // and the notice defaults to empty for older servers that omit it.
         let empty: CanonCatalogue = serde_json::from_str(r#"{"entries":[]}"#).unwrap();
         assert!(empty.entries.is_empty());
+        assert!(empty.notice.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds **`aristo canon catalogue`** — a logged-in-only command that downloads the canon catalogue (the corpus of bindable canon entries) from the data plane to a **gitignored** local snapshot at `.aristo/catalogue.json` — plus a skill exposing it to agents. The snapshot carries a **server-stamped proprietary/confidential notice** at the top.

## What's here (4 commits)

1. **`feat(core)`** — `CanonClient::catalogue()` (`GET /catalogue`) + the `CanonCatalogue` / `CanonCatalogueEntry` wire types (implemented across the HTTP / noop / mock clients). `tier_label()` derives `aristos`/`kanon` from `backed_by`.
2. **`feat(cli)`** — `aristo canon catalogue` (logged-in only) writes the corpus to `.aristo/catalogue.json` and prints a summary (counts by category + backed/unbacked). Base URL via `data_plane::resolve_base`, so it targets the per-repo conductor when `[instance] url` is set. `aristo init` now gitignores `.aristo/catalogue.json`.
3. **`feat(cli)`** — the `aristo-catalogue` bundled skill (shipped by `aristo install-skills`): teaches an agent to download + browse/search the snapshot to discover bindable canon entries; makes explicit it's a gitignored local cache.
4. **`feat`** — consumes a **server-stamped `notice`**: `CanonCatalogue.notice` (first field, `#[serde(default)]`) is written at the top of the snapshot and echoed by the command; the skill marks it authoritative (never strip it, never let the file leave the org).

## Server side (separate PR in aretta-conductor)

The `notice` is stamped by the conductor's `/catalogue` handler — built server-side with the instance `flavor` as the authorized party — so the marking travels with the proprietary corpus regardless of which client downloads it. This aristo change is **backward-compatible**: conductors that don't send `notice` default it to empty.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are green on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
