### PR TITLE
fix(canon): reconcile canon-matches.toml with source on scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [`CLAUDE.md`](./CLAUDE.md) §3 for the discipline.
 
 ## [Unreleased]
 
+### Fixed
+- cli: `aristo stamp` now reconciles `.aristo/canon-matches.toml` with source — entries for annotations deleted from source are pruned (with an extra warning when the pruned rows carried accepted bindings), and accepted matches on ids that are local (unprefixed) in source are dropped, each with a stderr note. Previously a deleted annotation's entry lingered forever unless you remembered to run `aristo canon unbind` BEFORE deleting (real incident: a removed `aristos:`-bound intent kept showing as a live binding on dashboards mirroring the committed file). The live-id authority is deliberately wider than the index: ids are taken from the raw walk before validation and, when `[index].exclude` is configured, from a re-walk without the excludes — so an annotation that merely fell out of the index (warning skip, exclude glob) is never treated as deleted, and the reconcile skips itself (with a note) when an id fails to parse or the unexcluded walk fails. A dead `aristos:`/`kanon:`-keyed row whose bare id is still live is reported as a demotion and its rejected-match memory is rekeyed, not pruned. `aristo canon unbind` remains the way to unbind a LIVE annotation. Tradeoff: truly deleting an annotation now also drops its cached match-skip and rejected-match memory, so a deleted-then-restored annotation re-matches from scratch. `aristo stamp --check` detects the same drift read-only: once the index sync check passes it dry-runs the reconcile on a clone of the cache (same authority, same skip conditions) and exits non-zero — naming the affected ids — when `canon-matches.toml` is out of sync with source, writing nothing; when the authority is unreliable it prints the same skip note and passes instead of false-failing CI.
+
 ## [0.5.0] — 2026-07-02
 
 ### Added

--- a/crates/aristo-cli/src/commands/stamp.rs
+++ b/crates/aristo-cli/src/commands/stamp.rs
@@ -17,9 +17,12 @@
 //!   `.aristo/archive/proofs/`, never deleted; `--gc` is the only purge.
 //!
 //! - **`--check` CI mode.** Computes everything but does NOT write the index.
-//!   Exits non-zero if the regenerated entries differ from the committed cache.
-//!   (The canonical freshness gate is `aristo verify --audit --strict`, which
-//!   does not need a committed index at all.)
+//!   Exits non-zero if the regenerated entries differ from the committed
+//!   cache, or — once the index is in sync — if a dry-run of the
+//!   canon-matches reconcile finds `.aristo/canon-matches.toml` out of sync
+//!   with source. (The canonical freshness gate is
+//!   `aristo verify --audit --strict`, which does not need a committed index
+//!   at all.)
 //!
 //! Slice 17 deferred the offer-rename UX (interactive promotion of opaque ids
 //! to readable ones); opaque ids assigned by `aristo index` stay opaque until
@@ -127,6 +130,11 @@ pub(crate) fn run(check: bool, skip_canon: bool, refresh_canon: bool, gc: bool) 
             Some(prev) => prev == &index.entries,
         };
         if entries_unchanged {
+            // Index is in sync — now dry-run the canon-matches
+            // reconcile (same authority, same skip conditions, on a
+            // clone) so canon-matches drift fails CI the same way
+            // index drift does. Never writes.
+            check_canon_matches_drift(&ws, &index, &discovered)?;
             println!();
             println!("ok: index is up to date (no rewrite needed).");
             warn_on_counterexamples(&index);
@@ -141,6 +149,16 @@ pub(crate) fn run(check: bool, skip_canon: bool, refresh_canon: bool, gc: bool) 
     }
 
     atomic_write(&ws.index_path(), &toml_text)?;
+
+    // ── Source-authoritative reconcile of .aristo/canon-matches.toml
+    //    against the RAW walk (never against a possibly stale on-disk
+    //    index, and never against the post-validation entry set).
+    //    Runs before the canon step so its early returns
+    //    (--skip-canon, disabled config, cache hit, free tier,
+    //    degraded) can't let stale rows survive; under --check the
+    //    early return above runs the same reconcile as a read-only
+    //    drift check instead (check_canon_matches_drift). ────────────
+    reconcile_canon_matches(&ws, &index, &discovered)?;
 
     // ── Canon-match step (post-index write so the cache is keyed
     //    against the freshly-stamped ids). Skipped under --check so
@@ -198,6 +216,254 @@ fn run_canon_step_for_stamp(
         // Non-fatal — daily loop continues.
     }
     Ok(())
+}
+
+#[aristo::intent(
+    "The canon-matches cache is reconciled on every mutating stamp, at \
+     a point the canon step's early returns cannot skip: rows for \
+     annotations deleted from source are pruned and accepted matches \
+     on ids that are local in source are dropped, with a stderr note \
+     per category (a prune that discards accepted bindings warns \
+     louder — that's re-accept work destroyed if it was a \
+     misconfiguration). The live-id authority is deliberately WIDER \
+     than the freshly-built index: ids come from the RAW walk before \
+     build_entries validation (a warning-skipped annotation still \
+     counts as live), and when aristo.toml [index].exclude is set the \
+     walk is re-run WITHOUT the excludes (an excluded annotation still \
+     counts as live), because pruning from a walk that is known to be \
+     partial would destroy accepted bindings for annotations that \
+     still exist in source. When the authority itself is unreliable — \
+     an explicit id fails to parse, or the unexcluded walk fails — the \
+     reconcile is skipped with a note instead of mispruning. The file \
+     is rewritten ONLY when the reconcile changed something — repeated \
+     stamps must not churn a committed file. Hanging this off the \
+     canon step instead would leave the stale rows in place forever: \
+     --skip-canon / disabled-config return before the cache read, and \
+     a deleted annotation makes every surviving row a cache hit, \
+     which also returns without writing.",
+    verify = "test",
+    id = "stamp_reconciles_canon_matches_with_source"
+)]
+fn reconcile_canon_matches(
+    ws: &crate::Workspace,
+    index: &IndexFile,
+    discovered: &[aristo_core::walk::DiscoveredAnnotation],
+) -> CliResult<()> {
+    let cache_path = ws.canon_matches_path();
+    let mut cache = CanonMatchesFile::read(&cache_path).map_err(|e| CliError::Other {
+        message: format!("reading {}: {e}", cache_path.display()),
+        exit_code: 1,
+    })?;
+    if cache.entries.is_empty() {
+        // Nothing to prune or demote — skip the (possibly second)
+        // walk entirely.
+        return Ok(());
+    }
+
+    let Some(live_ids) = reconcile_live_ids(ws, index, discovered) else {
+        // Authority unreliable — the skip note was already printed.
+        return Ok(());
+    };
+
+    let report = aristo_core::canon::reconcile(&mut cache, &live_ids);
+    print_reconcile_notes(&report);
+    if report.changed() {
+        cache
+            .write_atomic(&cache_path)
+            .map_err(|e| CliError::Other {
+                message: format!("writing {}: {e}", cache_path.display()),
+                exit_code: 1,
+            })?;
+    }
+    Ok(())
+}
+
+/// The GC-authority live-id set the canon-matches reconcile prunes
+/// against: the RAW discovered annotations before `build_entries`
+/// validation, re-walked WITHOUT `[index].exclude` when excludes are
+/// configured (a partial walk must never count as deletion), unioned
+/// with the freshly-built index keys. Returns `None` — after printing
+/// a skip note — when the authority is unreliable (an explicit id
+/// fails to parse, or the unexcluded walk fails): reconciling against
+/// a lossy authority would misprune rows for annotations that still
+/// exist in source. Shared by the write path
+/// ([`reconcile_canon_matches`]) and the `--check` dry run
+/// ([`check_canon_matches_drift`]) so both judge drift by the same
+/// rules.
+fn reconcile_live_ids(
+    ws: &crate::Workspace,
+    index: &IndexFile,
+    discovered: &[aristo_core::walk::DiscoveredAnnotation],
+) -> Option<std::collections::BTreeSet<AnnotationId>> {
+    use aristo_core::walk::WalkOptions;
+
+    // GC-authority live set: the RAW discovered annotations, before
+    // build_entries validation. When [index].exclude is configured
+    // the index walk is partial by design, so re-walk without the
+    // excludes — an excluded annotation is still in source and its
+    // rows (accepted bindings, rejected-match memory) must survive.
+    let cfg = ws.load_config();
+    let raw = if cfg.index.exclude.is_empty() {
+        aristo_core::canon::raw_live_ids(discovered)
+    } else {
+        match walk_directory_with(&ws.root, &WalkOptions::none()) {
+            Ok(all) => aristo_core::canon::raw_live_ids(&all),
+            Err(e) => {
+                // The excluded paths may be excluded precisely because
+                // they don't walk cleanly — degrade to "no reconcile"
+                // rather than failing the stamp or pruning blind.
+                eprintln!(
+                    "  note: canon-matches: reconcile skipped (walk without \
+                     [index].exclude failed: {e})"
+                );
+                return None;
+            }
+        }
+    };
+    if raw.unparseable_explicit_ids > 0 {
+        eprintln!(
+            "  note: canon-matches: reconcile skipped ({} annotation(s) have \
+             unparseable ids; fix them so stale cache entries can be pruned)",
+            raw.unparseable_explicit_ids
+        );
+        return None;
+    }
+    let mut live_ids: std::collections::BTreeSet<AnnotationId> = raw.ids;
+    // Belt-and-braces: anything in the freshly-built index is live by
+    // definition (guards against ordinal drift between the excluded
+    // and unexcluded walks for idless duplicate annotations).
+    live_ids.extend(index.entries.keys().cloned());
+    Some(live_ids)
+}
+
+/// Per-category stderr notes for a [`ReconcileReport`] — shared
+/// verbatim between the write path (what the reconcile did) and the
+/// `--check` dry run (what it would do), so the affected ids read the
+/// same either way.
+fn print_reconcile_notes(report: &aristo_core::canon::ReconcileReport) {
+    if !report.pruned.is_empty() {
+        let n = report.pruned.len();
+        let (noun, id_phrase) = if n == 1 {
+            ("entry", "id is")
+        } else {
+            ("entries", "ids are")
+        };
+        let ids = report
+            .pruned
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        // "no longer in source", not "removed annotations": a dead id
+        // also arises from rewording an idless intent (the aret_* id
+        // is content-addressed) or from accept's bare→prefixed rekey.
+        eprintln!(
+            "  note: canon-matches: pruned {n} stale {noun} whose annotation \
+             {id_phrase} no longer in source: {ids}"
+        );
+    }
+    if !report.pruned_bound.is_empty() {
+        let n = report.pruned_bound.len();
+        let (noun, verb) = if n == 1 {
+            ("entry", "was")
+        } else {
+            ("entries", "were")
+        };
+        let ids = report
+            .pruned_bound
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "  warning: canon-matches: {n} pruned {noun} {verb} carrying \
+             accepted canon bindings: {ids}. If this is unexpected, restore \
+             .aristo/canon-matches.toml from git; re-binding otherwise takes \
+             a fresh `aristo canon accept`."
+        );
+    }
+    for id in &report.demoted {
+        eprintln!(
+            "  note: canon-matches: demoted `{}` (source id lost its canon prefix). \
+             Re-match with `aristo stamp --refresh-canon` and re-bind with \
+             `aristo canon accept`, or leave it local.",
+            id.as_str()
+        );
+    }
+    for id in &report.preserved_for_recovery {
+        eprintln!(
+            "  note: canon-matches: kept `{}` (annotation no longer in source, \
+             but a pending match's canon-prefixed id is live and unbound — \
+             looks like an interrupted `aristo canon accept`; re-run it to \
+             finish, after which this row is cleaned up).",
+            id.as_str()
+        );
+    }
+    // report.missing_binding (live prefixed id without a derivable
+    // binding) is already warned about by derive_bindings_from_cache
+    // earlier in this same run — no duplicate warning here.
+}
+
+#[aristo::intent(
+    "`aristo stamp --check` detects canon-matches drift the same way it \
+     detects index drift: after the index sync check passes it dry-runs \
+     the reconcile — the same live-id authority and skip conditions as \
+     the write path, run on a CLONE of the loaded cache — and exits \
+     non-zero, naming the affected ids, when the reconcile would change \
+     .aristo/canon-matches.toml. Nothing is written. When the authority \
+     is unreliable (unparseable explicit id, failed unexcluded walk) the \
+     same skip note is printed and the check passes: the write path \
+     would skip the reconcile too, so there is no drift a re-run could \
+     fix — failing would be a --check false positive, which is worse \
+     than a missed drift.",
+    verify = "test",
+    id = "stamp_check_detects_canon_matches_drift"
+)]
+fn check_canon_matches_drift(
+    ws: &crate::Workspace,
+    index: &IndexFile,
+    discovered: &[aristo_core::walk::DiscoveredAnnotation],
+) -> CliResult<()> {
+    let cache_path = ws.canon_matches_path();
+    let cache = CanonMatchesFile::read(&cache_path).map_err(|e| CliError::Other {
+        message: format!("reading {}: {e}", cache_path.display()),
+        exit_code: 1,
+    })?;
+    if cache.entries.is_empty() {
+        // Nothing the reconcile could prune or demote — skip the
+        // (possibly second) walk entirely, like the write path.
+        return Ok(());
+    }
+    let Some(live_ids) = reconcile_live_ids(ws, index, discovered) else {
+        // Authority unreliable — the skip note was already printed.
+        // The write path would skip the reconcile for the same
+        // reason, so there is no drift to fail on.
+        return Ok(());
+    };
+    // Dry run on a clone: --check never writes.
+    let mut probe = cache.clone();
+    let report = aristo_core::canon::reconcile(&mut probe, &live_ids);
+    if !report.changed() {
+        return Ok(());
+    }
+    print_reconcile_notes(&report);
+    let stale = report.pruned.len();
+    let demotions = report.demoted.len();
+    let stale_noun = if stale == 1 { "entry" } else { "entries" };
+    let demotion_noun = if demotions == 1 {
+        "demotion"
+    } else {
+        "demotions"
+    };
+    println!();
+    Err(CliError::Other {
+        message: format!(
+            "canon-matches.toml is out of sync with source ({stale} stale {stale_noun}, \
+             {demotions} {demotion_noun}). Run `aristo stamp` (without --check) to \
+             reconcile, then commit."
+        ),
+        exit_code: 2,
+    })
 }
 
 #[aristo::intent(

--- a/crates/aristo-cli/src/lib.rs
+++ b/crates/aristo-cli/src/lib.rs
@@ -134,10 +134,10 @@ enum Commands {
     /// Refresh the annotation index — pick up new annotations, detect
     /// drift, and (when signed in) match against the Aretta canon.
     Stamp {
-        /// CI mode: report whether `stamp` would change the index,
-        /// without writing. Exits non-zero if it would. Skips the
-        /// canon-match step too (no outbound network calls in this
-        /// mode).
+        /// CI mode: report whether `stamp` would change the index or
+        /// `.aristo/canon-matches.toml`, without writing either.
+        /// Exits non-zero if it would. Skips the canon-match step
+        /// too (no outbound network calls in this mode).
         #[arg(long)]
         check: bool,
         /// Skip the canon-match step for this run. Doesn't disable
@@ -742,6 +742,10 @@ pub(crate) enum CanonAction {
     /// changes; canonical text + verify + parent are preserved).
     /// The next `aristo stamp` may re-pull a fresh pending match
     /// against the same annotation text.
+    ///
+    /// Unbind is for LIVE annotations. If the annotation was deleted
+    /// from source, no unbind is needed: the next `aristo stamp`
+    /// prunes its `.aristo/canon-matches.toml` entry automatically.
     Unbind {
         /// Canon-bound annotation id including the prefix (e.g.
         /// `aristos:cell_written_exactly_once_per_page_edit`).

--- a/crates/aristo-cli/tests/canon_stamp_command.rs
+++ b/crates/aristo-cli/tests/canon_stamp_command.rs
@@ -355,10 +355,17 @@ fn stamp_unreachable_server_retains_cache() {
         .expect("cache should exist after first stamp");
 
     // Drift the annotation text — forces a re-query on the next stamp.
+    // Keep the SAME explicit id: with a fresh id the source-reconcile
+    // step would (correctly) prune the old id's row, which is not the
+    // behavior under test here — this test is about the Degraded path
+    // retaining cached matches for a still-live annotation.
     std::fs::write(
         ws.path().join("src/lib.rs"),
         r#"
-#[aristo::intent("each cell is written exactly one time during a page edit")]
+#[aristo::intent(
+    "each cell is written exactly one time during a page edit",
+    id = "edit_page_cell_write_invariant"
+)]
 pub fn edit_page() {}
 "#,
     )
@@ -429,6 +436,507 @@ fn stamp_check_mode_does_not_call_canon() {
     // No canon-matches.toml should have been written during --check.
     assert!(
         !ws.path().join(".aristo/canon-matches.toml").exists(),
+        "--check must not write canon-matches.toml"
+    );
+}
+
+// ─── Source-authoritative reconcile of canon-matches.toml ─────────────────
+
+#[test]
+fn stamp_prunes_cache_entry_for_removed_annotation() {
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let fixture = ws.path().join("fixtures/canon");
+    write_match_fixture_one_match(&fixture);
+
+    // First stamp: cache gains a row for the annotation.
+    let out = aristo_in(ws.path())
+        .env("ARISTO_CANON_FIXTURE", &fixture)
+        .args(["stamp"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "first stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    assert!(std::fs::read_to_string(&cache_path)
+        .unwrap()
+        .contains("edit_page_cell_write_invariant"));
+
+    // Delete the annotation from source (the function stays).
+    std::fs::write(ws.path().join("src/lib.rs"), "pub fn edit_page() {}\n").unwrap();
+
+    // Second stamp (offline — no fixture, no token needed): the
+    // reconcile step prunes the stale row and says so.
+    let out2 = aristo_in(ws.path()).args(["stamp"]).output().unwrap();
+    assert!(
+        out2.status.success(),
+        "second stamp failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        stderr.contains(
+            "canon-matches: pruned 1 stale entry whose annotation id is no \
+             longer in source: edit_page_cell_write_invariant"
+        ),
+        "stderr: {stderr}"
+    );
+    let cache_body = std::fs::read_to_string(&cache_path).unwrap();
+    assert!(
+        !cache_body.contains("edit_page_cell_write_invariant"),
+        "stale entry must be pruned, got: {cache_body}"
+    );
+    assert!(
+        cache_body.contains("schema_version"),
+        "__meta__ must survive the prune, got: {cache_body}"
+    );
+
+    // Third stamp: reconcile is idempotent — no note, file byte-stable.
+    let before = std::fs::read_to_string(&cache_path).unwrap();
+    let out3 = aristo_in(ws.path()).args(["stamp"]).output().unwrap();
+    assert!(out3.status.success());
+    let stderr3 = String::from_utf8_lossy(&out3.stderr);
+    assert!(
+        !stderr3.contains("canon-matches: pruned"),
+        "second reconcile must find nothing, stderr: {stderr3}"
+    );
+    assert_eq!(
+        before,
+        std::fs::read_to_string(&cache_path).unwrap(),
+        "no-op reconcile must not rewrite the committed file"
+    );
+}
+
+#[test]
+fn stamp_demotes_live_bare_id_carrying_accepted_matches() {
+    // The hand-stripped-prefix case: the user removed the canon
+    // prefix in source by hand (instead of `aristo canon unbind`),
+    // leaving a live BARE id whose cache row still carries
+    // accepted_matches. Source says local — source wins.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let cache_body = r#"[__meta__]
+schema_version = 1
+canon_version = "v0.2.0"
+
+[edit_page_cell_write_invariant]
+last_match_text_hash = "blake3:stale"
+canon_fetched_at = "2026-06-15T09:14:22Z"
+
+[[edit_page_cell_write_invariant.accepted_matches]]
+canon_id = "cell_written_exactly_once_per_page_edit"
+version = "v0.2.1"
+canonical_text = "edit_page writes each cell exactly once"
+canon_version = "v0.2.0"
+confidence = 0.92
+prefix_tier = "aristos:"
+accepted_at = "2026-06-15T09:20:00Z"
+bound_at = "2026-06-15T09:20:00Z"
+"#;
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    std::fs::write(&cache_path, cache_body).unwrap();
+
+    // --skip-canon on purpose: the reconcile step must run even when
+    // the canon-match step itself is skipped.
+    let out = aristo_in(ws.path())
+        .args(["stamp", "--skip-canon"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(
+            "canon-matches: demoted `edit_page_cell_write_invariant` \
+             (source id lost its canon prefix)"
+        ),
+        "stderr: {stderr}"
+    );
+    let cache_after = std::fs::read_to_string(&cache_path).unwrap();
+    assert!(
+        !cache_after.contains("accepted_matches"),
+        "accepted bucket must be dropped, got: {cache_after}"
+    );
+    assert!(
+        cache_after.contains("[edit_page_cell_write_invariant]"),
+        "the rest of the row must survive, got: {cache_after}"
+    );
+    assert!(
+        cache_after.contains("canon_version = \"v0.2.0\""),
+        "__meta__ must survive the demote, got: {cache_after}"
+    );
+}
+
+#[test]
+fn stamp_reconcile_keeps_rows_for_excluded_annotations() {
+    // Narrowing the walk via aristo.toml [index].exclude must NOT
+    // count as deleting the excluded annotations: "absent from this
+    // (partial) walk" is not "absent from source". The reconcile
+    // re-walks without the excludes to build its live set.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let fixture = ws.path().join("fixtures/canon");
+    write_match_fixture_one_match(&fixture);
+
+    let out = aristo_in(ws.path())
+        .env("ARISTO_CANON_FIXTURE", &fixture)
+        .args(["stamp"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "first stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    assert!(std::fs::read_to_string(&cache_path)
+        .unwrap()
+        .contains("edit_page_cell_write_invariant"));
+
+    // Exclude the whole src tree from the index walk. The annotation
+    // is still in source.
+    std::fs::write(
+        ws.path().join("aristo.toml"),
+        "[index]\nexclude = [\"src/**\"]\n",
+    )
+    .unwrap();
+
+    let out2 = aristo_in(ws.path()).args(["stamp"]).output().unwrap();
+    assert!(
+        out2.status.success(),
+        "second stamp failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        !stderr.contains("canon-matches: pruned"),
+        "an excluded annotation is still in source — nothing to prune, \
+         stderr: {stderr}"
+    );
+    assert!(
+        std::fs::read_to_string(&cache_path)
+            .unwrap()
+            .contains("edit_page_cell_write_invariant"),
+        "the row must survive an [index].exclude narrowing"
+    );
+}
+
+#[test]
+fn stamp_reconcile_keeps_row_for_validation_skipped_annotation() {
+    // A warn-level build_entries skip (typo'd parent id) drops the
+    // annotation from the index, but it still exists in source: its
+    // canon-match memory must survive the stamp. The reconcile's
+    // live set comes from the RAW walk, before validation.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let fixture = ws.path().join("fixtures/canon");
+    write_match_fixture_one_match(&fixture);
+
+    let out = aristo_in(ws.path())
+        .env("ARISTO_CANON_FIXTURE", &fixture)
+        .args(["stamp"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "first stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    assert!(std::fs::read_to_string(&cache_path)
+        .unwrap()
+        .contains("edit_page_cell_write_invariant"));
+
+    // Same annotation, now with an invalid parent id — build_entries
+    // skips it with a warning and stamp still exits 0.
+    std::fs::write(
+        ws.path().join("src/lib.rs"),
+        r#"
+#[aristo::intent(
+    "each cell should be written exactly once per page edit",
+    id = "edit_page_cell_write_invariant",
+    parent = "Bad Parent Typo!!"
+)]
+pub fn edit_page() {}
+"#,
+    )
+    .unwrap();
+
+    let out2 = aristo_in(ws.path()).args(["stamp"]).output().unwrap();
+    assert!(
+        out2.status.success(),
+        "second stamp failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        stderr.contains("invalid parent id"),
+        "precondition: the annotation must have been skipped with a \
+         warning, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("canon-matches: pruned"),
+        "a validation-skipped annotation is still in source — nothing \
+         to prune, stderr: {stderr}"
+    );
+    assert!(
+        std::fs::read_to_string(&cache_path)
+            .unwrap()
+            .contains("edit_page_cell_write_invariant"),
+        "the row must survive a warn-level validation skip"
+    );
+}
+
+#[test]
+fn stamp_warns_louder_when_prune_discards_accepted_bindings() {
+    // Pruning ordinary match memory gets a note; pruning a row that
+    // carried ACCEPTED bindings gets a warning too — that is
+    // re-accept work destroyed if the deletion was unintended.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let cache_body = r#"[__meta__]
+schema_version = 1
+
+["aristos:some_gone_binding"]
+last_match_text_hash = "blake3:stale"
+canon_fetched_at = "2026-06-15T09:14:22Z"
+
+[["aristos:some_gone_binding".accepted_matches]]
+canon_id = "some_gone_binding"
+version = "v0.2.1"
+canonical_text = "a binding whose annotation is gone"
+canon_version = "v0.2.0"
+confidence = 0.92
+prefix_tier = "aristos:"
+accepted_at = "2026-06-15T09:20:00Z"
+bound_at = "2026-06-15T09:20:00Z"
+"#;
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    std::fs::write(&cache_path, cache_body).unwrap();
+
+    let out = aristo_in(ws.path())
+        .args(["stamp", "--skip-canon"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(
+            "canon-matches: pruned 1 stale entry whose annotation id is no \
+             longer in source: aristos:some_gone_binding"
+        ),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "warning: canon-matches: 1 pruned entry was carrying accepted \
+             canon bindings: aristos:some_gone_binding"
+        ),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !std::fs::read_to_string(&cache_path)
+            .unwrap()
+            .contains("some_gone_binding"),
+        "the dead bound row is still pruned — the warning is loud, not \
+         a veto"
+    );
+}
+
+// ─── --check detects canon-matches drift (read-only) ──────────────────────
+
+/// A committed cache whose only row is keyed by an id that exists in
+/// no test source file — the lingering-binding drift `stamp --check`
+/// must flag.
+const STALE_BOUND_CACHE: &str = r#"[__meta__]
+schema_version = 1
+
+["aristos:some_gone_binding"]
+last_match_text_hash = "blake3:stale"
+canon_fetched_at = "2026-06-15T09:14:22Z"
+
+[["aristos:some_gone_binding".accepted_matches]]
+canon_id = "some_gone_binding"
+version = "v0.2.1"
+canonical_text = "a binding whose annotation is gone"
+canon_version = "v0.2.0"
+confidence = 0.92
+prefix_tier = "aristos:"
+accepted_at = "2026-06-15T09:20:00Z"
+bound_at = "2026-06-15T09:20:00Z"
+"#;
+
+#[test]
+fn stamp_check_fails_on_stale_canon_matches() {
+    // Index in sync, canon-matches stale: --check must fail with the
+    // canon-matches drift message (styled after the index one) and
+    // write NOTHING — neither file may change byte-for-byte.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+
+    // Bring the index in sync first, so canon-matches drift is the
+    // ONLY thing --check can complain about.
+    let out = aristo_in(ws.path())
+        .args(["stamp", "--skip-canon"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "setup stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Plant a stale row: its annotation was never in this source.
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    std::fs::write(&cache_path, STALE_BOUND_CACHE).unwrap();
+    let index_path = ws.path().join(".aristo/index.toml");
+    let index_before = std::fs::read(&index_path).unwrap();
+
+    let out2 = aristo_in(ws.path())
+        .args(["stamp", "--check"])
+        .output()
+        .unwrap();
+    assert!(
+        !out2.status.success(),
+        "--check must exit non-zero on canon-matches drift"
+    );
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        stderr.contains(
+            "canon-matches.toml is out of sync with source (1 stale entry, \
+             0 demotions). Run `aristo stamp` (without --check) to \
+             reconcile, then commit."
+        ),
+        "stderr: {stderr}"
+    );
+    // The affected id is named the same way the write-path note does.
+    assert!(
+        stderr.contains(
+            "canon-matches: pruned 1 stale entry whose annotation id is no \
+             longer in source: aristos:some_gone_binding"
+        ),
+        "stderr: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read(&cache_path).unwrap(),
+        STALE_BOUND_CACHE.as_bytes(),
+        "--check must not write canon-matches.toml"
+    );
+    assert_eq!(
+        std::fs::read(&index_path).unwrap(),
+        index_before,
+        "--check must not write the index"
+    );
+}
+
+#[test]
+fn stamp_check_passes_when_canon_matches_in_sync() {
+    // The cache row is keyed by a LIVE annotation id — the dry-run
+    // reconcile finds nothing to change, so --check keeps exiting 0.
+    let ws = setup_workspace(ARISTO_TOML_DEFAULT, SOURCE_WITH_ONE_INTENT);
+    let fixture = ws.path().join("fixtures/canon");
+    write_match_fixture_one_match(&fixture);
+
+    let out = aristo_in(ws.path())
+        .env("ARISTO_CANON_FIXTURE", &fixture)
+        .args(["stamp"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "setup stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Precondition: the cache has a row for the live annotation.
+    assert!(
+        std::fs::read_to_string(ws.path().join(".aristo/canon-matches.toml"))
+            .unwrap()
+            .contains("edit_page_cell_write_invariant")
+    );
+
+    let out2 = aristo_in(ws.path())
+        .args(["stamp", "--check"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        out2.status.success(),
+        "--check must pass on an in-sync workspace, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("canon-matches.toml is out of sync"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        String::from_utf8_lossy(&out2.stdout).contains("ok: index is up to date"),
+        "the index-ok line still prints"
+    );
+}
+
+#[test]
+fn stamp_check_skips_canon_matches_drift_when_authority_unreliable() {
+    // An unparseable explicit id makes the live-id authority lossy:
+    // the write path skips the reconcile, so --check must print the
+    // same skip note and PASS — a false CI failure that re-running
+    // `aristo stamp` cannot fix is worse than a missed drift.
+    let ws = setup_workspace(
+        ARISTO_TOML_DEFAULT,
+        r#"
+#[aristo::intent(
+    "each cell should be written exactly once per page edit",
+    id = "edit_page_cell_write_invariant"
+)]
+pub fn edit_page() {}
+
+#[aristo::intent(
+    "an invariant whose explicit id cannot parse",
+    id = "Not A Valid Id!"
+)]
+pub fn save_page() {}
+"#,
+    );
+
+    let out = aristo_in(ws.path())
+        .args(["stamp", "--skip-canon"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "setup stamp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Plant the same stale row the failing test uses — with a
+    // reliable authority this WOULD be drift.
+    let cache_path = ws.path().join(".aristo/canon-matches.toml");
+    std::fs::write(&cache_path, STALE_BOUND_CACHE).unwrap();
+
+    let out2 = aristo_in(ws.path())
+        .args(["stamp", "--check"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out2.stderr);
+    assert!(
+        out2.status.success(),
+        "--check must not fail when the reconcile authority is \
+         unreliable, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "canon-matches: reconcile skipped (1 annotation(s) have \
+             unparseable ids"
+        ),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("canon-matches.toml is out of sync"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read(&cache_path).unwrap(),
+        STALE_BOUND_CACHE.as_bytes(),
         "--check must not write canon-matches.toml"
     );
 }

--- a/crates/aristo-core/src/canon/cache.rs
+++ b/crates/aristo-core/src/canon/cache.rs
@@ -38,6 +38,20 @@
 //!   `text_hash`; once the annotation text changes, the rejection
 //!   no longer suppresses re-evaluation (per L5 invalidation rules).
 //!
+//! ## Source-authoritative reconcile
+//!
+//! The file is garbage-collected against source on every mutating
+//! `aristo stamp` (see [`mod@super::reconcile`]): an entry whose
+//! annotation was deleted from source is pruned, and accepted
+//! matches on an id that is local (unprefixed) in source are
+//! dropped. The live-id authority is the RAW walk — pre-validation
+//! and ignoring `[index].exclude` — so an annotation that merely
+//! fell out of the index (warning skip, exclude glob) is NOT treated
+//! as deleted. `aristo canon unbind` remains the way to unbind a
+//! LIVE annotation; deleting the annotation and re-stamping now
+//! cleans up its entry — including its rejected-match memory —
+//! automatically.
+//!
 //! ## Atomic write
 //!
 //! Writes go through a temp-then-rename dance

--- a/crates/aristo-core/src/canon/mod.rs
+++ b/crates/aristo-core/src/canon/mod.rs
@@ -35,6 +35,10 @@
 //!   accepted matches (records deduped by `accessor_id`, companions
 //!   by `(symbol, file)`, per-`payload_ref` groups on provenance
 //!   mismatch) + TOML-persistence null sanitizing.
+//! - [`mod@reconcile`]: source-authoritative reconciliation of the cache
+//!   against a raw (pre-validation, unexcluded) source walk — prune
+//!   rows for deleted annotations, demote rows whose source id lost
+//!   its canon prefix.
 //!
 //! **Phase 1 scope**: no verification execution. The `verification`
 //! block on [`CanonMatch`] is informational
@@ -49,6 +53,7 @@ pub mod http_client;
 pub mod instrumentation;
 pub mod mock_client;
 pub mod noop_client;
+pub mod reconcile;
 pub mod rewrite;
 pub mod types;
 
@@ -64,6 +69,7 @@ pub use instrumentation::{
 };
 pub use mock_client::MockCanonClient;
 pub use noop_client::NoopCanonClient;
+pub use reconcile::{raw_live_ids, reconcile, RawLiveIds, ReconcileReport};
 pub use rewrite::{compute_rewrite, AcceptRewriteRequest, AttributeRewrite, RewriteError};
 pub use types::{
     synthesize_phase1_linked, AnnotationMatchInput, BundleCompanion, BundleCompileCheck,

--- a/crates/aristo-core/src/canon/reconcile.rs
+++ b/crates/aristo-core/src/canon/reconcile.rs
@@ -1,0 +1,888 @@
+//! Source-authoritative reconciliation of `.aristo/canon-matches.toml`.
+//!
+//! The cache file is committed by default and was never garbage
+//! collected: deleting an annotation from source left its entry
+//! lingering forever (real incident: a client repo removed an
+//! `aristos:`-bound intent but the accepted binding stayed in
+//! `canon-matches.toml`, so dashboards mirroring the committed file
+//! kept showing a dead binding). [`reconcile`] makes the write-path
+//! scan self-healing: given the live annotation-id set, it prunes
+//! rows for removed annotations and demotes rows whose source id
+//! lost its canon prefix. `aristo canon unbind` remains the way to
+//! unbind a LIVE annotation.
+//!
+//! The live-id set must be a GC-grade authority: derive it with
+//! [`raw_live_ids`] from a RAW, unexcluded source walk — never from
+//! the post-validation index — so an annotation that was skipped
+//! with a warning or filtered by `[index].exclude` still counts as
+//! live. Pruning from a partial walk would destroy accepted bindings
+//! for annotations that still exist in source.
+//!
+//! Pure functions — no I/O, unit-testable without a repo. Callers
+//! (the `aristo stamp` write path) read the cache, reconcile, and
+//! write it back only when [`ReconcileReport::changed`] says
+//! something actually changed.
+
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeSet, HashMap};
+
+use crate::id::{deterministic_id, id_bucket_key};
+use crate::index::AnnotationId;
+use crate::walk::DiscoveredAnnotation;
+
+use super::cache::{CacheEntry, CanonMatchesFile, PendingMatch, RejectedMatch};
+
+/// What [`reconcile`] did (or would warn about). Every bucket is
+/// sorted so callers can print deterministic summaries.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Rows removed whole: their key (either key form — bare or
+    /// canon-prefixed) matches no live annotation id.
+    pub pruned: Vec<AnnotationId>,
+    /// The subset of [`Self::pruned`] whose rows still carried
+    /// `accepted_matches` — a pruned binding is worth a louder
+    /// warning, since re-accepting is real work.
+    pub pruned_bound: Vec<AnnotationId>,
+    /// Live but unprefixed ids that lost their `accepted_matches`
+    /// bucket (source says local, source wins). Covers both a live
+    /// bare-keyed row that carried the bucket and a dead prefixed
+    /// key rekeyed onto its live bare form; the rest of the row
+    /// (pending + rejected memory) is kept either way.
+    pub demoted: Vec<AnnotationId>,
+    /// Live canon-prefixed ids with no cache row or no
+    /// `accepted_matches` — no mutation; the caller may warn and
+    /// suggest `aristo canon refresh`.
+    pub missing_binding: Vec<AnnotationId>,
+    /// Dead bare-id rows preserved instead of pruned because a
+    /// pending match's canon-prefixed form IS live in source AND
+    /// that prefixed id has no accepted row in the cache — the
+    /// interrupted-`canon accept` recovery state (source was
+    /// rewritten, the cache rekey never completed).
+    pub preserved_for_recovery: Vec<AnnotationId>,
+}
+
+impl ReconcileReport {
+    /// Did the reconcile mutate the cache? Only prune and demote
+    /// mutate; warnings and preserved rows do not.
+    pub fn changed(&self) -> bool {
+        !(self.pruned.is_empty() && self.demoted.is_empty())
+    }
+}
+
+/// The GC-authority live-id set, derived from RAW walk output —
+/// deliberately BEFORE `build_entries` validation, see
+/// [`raw_live_ids`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RawLiveIds {
+    /// Every id derivable from the walk: explicit ids that parse,
+    /// plus the deterministic `aret_*` id of every idless annotation.
+    pub ids: BTreeSet<AnnotationId>,
+    /// How many annotations carried an explicit `id = "…"` that does
+    /// not parse. Such an id cannot be represented in the set, so a
+    /// caller that sees a nonzero count must NOT treat the set as
+    /// authoritative for pruning (a typo'd id would otherwise turn
+    /// into a destructive prune of the still-existing annotation's
+    /// row).
+    pub unparseable_explicit_ids: usize,
+}
+
+#[aristo::intent(
+    "The reconcile's live-id authority is derived from the RAW walk, \
+     before build_entries validation: an annotation skipped with a \
+     warning (invalid parent id, invalid verify value, duplicate id) \
+     still contributes its id, and an idless annotation contributes \
+     the same deterministic aret_* id build_entries would mint \
+     (same bucket key, same ordinal assignment). Treating \
+     'skipped from the index' as 'deleted from source' would prune — \
+     and destroy — the accepted bindings and rejected-match memory of \
+     annotations that still exist. The one id class the set cannot \
+     represent is an explicit id that fails to parse; those are \
+     counted so the caller can skip reconciliation instead of \
+     mispruning.",
+    verify = "test",
+    id = "raw_live_ids_counts_skipped_annotations_as_live"
+)]
+pub fn raw_live_ids(discovered: &[DiscoveredAnnotation]) -> RawLiveIds {
+    let mut out = RawLiveIds::default();
+    // Same ordinal bookkeeping as build_entries' resolve_id (ID-D2):
+    // idless duplicates of one (kind, text, site) bucket mint
+    // distinct source-order ordinals.
+    let mut ordinal_counter: HashMap<(crate::index::AnnotationKind, String, String), usize> =
+        HashMap::new();
+    for d in discovered {
+        match &d.annotation.id {
+            Some(s) => match AnnotationId::parse(s) {
+                Ok(id) => {
+                    out.ids.insert(id);
+                }
+                Err(_) => out.unparseable_explicit_ids += 1,
+            },
+            None => {
+                let key = id_bucket_key(d.annotation.kind, &d.annotation.text, &d.annotation.site);
+                let ordinal = ordinal_counter.entry(key).or_insert(0);
+                out.ids.insert(deterministic_id(
+                    d.annotation.kind,
+                    &d.annotation.text,
+                    &d.annotation.site,
+                    *ordinal,
+                ));
+                *ordinal += 1;
+            }
+        }
+    }
+    out
+}
+
+#[aristo::intent(
+    "Reconciliation is source-authoritative and idempotent: the live-id \
+     set from a fresh source walk is the sole authority. A cache row \
+     whose key (either key form, bare or canon-prefixed) matches no \
+     live annotation id is removed whole; a live but unprefixed id \
+     that still carries accepted_matches loses exactly that bucket \
+     (source says local, source wins). Two refinements keep memory \
+     the live set says is still meaningful. A dead canon-prefixed key \
+     whose BARE form is live is a demotion, not a removal: the row is \
+     rekeyed under the bare id with accepted_matches dropped and \
+     rejected-match memory preserved. And a dead bare id is preserved \
+     untouched only while a pending match's canon-prefixed form is \
+     live in source AND that prefixed id has no accepted row in the \
+     cache — the interrupted-accept window, where pruning would \
+     destroy the pending entry a re-run `aristo canon accept` needs \
+     to finish the rekey. Once the prefixed row carries an accepted \
+     match the binding completed (via this or another annotation) and \
+     the dead bare row is ordinary garbage. `__meta__` is never \
+     touched, and a second run over the same inputs reports no \
+     changes.",
+    verify = "test",
+    id = "canon_reconcile_is_source_authoritative_and_idempotent"
+)]
+pub fn reconcile(
+    cache: &mut CanonMatchesFile,
+    live_ids: &BTreeSet<AnnotationId>,
+) -> ReconcileReport {
+    let mut report = ReconcileReport::default();
+
+    // Rule 1 — dead keys: any row whose key matches no live
+    // annotation id is pruned whole (same set-difference pattern as
+    // orphan-proof archival: the source walk is the sole authority),
+    // except the demote-rekey and interrupted-accept cases, see the
+    // intent above.
+    let dead: Vec<AnnotationId> = cache
+        .entries
+        .keys()
+        .filter(|id| !live_ids.contains(*id))
+        .cloned()
+        .collect();
+    for id in dead {
+        // Rule 1a — DEMOTE-REKEY: a dead PREFIXED key whose bare form
+        // is live means the source id lost its canon prefix (hand
+        // edit, or a source-only revert after an accept). Nothing was
+        // removed from source — rekey the row under the live bare id,
+        // dropping only the accepted bucket, so the pending/rejected
+        // memory the demote rule promises to keep survives.
+        if id.is_canon_bound() {
+            if let Some(bare) = bare_form(&id).filter(|b| live_ids.contains(b)) {
+                let mut row = cache
+                    .entries
+                    .remove(&id)
+                    .expect("dead key was collected from this map");
+                row.accepted_matches.clear();
+                match cache.entries.entry(bare.clone()) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(row);
+                    }
+                    // A live bare row already exists (e.g. the
+                    // leftover shell accept leaves behind): it is
+                    // authoritative for the current text, so keep it
+                    // and fold in only the prefixed row's
+                    // rejected-match memory.
+                    Entry::Occupied(mut slot) => {
+                        merge_rejected(&mut slot.get_mut().rejected_matches, row.rejected_matches);
+                    }
+                }
+                report.demoted.push(bare);
+                continue;
+            }
+        }
+        // Rule 1b — PRESERVE: the interrupted-accept recovery state.
+        let is_recovery_row = !id.is_canon_bound()
+            && cache
+                .entries
+                .get(&id)
+                .is_some_and(|entry| pending_rekey_awaits_completion(entry, cache, live_ids));
+        if is_recovery_row {
+            report.preserved_for_recovery.push(id);
+            continue;
+        }
+        // Rule 1c — PRUNE.
+        let row = cache
+            .entries
+            .remove(&id)
+            .expect("dead key was collected from this map");
+        if !row.accepted_matches.is_empty() {
+            report.pruned_bound.push(id.clone());
+        }
+        report.pruned.push(id);
+    }
+
+    // Rule 2 — DEMOTE: a live, unprefixed id whose row still carries
+    // accepted_matches. Source says local, source wins: drop the
+    // accepted bucket, keep the rest of the row (pending + rejected
+    // memory survive).
+    for (id, entry) in cache.entries.iter_mut() {
+        if !id.is_canon_bound() && live_ids.contains(id) && !entry.accepted_matches.is_empty() {
+            entry.accepted_matches.clear();
+            report.demoted.push(id.clone());
+        }
+    }
+    // Rule 1a pushes bare forms out of key order, and 1a + 2 can both
+    // report the same id (rekey onto a bare row that itself carried
+    // an accepted bucket) — sort + dedupe for deterministic output.
+    report.demoted.sort();
+    report.demoted.dedup();
+
+    // Rule 3 — WARN (no mutation): a live canon-prefixed id with no
+    // cache row or no accepted_matches cannot derive its binding.
+    // Collected for the caller to warn on; reconcile never fetches
+    // (scans stay offline-safe).
+    for id in live_ids {
+        if !id.is_canon_bound() {
+            continue;
+        }
+        let has_accepted = cache
+            .entries
+            .get(id)
+            .is_some_and(|e| !e.accepted_matches.is_empty());
+        if !has_accepted {
+            report.missing_binding.push(id.clone());
+        }
+    }
+
+    report
+}
+
+/// Does any of this row's pending matches rekey to a canon-prefixed
+/// id that is live in source and NOT yet bound in the cache? True
+/// means the row is the documented interrupted-`canon accept`
+/// transient (source→index→cache ordering died after the source
+/// rewrite, so the rekeyed row never gained its accepted match) and
+/// must be preserved for the re-run to complete. A live prefixed
+/// target that already carries an accepted row means the binding
+/// completed — via this annotation or another one matched to the
+/// same canon entry — and preserving would make the dead bare row
+/// immortal.
+fn pending_rekey_awaits_completion(
+    entry: &CacheEntry,
+    cache: &CanonMatchesFile,
+    live_ids: &BTreeSet<AnnotationId>,
+) -> bool {
+    entry.pending_matches.iter().any(|p| {
+        pending_prefixed_form(p).is_some_and(|pid| {
+            live_ids.contains(&pid)
+                && cache
+                    .entries
+                    .get(&pid)
+                    .is_none_or(|e| e.accepted_matches.is_empty())
+        })
+    })
+}
+
+/// The canon-prefixed id this pending match would rekey the row to
+/// on accept (`aristos:<canon_id>` / `kanon:<canon_id>` per tier).
+fn pending_prefixed_form(p: &PendingMatch) -> Option<AnnotationId> {
+    AnnotationId::parse(&format!("{}{}", p.prefix_tier.as_prefix(), p.canon_id)).ok()
+}
+
+/// The bare (prefix-stripped) form of a canon-prefixed id; `None`
+/// for ids that carry no canon prefix.
+fn bare_form(id: &AnnotationId) -> Option<AnnotationId> {
+    let s = id.as_str();
+    let body = s
+        .strip_prefix("aristos:")
+        .or_else(|| s.strip_prefix("kanon:"))?;
+    AnnotationId::parse(body).ok()
+}
+
+/// Fold `from` into `into`, skipping entries whose
+/// `(canon_id, text_hash)` rejection key is already present.
+fn merge_rejected(into: &mut Vec<RejectedMatch>, from: Vec<RejectedMatch>) {
+    for r in from {
+        let dup = into
+            .iter()
+            .any(|x| x.canon_id == r.canon_id && x.text_hash == r.text_hash);
+        if !dup {
+            into.push(r);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cache::{AcceptedMatch, Disposition};
+    use super::super::types::PrefixTier;
+    use super::*;
+    use crate::index::AnnotationKind;
+
+    fn aid(s: &str) -> AnnotationId {
+        AnnotationId::parse(s).unwrap_or_else(|e| panic!("parse {s:?}: {e}"))
+    }
+
+    fn live(ids: &[&str]) -> BTreeSet<AnnotationId> {
+        ids.iter().map(|s| aid(s)).collect()
+    }
+
+    fn pending(canon_id: &str, tier: PrefixTier) -> PendingMatch {
+        PendingMatch {
+            canon_id: canon_id.into(),
+            version: "v0.2.1".into(),
+            canonical_text: "canonical".into(),
+            canon_version: "v0.2.0".into(),
+            confidence: 0.92,
+            prefix_tier: tier,
+            backed_by: None,
+            linked: None,
+            verification: None,
+            disposition: Disposition::Open,
+            found_at: "2026-06-15T09:14:22Z".into(),
+            found_by: "aristo stamp".into(),
+        }
+    }
+
+    fn accepted(canon_id: &str) -> AcceptedMatch {
+        AcceptedMatch {
+            canon_id: canon_id.into(),
+            version: "v0.2.1".into(),
+            canonical_text: "canonical".into(),
+            canon_version: "v0.2.0".into(),
+            confidence: 1.0,
+            prefix_tier: PrefixTier::Aristos,
+            backed_by: None,
+            linked: None,
+            verification: None,
+            accepted_at: "2026-06-15T09:20:00Z".into(),
+            bound_at: "2026-06-15T09:20:00Z".into(),
+        }
+    }
+
+    fn rejected(canon_id: &str) -> RejectedMatch {
+        RejectedMatch {
+            canon_id: canon_id.into(),
+            version: "v0.1.2".into(),
+            text_hash: "blake3:c2f7a912".into(),
+            rejected_at: "2026-06-13T11:48:00Z".into(),
+            reason: None,
+        }
+    }
+
+    fn row(
+        pending_matches: Vec<PendingMatch>,
+        accepted_matches: Vec<AcceptedMatch>,
+        rejected_matches: Vec<RejectedMatch>,
+    ) -> CacheEntry {
+        CacheEntry {
+            last_match_text_hash: "blake3:x".into(),
+            canon_fetched_at: "2026-06-15T09:14:22Z".into(),
+            pending_matches,
+            accepted_matches,
+            rejected_matches,
+        }
+    }
+
+    // ─── Rule 1: PRUNE ────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_removes_bare_entry_for_removed_annotation() {
+        let mut cache = CanonMatchesFile::default();
+        cache
+            .entries
+            .insert(aid("deleted_one"), row(vec![], vec![], vec![]));
+        cache
+            .entries
+            .insert(aid("still_here"), row(vec![], vec![], vec![]));
+
+        let report = reconcile(&mut cache, &live(&["still_here"]));
+
+        assert_eq!(report.pruned, vec![aid("deleted_one")]);
+        assert!(report.pruned_bound.is_empty(), "no accepted bucket pruned");
+        assert!(report.changed());
+        assert!(!cache.entries.contains_key(&aid("deleted_one")));
+        assert!(cache.entries.contains_key(&aid("still_here")));
+    }
+
+    #[test]
+    fn prune_removes_prefixed_entry_for_removed_annotation() {
+        // Both prefixed key forms — the turso lingering-binding case:
+        // the aristos:-bound intent was deleted from source but the
+        // accepted binding stayed in canon-matches.toml.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("aristos:wal_checkpoint_error_no_db_leak"),
+            row(
+                vec![],
+                vec![accepted("wal_checkpoint_error_no_db_leak")],
+                vec![],
+            ),
+        );
+        cache.entries.insert(
+            aid("kanon:checkout_total_non_negative"),
+            row(
+                vec![],
+                vec![accepted("checkout_total_non_negative")],
+                vec![],
+            ),
+        );
+
+        let report = reconcile(&mut cache, &live(&["unrelated_live_id"]));
+
+        assert_eq!(
+            report.pruned,
+            vec![
+                aid("aristos:wal_checkpoint_error_no_db_leak"),
+                aid("kanon:checkout_total_non_negative"),
+            ]
+        );
+        // Both rows carried accepted bindings — flagged for the
+        // caller's louder warning.
+        assert_eq!(report.pruned_bound, report.pruned);
+        assert!(cache.entries.is_empty());
+    }
+
+    #[test]
+    fn prune_preserves_interrupted_accept_recovery_row() {
+        // accept's ordering contract is source→index→cache. If accept
+        // dies after the source rewrite, source holds `aristos:x`
+        // while the cache still holds the pending match under the OLD
+        // BARE id (and no accepted row exists under `aristos:x` yet)
+        // — the re-run needs that row; do not prune it.
+        let mut cache = CanonMatchesFile::default();
+        let mut p = pending("cell_write_once", PrefixTier::Aristos);
+        p.disposition = Disposition::Accepted; // the documented transient
+        cache
+            .entries
+            .insert(aid("edit_page_invariant"), row(vec![p], vec![], vec![]));
+
+        let report = reconcile(&mut cache, &live(&["aristos:cell_write_once"]));
+
+        assert!(report.pruned.is_empty());
+        assert_eq!(
+            report.preserved_for_recovery,
+            vec![aid("edit_page_invariant")]
+        );
+        assert!(!report.changed(), "preservation must not force a write");
+        assert!(cache.entries.contains_key(&aid("edit_page_invariant")));
+    }
+
+    #[test]
+    fn prune_preserves_recovery_row_when_prefixed_row_exists_without_accepted() {
+        // Boundary of the recovery window: the prefixed target's row
+        // exists (e.g. pending-only) but carries no accepted match —
+        // the rekey has not completed, keep waiting.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("edit_page_invariant"),
+            row(
+                vec![pending("cell_write_once", PrefixTier::Aristos)],
+                vec![],
+                vec![],
+            ),
+        );
+        cache
+            .entries
+            .insert(aid("aristos:cell_write_once"), row(vec![], vec![], vec![]));
+
+        let report = reconcile(&mut cache, &live(&["aristos:cell_write_once"]));
+
+        assert_eq!(
+            report.preserved_for_recovery,
+            vec![aid("edit_page_invariant")]
+        );
+        assert!(report.pruned.is_empty());
+    }
+
+    #[test]
+    fn prune_does_not_preserve_dead_row_whose_rekey_target_is_already_bound() {
+        // Two annotations matched the same popular canon entry; B
+        // accepted (so `aristos:cell_write_once` is live AND carries
+        // an accepted row), then A was genuinely deleted. A's dead
+        // bare row is NOT an interrupted accept — the binding
+        // completed via B — so it must be pruned, not preserved
+        // forever.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("deleted_ann"),
+            row(
+                vec![pending("cell_write_once", PrefixTier::Aristos)],
+                vec![],
+                vec![],
+            ),
+        );
+        cache.entries.insert(
+            aid("aristos:cell_write_once"),
+            row(vec![], vec![accepted("cell_write_once")], vec![]),
+        );
+
+        let report = reconcile(&mut cache, &live(&["aristos:cell_write_once"]));
+
+        assert_eq!(report.pruned, vec![aid("deleted_ann")]);
+        assert!(report.preserved_for_recovery.is_empty());
+        assert!(!cache.entries.contains_key(&aid("deleted_ann")));
+        assert!(
+            cache.entries.contains_key(&aid("aristos:cell_write_once")),
+            "the completed binding is untouched"
+        );
+    }
+
+    #[test]
+    fn prune_does_not_preserve_dead_row_whose_rekey_target_is_not_live() {
+        // A dead bare row with pending matches whose prefixed forms
+        // are NOT in source is ordinary garbage — prune it.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("gone_annotation"),
+            row(
+                vec![pending("some_canon_entry", PrefixTier::Kanon)],
+                vec![],
+                vec![],
+            ),
+        );
+
+        let report = reconcile(&mut cache, &live(&["unrelated_live_id"]));
+
+        assert_eq!(report.pruned, vec![aid("gone_annotation")]);
+        assert!(report.preserved_for_recovery.is_empty());
+    }
+
+    // ─── Rule 2: DEMOTE ───────────────────────────────────────────────────
+
+    #[test]
+    fn demote_drops_accepted_matches_on_live_unprefixed_id() {
+        // Source says local (no aristos:/kanon: prefix) — source
+        // wins: the accepted bucket goes, everything else stays.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("hand_stripped"),
+            row(
+                vec![pending("other_entry", PrefixTier::Aristos)],
+                vec![accepted("stripped_entry")],
+                vec![rejected("rejected_entry")],
+            ),
+        );
+
+        let report = reconcile(&mut cache, &live(&["hand_stripped"]));
+
+        assert_eq!(report.demoted, vec![aid("hand_stripped")]);
+        assert!(report.changed());
+        let entry = &cache.entries[&aid("hand_stripped")];
+        assert!(entry.accepted_matches.is_empty(), "accepted dropped");
+        assert_eq!(entry.pending_matches.len(), 1, "pending kept");
+        assert_eq!(entry.rejected_matches.len(), 1, "rejection memory kept");
+        assert_eq!(entry.last_match_text_hash, "blake3:x", "hash kept");
+    }
+
+    #[test]
+    fn demote_rekeys_dead_prefixed_row_onto_live_bare_form() {
+        // The realistic post-accept demotion: accept keyed the row
+        // under the PREFIXED id; the user then hand-stripped the
+        // prefix in source (or reverted src/ without .aristo/). The
+        // dead prefixed key must not be reported as a removed
+        // annotation — it is a demotion, and the rejected-match
+        // memory rekeys onto the live bare id.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("aristos:cell_write_once"),
+            row(
+                vec![],
+                vec![accepted("cell_write_once")],
+                vec![rejected("other_entry")],
+            ),
+        );
+
+        let report = reconcile(&mut cache, &live(&["cell_write_once"]));
+
+        assert!(report.pruned.is_empty(), "nothing was removed from source");
+        assert_eq!(report.demoted, vec![aid("cell_write_once")]);
+        assert!(report.changed());
+        assert!(!cache.entries.contains_key(&aid("aristos:cell_write_once")));
+        let entry = &cache.entries[&aid("cell_write_once")];
+        assert!(entry.accepted_matches.is_empty(), "accepted dropped");
+        assert_eq!(
+            entry.rejected_matches.len(),
+            1,
+            "rejection memory rekeyed onto the bare id"
+        );
+    }
+
+    #[test]
+    fn demote_rekey_merges_rejected_memory_into_existing_bare_row() {
+        // Both key forms exist (accept leaves a bare leftover shell
+        // behind): the live bare row is authoritative; the dead
+        // prefixed row folds its rejected memory in and disappears.
+        // The id is reported as demoted exactly once.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("cell_write_once"),
+            row(
+                vec![pending("other_entry", PrefixTier::Kanon)],
+                vec![],
+                vec![rejected("already_here")],
+            ),
+        );
+        cache.entries.insert(
+            aid("aristos:cell_write_once"),
+            row(
+                vec![],
+                vec![accepted("cell_write_once")],
+                vec![rejected("already_here"), rejected("only_in_prefixed")],
+            ),
+        );
+
+        let report = reconcile(&mut cache, &live(&["cell_write_once"]));
+
+        assert_eq!(report.demoted, vec![aid("cell_write_once")]);
+        assert!(report.pruned.is_empty());
+        assert!(!cache.entries.contains_key(&aid("aristos:cell_write_once")));
+        let entry = &cache.entries[&aid("cell_write_once")];
+        assert_eq!(entry.pending_matches.len(), 1, "live row's pending kept");
+        let mut names: Vec<&str> = entry
+            .rejected_matches
+            .iter()
+            .map(|r| r.canon_id.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["already_here", "only_in_prefixed"],
+            "rejected memory merged without duplicates"
+        );
+    }
+
+    #[test]
+    fn demote_ignores_live_prefixed_id_with_accepted_matches() {
+        // Steady state after accept: prefixed id live in source,
+        // accepted match in cache. Reconcile must not touch it.
+        let mut cache = CanonMatchesFile::default();
+        cache.entries.insert(
+            aid("aristos:cell_write_once"),
+            row(vec![], vec![accepted("cell_write_once")], vec![]),
+        );
+
+        let report = reconcile(&mut cache, &live(&["aristos:cell_write_once"]));
+
+        assert!(!report.changed());
+        assert_eq!(
+            cache.entries[&aid("aristos:cell_write_once")]
+                .accepted_matches
+                .len(),
+            1
+        );
+    }
+
+    // ─── Rule 3: WARN (no mutation) ───────────────────────────────────────
+
+    #[test]
+    fn warn_collects_live_prefixed_ids_without_a_derivable_binding() {
+        let mut cache = CanonMatchesFile::default();
+        // Row exists but has no accepted_matches.
+        cache.entries.insert(
+            aid("kanon:row_without_accepted"),
+            row(vec![], vec![], vec![]),
+        );
+        // aristos:no_row_at_all has no cache row.
+        // aristos:fully_bound is healthy.
+        cache.entries.insert(
+            aid("aristos:fully_bound"),
+            row(vec![], vec![accepted("fully_bound")], vec![]),
+        );
+
+        let report = reconcile(
+            &mut cache,
+            &live(&[
+                "aristos:no_row_at_all",
+                "kanon:row_without_accepted",
+                "aristos:fully_bound",
+            ]),
+        );
+
+        assert_eq!(
+            report.missing_binding,
+            vec![
+                aid("aristos:no_row_at_all"),
+                aid("kanon:row_without_accepted")
+            ]
+        );
+        assert!(!report.changed(), "warnings never mutate the cache");
+        assert!(
+            cache
+                .entries
+                .contains_key(&aid("kanon:row_without_accepted")),
+            "the warned row is a legitimate state, never pruned"
+        );
+    }
+
+    // ─── Idempotence + __meta__ + empties ─────────────────────────────────
+
+    #[test]
+    fn reconcile_is_idempotent() {
+        let mut cache = CanonMatchesFile::default();
+        cache
+            .entries
+            .insert(aid("deleted_one"), row(vec![], vec![], vec![]));
+        cache.entries.insert(
+            aid("hand_stripped"),
+            row(vec![], vec![accepted("stripped_entry")], vec![]),
+        );
+        cache.entries.insert(
+            aid("aristos:rekeyed_demote"),
+            row(vec![], vec![accepted("rekeyed_demote")], vec![]),
+        );
+        let live_ids = live(&[
+            "hand_stripped",
+            "rekeyed_demote",
+            "aristos:orphaned_binding",
+        ]);
+
+        let first = reconcile(&mut cache, &live_ids);
+        assert!(first.changed());
+        let after_first = cache.clone();
+
+        let second = reconcile(&mut cache, &live_ids);
+        assert!(!second.changed(), "second run must report no changes");
+        assert!(second.pruned.is_empty());
+        assert!(second.demoted.is_empty());
+        assert_eq!(cache, after_first, "second run must not mutate");
+        // Warnings are stable across runs (they never mutate).
+        assert_eq!(first.missing_binding, second.missing_binding);
+    }
+
+    #[test]
+    fn meta_is_untouched_even_when_entries_are_pruned() {
+        let mut cache = CanonMatchesFile::default();
+        cache.meta.canon_version = Some("v0.2.0".into());
+        cache.meta.last_fetched = Some("2026-06-15T09:14:22Z".into());
+        cache
+            .entries
+            .insert(aid("deleted_one"), row(vec![], vec![], vec![]));
+
+        let report = reconcile(&mut cache, &live(&[]));
+
+        assert_eq!(report.pruned, vec![aid("deleted_one")]);
+        assert_eq!(cache.meta.schema_version, 1);
+        assert_eq!(cache.meta.canon_version.as_deref(), Some("v0.2.0"));
+        assert_eq!(
+            cache.meta.last_fetched.as_deref(),
+            Some("2026-06-15T09:14:22Z")
+        );
+    }
+
+    #[test]
+    fn empty_cache_is_a_no_op() {
+        let mut cache = CanonMatchesFile::default();
+        let report = reconcile(&mut cache, &live(&["anything_live"]));
+        assert_eq!(report, ReconcileReport::default());
+        assert!(!report.changed());
+    }
+
+    #[test]
+    fn empty_live_set_prunes_every_entry() {
+        // Empty index (all annotations deleted): every row goes.
+        let mut cache = CanonMatchesFile::default();
+        cache
+            .entries
+            .insert(aid("bare_one"), row(vec![], vec![], vec![]));
+        cache.entries.insert(
+            aid("aristos:bound_one"),
+            row(vec![], vec![accepted("bound_one")], vec![]),
+        );
+
+        let report = reconcile(&mut cache, &BTreeSet::new());
+
+        assert_eq!(
+            report.pruned,
+            vec![aid("aristos:bound_one"), aid("bare_one")]
+        );
+        assert_eq!(report.pruned_bound, vec![aid("aristos:bound_one")]);
+        assert!(cache.entries.is_empty());
+    }
+
+    // ─── raw_live_ids ─────────────────────────────────────────────────────
+
+    fn discovered(
+        explicit_id: Option<&str>,
+        text: &str,
+        site: &str,
+        parent: Option<&str>,
+    ) -> DiscoveredAnnotation {
+        use crate::walk::{AnnotationForm, ExtractedAnnotation, ParentRaw};
+        DiscoveredAnnotation {
+            file: std::path::PathBuf::from("src/lib.rs"),
+            annotation: ExtractedAnnotation {
+                kind: AnnotationKind::Intent,
+                form: AnnotationForm::Attribute,
+                text: text.to_string(),
+                verify: None,
+                parent: parent.map(|p| ParentRaw::Single(p.to_string())),
+                id: explicit_id.map(str::to_string),
+                site: site.to_string(),
+                line: 1,
+                covered_region: crate::index::CoveredRegion::Function,
+                text_hash: crate::hash::text_hash(text),
+                body_hash: crate::hash::body_hash("fn body() {}"),
+            },
+        }
+    }
+
+    #[test]
+    fn raw_live_ids_includes_annotations_build_entries_would_skip() {
+        // A typo'd parent id makes build_entries skip the annotation
+        // from the index — but the annotation still exists in source,
+        // so its id MUST count as live (pruning its canon-matches row
+        // would destroy an accepted binding over a warning).
+        let d = discovered(
+            Some("aristos:cell_write_once"),
+            "some invariant",
+            "fn foo",
+            Some("Bad Parent Typo!!"),
+        );
+        let raw = raw_live_ids(&[d]);
+        assert_eq!(raw.unparseable_explicit_ids, 0);
+        assert!(raw.ids.contains(&aid("aristos:cell_write_once")));
+    }
+
+    #[test]
+    fn raw_live_ids_derives_the_same_deterministic_id_as_build_entries() {
+        // Idless annotations contribute the deterministic aret_* id,
+        // with the same per-bucket ordinal assignment resolve_id
+        // uses — including for identical duplicates.
+        let a = discovered(None, "each cell written once", "fn edit_page", None);
+        let b = discovered(None, "each cell written once", "fn edit_page", None);
+        let raw = raw_live_ids(&[a, b]);
+        let id0 = deterministic_id(
+            AnnotationKind::Intent,
+            "each cell written once",
+            "fn edit_page",
+            0,
+        );
+        let id1 = deterministic_id(
+            AnnotationKind::Intent,
+            "each cell written once",
+            "fn edit_page",
+            1,
+        );
+        assert!(raw.ids.contains(&id0));
+        assert!(raw.ids.contains(&id1));
+        assert_eq!(raw.ids.len(), 2);
+    }
+
+    #[test]
+    fn raw_live_ids_counts_unparseable_explicit_ids() {
+        // An explicit id that doesn't parse can't be represented in
+        // the set — the caller must see the count and skip the
+        // reconcile rather than prune on a lossy authority.
+        let bad = discovered(Some("Not A Valid Id!"), "text", "fn foo", None);
+        let good = discovered(Some("fine_id"), "text2", "fn bar", None);
+        let raw = raw_live_ids(&[bad, good]);
+        assert_eq!(raw.unparseable_explicit_ids, 1);
+        assert_eq!(raw.ids.len(), 1);
+        assert!(raw.ids.contains(&aid("fine_id")));
+    }
+}

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -23,8 +23,8 @@ are in the [glossary](./GLOSSARY.md).
   from your source and the recorded proofs. A claim whose code has drifted from
   its proof shows up as `stale` the moment you look (`aristo status`, or
   `aristo verify --audit` in CI). You don't run `aristo stamp` to keep it
-  honest; it's an optional refresh (it also syncs canon matches and archives
-  proofs for removed annotations).
+  honest; it's an optional refresh (it also syncs canon matches, prunes
+  canon-match entries for removed annotations, and archives their proofs).
 - **You bring judgment.** You decide which claims are worth making
   and accept them into the codebase. Aristo verifies the claims you
   keep; it doesn't decide them for you.


### PR DESCRIPTION
Makes `.aristo/canon-matches.toml` **source-authoritative**: every `aristo stamp` reconciles the committed match cache against the freshly-walked source tree, so deleting an annotation self-heals instead of leaving a stale committed binding forever.

## Motivation

The cache is never garbage-collected. Real incident: tursodatabase/turso removed the `aristos:wal_checkpoint_error_no_db_leak` intent (their PR #7725) but the accepted binding stayed in the committed `canon-matches.toml` — server-side dashboards mirroring the committed file keep showing a dead binding. Hygiene currently requires knowing to run `aristo canon unbind` *before* deleting the annotation. Deeper cause: when `index.toml` left git, `canon-matches.toml` silently inherited its role as the durable binding record — but never inherited `stamp`'s consistency maintenance. This PR gives it that maintenance.

## What it does

New pure `aristo_core::canon::reconcile(cache, live_ids) -> ReconcileReport`, wired into `stamp` between the index write and the canon step (so it runs under `--skip-canon`, disabled config, and full cache-hit — exactly the paths where the old cache write was skipped):

- **Prune** — entries (either key form) whose annotation id is no longer in source. Reported: `note: canon-matches: pruned N stale entries whose annotation ids are no longer in source: …`; a **louder warning** when a pruned row carried `accepted_matches`.
- **Demote** — a live id that lost its canon prefix (hand-stripped, or source reverted without `.aristo/`): accepted bucket dropped, rejected-match memory rekeyed/preserved, actionable note (`stamp --refresh-canon` → `canon accept`).
- **Warn** — live prefixed id without a derivable binding (existing warnings; collected, not double-printed).
- **Interrupted-`accept` carve-out** — a dead bare row whose pending match targets a live prefixed id is preserved *only while that target has no accepted row* (the true mid-accept window); preservation prints a note.

Writes via `write_atomic` **only on change**; idempotent; `[__meta__]` untouched.

### Authority rule (the load-bearing invariant)

The live-id set comes from the **raw pre-validation walk** — not the post-validation, post-exclude index. With `[index].exclude` configured, the reconcile re-walks without excludes; if its authority is unreliable (unparseable explicit id, failed walk), it **skips itself with a note** rather than pruning blind. Nothing that derives the live set has narrower scope than what it may delete.

### `--check` mode

`aristo stamp --check` now also fails (exit 2, no writes) when the committed cache is out of sync with source — consistent with its existing index-drift contract, and CI-gateable by clients.

## Tradeoffs (documented in CHANGELOG)

- A deleted-then-restored annotation re-matches from scratch (its L5 skip and rejected-suggestion memory die with it).
- True deletions prune destructively (recoverable via git history of the committed file); an archive/`--gc` mechanism was considered and rejected as disproportionate once the mis-scoped-walk triggers were eliminated by the authority rule.
- `canon refresh` is deliberately not wired (it reconstructs from a possibly-stale index — unsafe prune authority).

## Review notes

Two majors were caught in adversarial review of the first cut and are fixed in this commit — both were consistency-authority mistakes worth reviewers' attention: (1) the recovery carve-out originally preserved dead rows whenever *any* annotation bound the same canon entry (silently immortal rows — the exact class this PR kills); (2) the live set originally came from the post-exclude/post-validation walk, so an exclude-glob edit or a warn-level validation skip destroyed committed accepted bindings with exit 0.

## Tests

23 unit tests (`canon/reconcile.rs`) covering every rule, both key forms, the carve-out in both directions, idempotence, and the raw-walk authority; 17 integration tests (`canon_stamp_command.rs`) including the literal turso scenario (bind → delete annotation → stamp prunes + third-stamp byte-stability), exclude-glob and validation-skip survival, demote via `--skip-canon`, and the three `--check` behaviors (fail-on-drift with byte-identical files, pass-in-sync, skip-when-authority-unreliable). Full gates green: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `test --workspace`, `RUSTDOCFLAGS="-D warnings" cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
